### PR TITLE
Week-1 MLV: floe-guard local budget guardrail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.venv/
+venv/
+
+# Tooling
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+
+# OS / editor
+.DS_Store
+.vscode/
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to floe-guard
+
+`floe-guard` is a local budget guardrail for AI agents: it hard-stops an agent
+before its next LLM call when it would cross a spend ceiling. It runs in-process
+with no account. Hosted Floe is the upgrade path — enforcement moves server-side
+so the ceiling becomes un-bypassable and cross-vendor.
+
+Contributions are welcome.
+
+## Development setup
+
+```bash
+git clone https://github.com/Floe-Labs/floe-guard.git
+cd floe-guard
+pip install -e ".[dev]"
+```
+
+Run the checks before opening a PR:
+
+```bash
+pytest               # tests
+ruff check .         # lint
+ruff format .        # format
+```
+
+The optional adapters need their extras to run/import:
+
+```bash
+pip install -e ".[crewai]"    # CrewAI adapter
+pip install -e ".[litellm]"   # LiteLLM adapter
+```
+
+## Contribution flow
+
+1. Fork the repo and create a branch off `main` (e.g. `feat/your-change`).
+2. Make your change with tests, and keep `pytest` + `ruff` green.
+3. Open a **draft pull request** against `main` and describe what changed and why.
+
+## Code style
+
+- Python 3.10+ with type hints.
+- Formatting and linting are handled by `ruff` (config in `pyproject.toml`) — run
+  `ruff format .` and `ruff check .` before pushing.
+- Keep the core (`src/floe_guard/`) dependency-free; framework integrations belong
+  in `src/floe_guard/integrations/` behind an optional extra.
+- Prefer small, focused changes with tests that describe behavior.
+
+## Areas we'd love help with
+
+- **LangChain adapter** (callback-based enforcement).
+- **Vercel AI SDK adapter** (TypeScript middleware / port).
+- **Cost-map coverage** — keeping the bundled pricing map current and broad.
+
+Open an issue first if you want to discuss a larger change.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,154 @@
+# floe-guard
+
+**A local budget guardrail for AI agents.** It hard-stops your agent *before its
+next LLM call* when it would cross a spend ceiling — so a runaway loop dies at
+$0.10 instead of $4,000. No account, no signup, no network. Runs in your process.
+
+```bash
+pip install floe-guard
+```
+
+```python
+from floe_guard import BudgetGuard
+
+guard = BudgetGuard(limit_usd=5.00)   # your ceiling
+guard.check()                         # before each LLM call — raises if it'd cross
+response = call_your_llm(...)         # your existing call
+guard.record("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens)
+```
+
+When the next call would cross the ceiling, the guard raises `BudgetExceeded` and
+prints:
+
+```
+BUDGET EXCEEDED — call blocked
+  spent so far: $5.001250  |  ceiling: $5.000000
+  The next call would cross your budget; floe-guard stopped your agent before it ran.
+```
+
+![stop the loop](docs/stop-the-loop.gif)
+<!-- TODO: record docs/stop-the-loop.gif — a screen capture of `python examples/runaway_loop.py` stopping the loop. -->
+
+## See it stop a loop (no API key needed)
+
+```bash
+python examples/runaway_loop.py
+```
+
+This rigs a loop against a **stub LLM** — no real API key, no account, no network.
+It prices each fake `gpt-4o` call offline and the guard halts the loop after a few
+iterations. This is the reproducible "stop the loop" demo.
+
+## How it works
+
+The guard sits **in the call path**, not on an event bus. A passive listener is
+told about spend *after the fact* and can't halt anything — so enforcement has to
+be the thing standing in front of the next call:
+
+- **`check()`** runs before each LLM call. It predicts the next call's cost from
+  the last one and raises `BudgetExceeded` if that would cross your ceiling — the
+  call never runs. (A running-total check also catches an overshoot if an estimate
+  came in low.)
+- **`record(model, prompt_tokens, completion_tokens)`** runs after each response.
+  It prices the tokens **offline** from a bundled
+  [LiteLLM cost map](src/floe_guard/cost_map.json) and adds the USD to a running
+  total.
+
+### Unpriceable models fail closed
+
+If a model isn't in the cost map and you didn't supply a price, the guard **warns
+loudly and refuses** (`UnpriceableModelError`) rather than silently treat it as
+free — *you can't cap spend you can't measure.* Give it a price to enforce it:
+
+```python
+from floe_guard import BudgetGuard, ManualPrice
+
+guard = BudgetGuard(
+    limit_usd=5.00,
+    price_overrides={"my-self-hosted-model": ManualPrice(1e-6, 2e-6)},  # USD/token
+)
+# or, set fail_closed=False to warn-and-skip for models you accept un-metered.
+```
+
+## Framework adapters (optional extras)
+
+### CrewAI
+
+```bash
+pip install floe-guard[crewai]
+```
+
+```python
+from crewai import Crew
+from floe_guard import BudgetGuard
+from floe_guard.integrations.crewai import guard_crew
+
+guard = BudgetGuard(limit_usd=1.00)
+guard_crew(guard)              # one line — enforces across the whole crew
+Crew(agents=[...], tasks=[...]).kickoff()
+```
+
+CrewAI runs on LiteLLM, so one callback caps every agent and task under a single
+budget.
+
+### LiteLLM
+
+```bash
+pip install floe-guard[litellm]
+```
+
+```python
+from floe_guard import BudgetGuard
+from floe_guard.integrations.litellm import guarded_completion
+
+guard = BudgetGuard(limit_usd=1.00)
+response = guarded_completion(guard, model="gpt-4o", messages=[...])
+```
+
+Prefer the LiteLLM-native callback? Register `budget_guard_callback(guard)` on
+`litellm.callbacks`.
+
+### Coming next
+
+LangChain (callback) and the Vercel AI SDK (TypeScript middleware) are next. Open
+an issue if you want one sooner.
+
+## Honest about what this is
+
+floe-guard is a **local, estimate-based** guardrail. It prices tokens from a
+vendored cost map *inside your process*:
+
+- The cost map can drift as vendors change prices — refresh it like any snapshot.
+- It only sees the vendors you instrument.
+- A determined agent or a bug could route around an in-process check.
+
+It's genuinely useful on its own, and it's honest about its limits. No inflated
+metrics, no "zero defaults" claims — it's a free local stop, not a vault.
+
+## Upgrade to hosted Floe
+
+When you need the ceiling to be **un-bypassable** and **cross-vendor**, hosted
+Floe moves enforcement server-side against a real credit line:
+
+- **Un-bypassable** — enforced at the spend rail, not in your process.
+- **Cross-vendor** — one budget over LLM tokens *and* paid (x402) tool calls.
+- **Team budgets + analytics** — shared ceilings, per-agent isolation, spend history.
+
+Set `FLOE_API_KEY` and floe-guard exposes a hook to delegate enforcement to
+hosted Floe (see [`src/floe_guard/hosted.py`](src/floe_guard/hosted.py) — wiring
+the live endpoint is in progress; the local guard is fully functional today).
+
+→ **[dev-dashboard.floelabs.xyz](https://dev-dashboard.floelabs.xyz)** ·
+**[floelabs.xyz](https://floelabs.xyz)**
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+ruff check .
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ BUDGET EXCEEDED — call blocked
   The next call would cross your budget; floe-guard stopped your agent before it ran.
 ```
 
-![stop the loop](docs/stop-the-loop.gif)
-<!-- TODO: record docs/stop-the-loop.gif — a screen capture of `python examples/runaway_loop.py` stopping the loop. -->
+_Animated demo coming — run `python examples/runaway_loop.py` to watch it stop a loop live._
+<!-- TODO: record docs/stop-the-loop.gif and restore the embed: ![stop the loop](docs/stop-the-loop.gif) -->
 
 ## See it stop a loop (no API key needed)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version of `floe-guard` is supported with security fixes.
+Please upgrade to the latest version before reporting an issue.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report them privately by email to **security@floelabs.xyz**. If you do not get a
+response, use **hello@floelabs.xyz** as a fallback contact.
+
+Please include:
+
+- a description of the vulnerability and its impact,
+- steps to reproduce (a minimal proof of concept helps),
+- the affected version.
+
+## What to expect
+
+- We aim to acknowledge your report within **3 business days**.
+- We will keep you updated on our assessment and the fix.
+- Please give us a reasonable window to release a fix before any public disclosure.
+
+Thank you for helping keep `floe-guard` and its users safe.

--- a/docs/stop-the-loop.gif.PLACEHOLDER.txt
+++ b/docs/stop-the-loop.gif.PLACEHOLDER.txt
@@ -1,0 +1,6 @@
+TODO: record this GIF.
+
+This is a placeholder for docs/stop-the-loop.gif — a short screen recording of
+`python examples/runaway_loop.py` running and the guard printing
+`BUDGET EXCEEDED — call blocked`. Replace this file with the recorded .gif
+(keep the filename so the README reference resolves).

--- a/examples/runaway_loop.py
+++ b/examples/runaway_loop.py
@@ -1,0 +1,58 @@
+"""Stop-the-loop demo — runs with NO API key and NO account.
+
+A naive agent loop that calls an LLM forever. The only thing standing between you
+and a five-figure overnight bill is ``floe-guard``: it hard-stops the loop before
+the call that would cross your $0.10 ceiling.
+
+Run it::
+
+    python examples/runaway_loop.py
+
+The "LLM" here is a stub that returns fixed token usage — no network, no key, no
+crewai/litellm needed. The cost is computed offline from the bundled cost map,
+exactly as it would be for a real ``gpt-4o`` call.
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"
+
+
+def stub_llm(prompt: str) -> dict[str, object]:
+    """A fake LLM call. No network, no API key — returns fixed token usage."""
+    return {
+        "model": MODEL,
+        "text": "...thinking... let me call myself again...",
+        "prompt_tokens": 1_000,
+        "completion_tokens": 1_000,
+    }
+
+
+def main() -> None:
+    # $0.10 ceiling. gpt-4o at 1k in + 1k out ≈ $0.0125/call, so the guard should
+    # stop the loop after a handful of iterations — well before any real damage.
+    guard = BudgetGuard(limit_usd=0.10)
+
+    print(f"Starting a runaway loop with a ${guard.limit_usd:.2f} budget...\n")
+    call = 0
+    while True:  # a real runaway loop never decides to stop on its own
+        call += 1
+        try:
+            guard.check()  # <-- the kill-switch: raises before the crossing call
+        except BudgetExceeded:
+            print(f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.")
+            break
+
+        response = stub_llm("keep going")
+        cost = guard.record(
+            str(response["model"]),
+            int(response["prompt_tokens"]),  # type: ignore[arg-type]
+            int(response["completion_tokens"]),  # type: ignore[arg-type]
+        )
+        print(f"  call #{call}: +${cost:.4f}  (running total ${guard.spent_usd:.4f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "floe-guard"
+version = "0.1.0"
+description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "Floe Labs" }]
+keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "cost", "openai", "anthropic"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = []
+
+[project.optional-dependencies]
+litellm = ["litellm>=1.0"]
+crewai = ["crewai>=0.30", "litellm>=1.0"]
+dev = ["pytest>=7.0", "ruff>=0.4"]
+
+[project.urls]
+Homepage = "https://floelabs.xyz"
+Dashboard = "https://dev-dashboard.floelabs.xyz"
+Source = "https://github.com/Floe-Labs/floe-guard"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/floe_guard"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/floe_guard/cost_map.json" = "floe_guard/cost_map.json"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["src", "tests", "examples"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = ["error::floe_guard.errors.UnpriceableModelWarning"]

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -1,0 +1,37 @@
+"""floe-guard — a local, framework-agnostic budget guardrail for AI agents.
+
+Hard-stops an agent before its next LLM call when it would cross a spend ceiling.
+Zero account, no network, runs in-process. Hosted Floe is the un-bypassable,
+cross-vendor upgrade path (see the README).
+
+    from floe_guard import BudgetGuard
+
+    guard = BudgetGuard(limit_usd=5.00)
+    guard.check()                       # before each LLM call (may raise)
+    guard.record("gpt-4o", 1200, 350)   # after each response
+"""
+
+from __future__ import annotations
+
+from .errors import (
+    BudgetExceeded,
+    FloeGuardError,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+from .guard import BudgetGuard
+from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "BudgetGuard",
+    "BudgetExceeded",
+    "FloeGuardError",
+    "UnpriceableModelError",
+    "UnpriceableModelWarning",
+    "ManualPrice",
+    "PricedModel",
+    "price_tokens",
+    "resolve_price",
+]

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -1,0 +1,734 @@
+{
+  "chatgpt-4o-latest": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "claude-3-7-sonnet-20250219": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-haiku-20240307": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000125,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-opus-20240229": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-4-opus-20250514": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-4-sonnet-20250514": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-haiku-4-5": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-haiku-4-5-20251001": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-1": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-1-20250805": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-20250514": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-5-20251101": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-6": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-6-20260205": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-7": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-7-20260416": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-opus-4-8": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-sonnet-4-20250514": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-sonnet-4-5": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-sonnet-4-5-20250929": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-sonnet-4-6": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "ft:gpt-3.5-turbo": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-3.5-turbo-0125": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-3.5-turbo-0613": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-3.5-turbo-1106": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4-0613": {
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4.1-2025-04-14": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4.1-mini-2025-04-14": {
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000032,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4.1-nano-2025-04-14": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 8e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4o-2024-08-06": {
+    "input_cost_per_token": 0.00000375,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4o-2024-11-20": {
+    "input_cost_per_token": 0.00000375,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:gpt-4o-mini-2024-07-18": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "ft:o4-mini-2025-04-16": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-3.5-turbo": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-3.5-turbo-0125": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-3.5-turbo-1106": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-3.5-turbo-16k": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000004,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4": {
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-0125-preview": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-0314": {
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-0613": {
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-1106-preview": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-turbo": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-turbo-2024-04-09": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4-turbo-preview": {
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1-2025-04-14": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1-mini": {
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1-mini-2025-04-14": {
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1-nano": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4.1-nano-2025-04-14": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-2024-05-13": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-2024-08-06": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-2024-11-20": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-audio-preview": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-audio-preview-2025-06-03": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-2024-07-18": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-audio-preview": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-audio-preview-2024-12-17": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-realtime-preview": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-realtime-preview-2024-12-17": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-search-preview": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-mini-search-preview-2025-03-11": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-realtime-preview": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-realtime-preview-2024-12-17": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-realtime-preview-2025-06-03": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-search-preview": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-4o-search-preview-2025-03-11": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-2025-08-07": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-chat": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-chat-latest": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-mini": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-mini-2025-08-07": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-nano": {
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-nano-2025-08-07": {
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-search-api": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5-search-api-2025-10-14": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.1": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.1-2025-11-13": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.1-chat-latest": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.2": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.2-2025-12-11": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.2-chat-latest": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.3-chat-latest": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4-2026-03-05": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4-mini": {
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4-nano": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.5-2026-04-23": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio-1.5": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio-2025-08-28": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio-mini": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-audio-mini-2025-12-15": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-1.5": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2025-08-28": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-mini": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o1": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o1-2024-12-17": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.00006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o3": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o3-2025-04-16": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o3-mini": {
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000044,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o3-mini-2025-01-31": {
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000044,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o4-mini": {
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000044,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "o4-mini-2025-04-16": {
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000044,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "text-embedding-3-large": {
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "openai",
+    "mode": "embedding"
+  },
+  "text-embedding-3-small": {
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 0,
+    "litellm_provider": "openai",
+    "mode": "embedding"
+  },
+  "text-embedding-ada-002": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "openai",
+    "mode": "embedding"
+  },
+  "text-embedding-ada-002-v2": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "openai",
+    "mode": "embedding"
+  }
+}

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -1,0 +1,47 @@
+"""Exceptions and warnings for floe-guard.
+
+Everything derives from :class:`FloeGuardError` (the package-root base) so callers
+can catch the whole family with a single ``except FloeGuardError``.
+"""
+
+from __future__ import annotations
+
+
+class FloeGuardError(Exception):
+    """Base class for every error raised by floe-guard."""
+
+
+class BudgetExceeded(FloeGuardError):
+    """Raised before an LLM call that would cross the configured spend ceiling.
+
+    The guard raises this *instead of* letting the next call run, so a runaway
+    loop stops here rather than burning more money.
+    """
+
+    def __init__(self, spent_usd: float, limit_usd: float) -> None:
+        self.spent_usd = spent_usd
+        self.limit_usd = limit_usd
+        super().__init__(
+            f"BUDGET EXCEEDED — call blocked (spent ${spent_usd:.6f} of ${limit_usd:.6f} ceiling)"
+        )
+
+
+class UnpriceableModelError(FloeGuardError):
+    """Raised when a model cannot be priced and the guard is fail-closed.
+
+    We refuse rather than silently accrue $0 — "we cannot cap what we cannot
+    price". Pass a manual price (``price_overrides`` or ``record(..., price=...)``)
+    to make the model enforceable.
+    """
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        super().__init__(
+            f"Cannot price model {model!r}: not in the bundled cost map and no "
+            f"manual price was given. The guard cannot enforce a budget on spend "
+            f"it cannot measure. Pass a price override to enable enforcement."
+        )
+
+
+class UnpriceableModelWarning(UserWarning):
+    """Warned (loudly) when an unpriceable model is seen in non-fail-closed mode."""

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -44,4 +44,9 @@ class UnpriceableModelError(FloeGuardError):
 
 
 class UnpriceableModelWarning(UserWarning):
-    """Warned (loudly) when an unpriceable model is seen in non-fail-closed mode."""
+    """Warned (loudly) whenever an unpriceable model is seen.
+
+    Always emitted regardless of ``fail_closed``. In fail-closed mode an
+    :class:`UnpriceableModelError` is additionally raised; in fail-open mode the
+    warning is emitted and the call's spend is skipped.
+    """

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -29,6 +29,9 @@ from .errors import (
 )
 from .pricing import ManualPrice, price_tokens, resolve_price
 
+# Tolerance for float rounding in the running spend total (well below $0.000001).
+_EPS = 1e-12
+
 
 class BudgetGuard:
     """Hard-stop an agent before its next LLM call crosses a USD ceiling.
@@ -79,7 +82,9 @@ class BudgetGuard:
         """
         estimate = self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
         projected = self.spent_usd + estimate
-        if self.spent_usd >= self.limit_usd or projected > self.limit_usd:
+        # Compare with an epsilon so float rounding in the running total doesn't
+        # block a call early or let one slip past the ceiling.
+        if self.spent_usd > self.limit_usd - _EPS or projected > self.limit_usd + _EPS:
             self._on_block(self.spent_usd, self.limit_usd)
             raise BudgetExceeded(self.spent_usd, self.limit_usd)
 
@@ -117,6 +122,10 @@ class BudgetGuard:
 
         cost = price_tokens(priced, prompt_tokens, completion_tokens)
         self.spent_usd += cost
+        # Clamp a sub-epsilon float overshoot back to the limit so the running
+        # total never reports as having crossed the ceiling by a rounding artifact.
+        if 0.0 < self.spent_usd - self.limit_usd < _EPS:
+            self.spent_usd = self.limit_usd
         self._last_cost = cost
         return cost
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -1,0 +1,136 @@
+"""The local, in-process budget guard.
+
+``BudgetGuard`` is a kill-switch that lives in the LLM call path. The contract:
+
+1. Call :meth:`check` BEFORE every LLM call. If the *next* call would cross the
+   ceiling, it raises :class:`BudgetExceeded` and the call never runs.
+2. Call :meth:`record` AFTER every response, with the token usage. It prices the
+   tokens offline and accrues the USD into a running total.
+
+Why a call-path wrapper and not an event listener: a passive event-bus listener
+is notified *after* the fact and cannot halt the run. To actually stop spend, the
+guard has to sit in front of the next call. That is the whole point.
+
+This is **estimate-based**: it prices tokens from a vendored cost map, it does
+not reconcile against a wallet. Hosted Floe is the un-bypassable, cross-vendor
+upgrade (see the README).
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from collections.abc import Callable
+
+from .errors import (
+    BudgetExceeded,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+from .pricing import ManualPrice, price_tokens, resolve_price
+
+
+class BudgetGuard:
+    """Hard-stop an agent before its next LLM call crosses a USD ceiling.
+
+    Args:
+        limit_usd: the spend ceiling, in USD. ``0`` blocks the very first call.
+        price_overrides: per-model manual prices for models the bundled cost map
+            cannot price (e.g. a brand-new or self-hosted model).
+        fail_closed: when ``True`` (default), recording an unpriceable model
+            without a manual price warns loudly AND raises
+            :class:`UnpriceableModelError` — the guard refuses to keep going when
+            it cannot measure spend. When ``False``, it warns and skips accrual
+            (you have explicitly opted into un-enforced spend for that model).
+        on_block: optional callback invoked with ``(spent_usd, limit_usd)`` right
+            before :class:`BudgetExceeded` is raised. Defaults to printing the
+            ``BUDGET EXCEEDED — call blocked`` banner to stderr.
+    """
+
+    def __init__(
+        self,
+        limit_usd: float,
+        *,
+        price_overrides: dict[str, ManualPrice] | None = None,
+        fail_closed: bool = True,
+        on_block: Callable[[float, float], None] | None = None,
+    ) -> None:
+        if limit_usd < 0:
+            raise ValueError(f"limit_usd must not be negative, got {limit_usd!r}")
+        self.limit_usd = float(limit_usd)
+        self.price_overrides = price_overrides
+        self.fail_closed = fail_closed
+        self._on_block = on_block or _default_on_block
+        self.spent_usd = 0.0
+        # Cost of the most recent priced call, used to predict the next one so we
+        # can block BEFORE the crossing call runs (not one call too late).
+        self._last_cost = 0.0
+
+    # ── enforcement ───────────────────────────────────────────────────────────
+
+    def check(self, estimated_next_cost: float | None = None) -> None:
+        """Raise :class:`BudgetExceeded` if the next call would cross the ceiling.
+
+        Call this immediately before each LLM request. The "next call" is
+        estimated from the last recorded call's cost (override with
+        ``estimated_next_cost``); the first call is always allowed unless the
+        ceiling is already met. A belt-and-suspenders check on the running total
+        catches an overshoot if the estimate was too low.
+        """
+        estimate = self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
+        projected = self.spent_usd + estimate
+        if self.spent_usd >= self.limit_usd or projected > self.limit_usd:
+            self._on_block(self.spent_usd, self.limit_usd)
+            raise BudgetExceeded(self.spent_usd, self.limit_usd)
+
+    def record(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        price: ManualPrice | None = None,
+    ) -> float:
+        """Price one response's tokens offline and add the cost to the total.
+
+        Returns the USD cost of this call. If the model is unpriceable and no
+        ``price`` is given, behaviour depends on ``fail_closed`` (see the class
+        docstring): warn + raise (default), or warn + skip accrual.
+        """
+        overrides = self.price_overrides
+        if price is not None:
+            overrides = {**(overrides or {}), model: price}
+
+        priced = resolve_price(model, overrides)
+        if priced is None:
+            warnings.warn(
+                f"Cannot price model {model!r}: not in the bundled cost map and no "
+                f"manual price given. The budget guard cannot enforce a ceiling on "
+                f"spend it cannot measure — pass price=ManualPrice(...) or set it in "
+                f"price_overrides.",
+                UnpriceableModelWarning,
+                stacklevel=2,
+            )
+            if self.fail_closed:
+                raise UnpriceableModelError(model)
+            return 0.0
+
+        cost = price_tokens(priced, prompt_tokens, completion_tokens)
+        self.spent_usd += cost
+        self._last_cost = cost
+        return cost
+
+    @property
+    def remaining_usd(self) -> float:
+        """USD left before the ceiling (never negative)."""
+        return max(0.0, self.limit_usd - self.spent_usd)
+
+
+def _default_on_block(spent_usd: float, limit_usd: float) -> None:
+    print(
+        "BUDGET EXCEEDED — call blocked\n"
+        f"  spent so far: ${spent_usd:.6f}  |  ceiling: ${limit_usd:.6f}\n"
+        "  The next call would cross your budget; floe-guard stopped your agent "
+        "before it ran.",
+        file=sys.stderr,
+    )

--- a/src/floe_guard/hosted.py
+++ b/src/floe_guard/hosted.py
@@ -1,0 +1,40 @@
+"""Hosted Floe upgrade hook (stub — not wired to a live endpoint).
+
+The local :class:`~floe_guard.BudgetGuard` is *estimate-based*: it prices tokens
+from a vendored cost map in your own process. A determined agent (or a bug) can
+run around it, and it only sees the one vendor you instrumented.
+
+Hosted Floe is the upgrade: enforcement moves server-side against a real credit
+line, so the ceiling is **un-bypassable** and spans **every vendor** (LLM tokens
+*and* paid x402 tool calls) under one budget, with team budgets and analytics.
+
+This module is intentionally a no-op stub. When ``FLOE_API_KEY`` is set,
+:func:`hosted_enforcement_available` reports it so callers can branch toward the
+hosted path. Wiring the actual delegation is tracked below — we do NOT ship a
+fabricated endpoint.
+
+    Upgrade: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+"""
+
+from __future__ import annotations
+
+import os
+
+FLOE_API_KEY_ENV = "FLOE_API_KEY"
+
+
+def hosted_enforcement_available() -> bool:
+    """True if a Floe API key is present in the environment.
+
+    Presence of a key is the signal that a caller *could* delegate enforcement to
+    hosted Floe. It does not itself perform any network call.
+    """
+    return bool(os.environ.get(FLOE_API_KEY_ENV, "").strip())
+
+
+# TODO(hosted-upgrade): when FLOE_API_KEY is set, delegate enforcement to hosted
+# Floe instead of (or alongside) the local estimate. The hosted path debits a
+# real, server-side credit line — un-bypassable and cross-vendor — so the budget
+# holds even if the local process is bypassed. This requires the public hosted
+# budget API to be finalized; until then this stays a documented no-op rather
+# than a fabricated endpoint. See README "Upgrade to hosted Floe".

--- a/src/floe_guard/integrations/__init__.py
+++ b/src/floe_guard/integrations/__init__.py
@@ -1,0 +1,7 @@
+"""Optional framework adapters for floe-guard.
+
+Each adapter lives behind an optional extra so the core stays dependency-free:
+
+    pip install floe-guard[litellm]
+    pip install floe-guard[crewai]
+"""

--- a/src/floe_guard/integrations/crewai.py
+++ b/src/floe_guard/integrations/crewai.py
@@ -44,7 +44,13 @@ def guard_crew(guard: BudgetGuard) -> None:
     before each call and accrues spend after. Call once before ``kickoff()``.
     Idempotent for the same guard — re-registering will not double-count.
     """
-    import litellm
+    try:
+        import litellm
+    except ImportError as e:
+        raise ImportError(
+            "guard_crew requires litellm (CrewAI runs on LiteLLM). "
+            "Install: pip install floe-guard[crewai]"
+        ) from e
 
     callback = budget_guard_callback(guard)
     existing = list(getattr(litellm, "callbacks", None) or [])

--- a/src/floe_guard/integrations/crewai.py
+++ b/src/floe_guard/integrations/crewai.py
@@ -1,0 +1,71 @@
+"""CrewAI adapter (optional extra: ``pip install floe-guard[crewai]``).
+
+This is the no-account, local descendant of Floe's hosted ``crewai-floe``
+integration. The hosted ``FloeLLM`` routes a crew through Floe's metered proxy
+and debits a server-side credit line; this version keeps everything in-process
+and free: it meters tokens against the bundled cost map and hard-stops the crew
+before the next LLM call crosses your ceiling.
+
+CrewAI calls ``litellm.completion`` under the hood for every agent step, so a
+single LiteLLM callback enforces the budget across the **whole crew** — every
+agent, every task — with no per-agent wiring.
+
+    from crewai import Agent, Crew, Task
+    from floe_guard import BudgetGuard
+    from floe_guard.integrations.crewai import guard_crew
+
+    guard = BudgetGuard(limit_usd=1.00)
+    guard_crew(guard)          # 1 line — enforces across the whole crew
+    Crew(agents=[...], tasks=[...]).kickoff()
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..guard import BudgetGuard
+from .litellm import budget_guard_callback
+
+
+def _require_crewai() -> Any:
+    try:
+        import crewai  # noqa: F401
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "The CrewAI adapter requires crewai. Install with: pip install floe-guard[crewai]"
+        ) from e
+    return crewai
+
+
+def guard_crew(guard: BudgetGuard) -> None:
+    """Enforce ``guard`` across every LLM call any CrewAI agent makes.
+
+    Registers a LiteLLM callback (CrewAI runs on LiteLLM) that checks the budget
+    before each call and accrues spend after. Call once before ``kickoff()``.
+    Idempotent for the same guard — re-registering will not double-count.
+    """
+    import litellm
+
+    callback = budget_guard_callback(guard)
+    existing = list(getattr(litellm, "callbacks", None) or [])
+    # Drop any previously-installed floe-guard callback bound to this same guard
+    # so repeated calls don't stack duplicate accrual.
+    existing = [cb for cb in existing if getattr(cb, "guard", None) is not guard]
+    existing.append(callback)
+    litellm.callbacks = existing
+
+
+def budget_guarded_llm(guard: BudgetGuard, model: str, **kwargs: Any) -> Any:
+    """Return a ``crewai.LLM`` for ``model`` with ``guard`` enforced crew-wide.
+
+    Convenience over :func:`guard_crew`: builds the LLM you pass to your agents
+    and registers the budget callback in one step.
+    """
+    _require_crewai()
+    from crewai import LLM
+
+    guard_crew(guard)
+    return LLM(model, **kwargs)
+
+
+__all__ = ["guard_crew", "budget_guarded_llm"]

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -58,8 +58,14 @@ def _usage_from(response: Any) -> tuple[int, int]:
 def _record_response(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> None:
     model = _model_from(kwargs, response)
     prompt_tokens, completion_tokens = _usage_from(response)
-    if model:
-        guard.record(model, prompt_tokens, completion_tokens)
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        # No tokens were spent (e.g. a usage-less event) — nothing to meter.
+        return
+    # There IS spend to account for. Route it through record() even when the
+    # model id is missing, so the guard's configured policy applies (fail-closed
+    # → warn + raise; fail-open → warn + skip). Silently skipping here would let
+    # a real, completed call go unmetered and skew the next check().
+    guard.record(model, prompt_tokens, completion_tokens)
 
 
 def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -1,0 +1,126 @@
+"""LiteLLM adapter (optional extra: ``pip install floe-guard[litellm]``).
+
+Two ways to wire the guard into LiteLLM:
+
+1. :func:`guarded_completion` / :func:`guarded_acompletion` — a thin wrapper
+   around ``litellm.completion``. This is the **guaranteed** enforcement path:
+   the guard's ``check()`` runs before the call in your own code, so a blocked
+   call simply never reaches LiteLLM.
+
+2. :class:`BudgetGuardCallback` — a LiteLLM ``CustomLogger`` you register with
+   ``litellm.callbacks``. It checks before the call (``log_pre_api_call``) and
+   records spend after (``log_success_event``). Use this when you cannot wrap the
+   call site yourself (e.g. CrewAI, which calls ``litellm.completion`` for you).
+
+Both route every priced response through the same :class:`~floe_guard.BudgetGuard`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..guard import BudgetGuard
+
+
+def _require_litellm() -> Any:
+    try:
+        import litellm  # noqa: F401
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "The LiteLLM adapter requires litellm. Install with: pip install floe-guard[litellm]"
+        ) from e
+    return litellm
+
+
+def _model_from(kwargs: dict[str, Any], response: Any) -> str:
+    model = kwargs.get("model")
+    if not model:
+        model = getattr(response, "model", None)
+    return str(model or "")
+
+
+def _usage_from(response: Any) -> tuple[int, int]:
+    """Pull (prompt_tokens, completion_tokens) from a LiteLLM/OpenAI response."""
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage")
+    if usage is None:
+        return 0, 0
+    get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
+    return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
+
+
+def _record_response(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> None:
+    model = _model_from(kwargs, response)
+    prompt_tokens, completion_tokens = _usage_from(response)
+    if model:
+        guard.record(model, prompt_tokens, completion_tokens)
+
+
+def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
+    """``litellm.completion`` with a pre-call budget check and post-call accrual.
+
+    Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
+    would be crossed — the request never reaches LiteLLM.
+    """
+    litellm = _require_litellm()
+    guard.check()
+    response = litellm.completion(**kwargs)
+    _record_response(guard, kwargs, response)
+    return response
+
+
+async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
+    """Async counterpart of :func:`guarded_completion`."""
+    litellm = _require_litellm()
+    guard.check()
+    response = await litellm.acompletion(**kwargs)
+    _record_response(guard, kwargs, response)
+    return response
+
+
+def budget_guard_callback(guard: BudgetGuard) -> Any:
+    """Build a LiteLLM ``CustomLogger`` that enforces ``guard`` on every call.
+
+    Register it globally::
+
+        import litellm
+        litellm.callbacks = [budget_guard_callback(guard)]
+
+    ``log_pre_api_call`` runs ``guard.check()`` (raising
+    :class:`~floe_guard.BudgetExceeded` to abort), and ``log_success_event``
+    records the response's token cost.
+    """
+    litellm = _require_litellm()
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class BudgetGuardCallback(CustomLogger):  # type: ignore[misc]
+        def __init__(self) -> None:
+            super().__init__()
+            self.guard = guard
+
+        def log_pre_api_call(self, model: Any, messages: Any, kwargs: Any) -> None:
+            self.guard.check()
+
+        def log_success_event(
+            self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
+        ) -> None:
+            _record_response(self.guard, kwargs, response_obj)
+
+        async def async_log_pre_api_call(self, model: Any, messages: Any, kwargs: Any) -> None:
+            self.guard.check()
+
+        async def async_log_success_event(
+            self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
+        ) -> None:
+            _record_response(self.guard, kwargs, response_obj)
+
+    _ = litellm  # adapter import already validated litellm is present
+    return BudgetGuardCallback()
+
+
+__all__ = [
+    "guarded_completion",
+    "guarded_acompletion",
+    "budget_guard_callback",
+]

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -35,7 +35,12 @@ def _require_litellm() -> Any:
 def _model_from(kwargs: dict[str, Any], response: Any) -> str:
     model = kwargs.get("model")
     if not model:
-        model = getattr(response, "model", None)
+        # LiteLLM returns either a ModelResponse object or a plain dict; read the
+        # model from whichever shape it is so a dict response is still recorded.
+        if isinstance(response, dict):
+            model = response.get("model")
+        else:
+            model = getattr(response, "model", None)
     return str(model or "")
 
 

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -1,0 +1,107 @@
+"""Offline token pricing from a vendored LiteLLM cost map.
+
+This mirrors the fail-closed logic of Floe's metered proxy
+(``floe-monorepo/apps/api/src/services/llm-pricing.ts``): BOTH the input and
+output per-token prices must be finite numbers, otherwise the model is treated
+as unpriceable. A half-valid entry would silently undercharge — so we refuse it.
+
+No network. The cost map (``cost_map.json``) is a snapshot of LiteLLM's
+``model_prices_and_context_window.json``; refresh it on a schedule, exactly like
+the proxy does, or estimates drift as vendors change prices.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ManualPrice:
+    """A user-supplied per-token price, in USD, for a model the map cannot price."""
+
+    input_cost_per_token: float
+    output_cost_per_token: float
+
+
+@dataclass(frozen=True)
+class PricedModel:
+    """A resolved per-token price plus where it came from."""
+
+    input_cost_per_token: float
+    output_cost_per_token: float
+    source: str  # "override" | "cost_map"
+
+
+def _load_cost_map() -> dict[str, Any]:
+    with resources.files("floe_guard").joinpath("cost_map.json").open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+_COST_MAP: dict[str, Any] = _load_cost_map()
+
+
+def _bare_model(model: str) -> str:
+    """Strip an optional ``provider/`` prefix (LiteLLM convention, e.g. ``openai/gpt-4o``)."""
+    m = model.strip()
+    slash = m.rfind("/")
+    return m if slash == -1 else m[slash + 1 :]
+
+
+def resolve_price(
+    model: str,
+    overrides: dict[str, ManualPrice] | None = None,
+) -> PricedModel | None:
+    """Resolve a model to its per-token price, or ``None`` if it cannot be priced.
+
+    Overrides win, then the bundled cost map (looked up by bare name, then the
+    raw field). Fail-closed: both prices must be finite, else ``None``.
+    """
+    bare = _bare_model(model)
+
+    if overrides:
+        ov = overrides.get(bare) or overrides.get(model.strip())
+        if ov is not None:
+            if _both_finite(ov.input_cost_per_token, ov.output_cost_per_token):
+                return PricedModel(
+                    input_cost_per_token=ov.input_cost_per_token,
+                    output_cost_per_token=ov.output_cost_per_token,
+                    source="override",
+                )
+            return None
+
+    entry = _COST_MAP.get(bare) or _COST_MAP.get(model.strip())
+    if not entry:
+        return None
+    input_cost = entry.get("input_cost_per_token")
+    output_cost = entry.get("output_cost_per_token")
+    if not _both_finite(input_cost, output_cost):
+        return None
+    return PricedModel(
+        input_cost_per_token=float(input_cost),
+        output_cost_per_token=float(output_cost),
+        source="cost_map",
+    )
+
+
+def _both_finite(a: Any, b: Any) -> bool:
+    return (
+        isinstance(a, (int, float))
+        and isinstance(b, (int, float))
+        and math.isfinite(a)
+        and math.isfinite(b)
+    )
+
+
+def price_tokens(priced: PricedModel, prompt_tokens: int, completion_tokens: int) -> float:
+    """USD cost for token usage. Negative counts are clamped to zero."""
+    p = max(0, prompt_tokens)
+    c = max(0, completion_tokens)
+    cost = p * priced.input_cost_per_token + c * priced.output_cost_per_token
+    if not math.isfinite(cost):
+        # Defense-in-depth: resolve_price already guarantees finite rates.
+        raise ValueError("Non-finite LLM cost — pricing entry is invalid")
+    return max(0.0, cost)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,29 @@
+"""The runaway-loop example must demo the stop with no API key and no extras."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+EXAMPLE = Path(__file__).resolve().parent.parent / "examples" / "runaway_loop.py"
+
+
+def test_runaway_loop_example_stops_and_prints_block(capsys: object, monkeypatch: object) -> None:
+    # Ensure no account/key is involved.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)  # type: ignore[attr-defined]
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)  # type: ignore[attr-defined]
+
+    sys.path.insert(0, str(EXAMPLE.parent))
+    try:
+        import runaway_loop
+
+        runaway_loop.main()
+    finally:
+        sys.path.remove(str(EXAMPLE.parent))
+
+    out = capsys.readouterr()  # type: ignore[attr-defined]
+    combined = out.out + out.err
+    assert "BUDGET EXCEEDED — call blocked" in combined
+    assert "Loop stopped at call" in combined
+    assert "OPENAI_API_KEY" not in os.environ

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -6,13 +6,17 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 EXAMPLE = Path(__file__).resolve().parent.parent / "examples" / "runaway_loop.py"
 
 
-def test_runaway_loop_example_stops_and_prints_block(capsys: object, monkeypatch: object) -> None:
+def test_runaway_loop_example_stops_and_prints_block(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Ensure no account/key is involved.
-    monkeypatch.delenv("FLOE_API_KEY", raising=False)  # type: ignore[attr-defined]
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)  # type: ignore[attr-defined]
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     sys.path.insert(0, str(EXAMPLE.parent))
     try:
@@ -22,7 +26,7 @@ def test_runaway_loop_example_stops_and_prints_block(capsys: object, monkeypatch
     finally:
         sys.path.remove(str(EXAMPLE.parent))
 
-    out = capsys.readouterr()  # type: ignore[attr-defined]
+    out = capsys.readouterr()
     combined = out.out + out.err
     assert "BUDGET EXCEEDED — call blocked" in combined
     assert "Loop stopped at call" in combined

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,0 +1,133 @@
+"""Behavioural tests for the core BudgetGuard kill-switch."""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    ManualPrice,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+
+MODEL = "gpt-4o"  # 1k in + 1k out = $0.0025 + $0.01 = $0.0125/call
+
+
+def _run_loop(guard: BudgetGuard, max_calls: int = 1000) -> int:
+    """Drive a runaway loop through the guard. Returns the number of LLM calls made."""
+    calls_made = 0
+    for _ in range(max_calls):
+        try:
+            guard.check()
+        except BudgetExceeded:
+            return calls_made
+        # The "LLM call" only runs because check() did not block.
+        guard.record(MODEL, 1_000, 1_000)
+        calls_made += 1
+    raise AssertionError("guard never blocked the loop")
+
+
+def test_guard_hard_stops_before_crossing_call() -> None:
+    # $0.05 ceiling, $0.0125/call. Calls 1-4 cost $0.05 total (== ceiling);
+    # call 5 would cross, so the guard must block BEFORE it runs.
+    guard = BudgetGuard(limit_usd=0.05)
+    calls_made = _run_loop(guard)
+    assert calls_made == 4
+    assert guard.spent_usd <= guard.limit_usd  # never overshot the ceiling
+
+
+def test_guard_blocks_before_overshoot_when_calls_dont_divide_evenly() -> None:
+    # $0.10 ceiling, $0.0125/call -> 8 even calls = $0.10. The predictive check
+    # blocks the 9th before it crosses; spend stays at or under the ceiling.
+    guard = BudgetGuard(limit_usd=0.10)
+    calls_made = _run_loop(guard)
+    assert guard.spent_usd <= guard.limit_usd
+    # Once blocked, no further calls slip through.
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+    assert calls_made == 8
+
+
+def test_spend_tally_is_accurate() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    cost1 = guard.record(MODEL, 1_000, 1_000)
+    cost2 = guard.record(MODEL, 2_000, 500)
+    assert cost1 == pytest.approx(0.0125)
+    assert cost2 == pytest.approx(2_000 * 2.5e-6 + 500 * 1e-5)  # 0.005 + 0.005
+    assert guard.spent_usd == pytest.approx(cost1 + cost2)
+
+
+def test_sub_ceiling_run_completes_normally() -> None:
+    # A short run that never approaches the ceiling must not raise.
+    guard = BudgetGuard(limit_usd=10.00)
+    for _ in range(5):
+        guard.check()
+        guard.record(MODEL, 1_000, 1_000)
+    assert guard.spent_usd == pytest.approx(5 * 0.0125)
+    guard.check()  # still room — does not raise
+
+
+def test_unpriceable_model_warns_and_fails_closed_by_default() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            guard.record("totally-made-up-model-x", 100, 100)
+    # It did NOT silently accrue $0 and keep going.
+    assert guard.spent_usd == 0.0
+
+
+def test_unpriceable_model_warns_and_skips_when_not_fail_closed() -> None:
+    guard = BudgetGuard(limit_usd=1.00, fail_closed=False)
+    with pytest.warns(UnpriceableModelWarning):
+        cost = guard.record("totally-made-up-model-x", 100, 100)
+    assert cost == 0.0  # could not price it, accrued nothing (user opted in)
+
+
+def test_manual_price_override_makes_model_enforceable() -> None:
+    guard = BudgetGuard(
+        limit_usd=1.00,
+        price_overrides={"my-local-model": ManualPrice(1e-6, 2e-6)},
+    )
+    cost = guard.record("my-local-model", 1_000, 1_000)
+    assert cost == pytest.approx(1_000 * 1e-6 + 1_000 * 2e-6)
+
+
+def test_per_call_price_override() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    cost = guard.record("ghost-model", 1_000, 0, price=ManualPrice(3e-6, 0.0))
+    assert cost == pytest.approx(0.003)
+
+
+def test_zero_budget_blocks_first_call() -> None:
+    guard = BudgetGuard(limit_usd=0.0)
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+
+
+def test_negative_limit_rejected() -> None:
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=-1.0)
+
+
+def test_on_block_callback_invoked() -> None:
+    seen: list[tuple[float, float]] = []
+    guard = BudgetGuard(limit_usd=0.0, on_block=lambda s, lim: seen.append((s, lim)))
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+    assert seen == [(0.0, 0.0)]
+
+
+def test_block_message_printed(capsys: pytest.CaptureFixture[str]) -> None:
+    guard = BudgetGuard(limit_usd=0.0)
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+    err = capsys.readouterr().err
+    assert "BUDGET EXCEEDED — call blocked" in err
+
+
+def test_remaining_usd() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard.record(MODEL, 1_000, 1_000)
+    assert guard.remaining_usd == pytest.approx(1.00 - 0.0125)

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -1,0 +1,17 @@
+"""The hosted upgrade hook is a documented no-op until FLOE_API_KEY is set."""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard.hosted import hosted_enforcement_available
+
+
+def test_no_key_means_no_hosted_enforcement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    assert hosted_enforcement_available() is False
+
+
+def test_key_present_signals_hosted_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLOE_API_KEY", "floe_test_key")
+    assert hosted_enforcement_available() is True

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -1,0 +1,57 @@
+"""Adapter-internal tests that need no litellm install.
+
+These exercise the response-parsing helpers directly (the parts that decide
+whether a call gets accrued), so the HIGH-severity dict-response path is covered
+even in CI without the optional extra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.litellm import _model_from, _record_response, _usage_from
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass
+class _ObjResponse:
+    model: str
+    usage: _Usage
+
+
+def test_model_from_object_response_without_kwargs_model() -> None:
+    resp = _ObjResponse(model="gpt-4o", usage=_Usage(1, 1))
+    assert _model_from({}, resp) == "gpt-4o"
+
+
+def test_model_from_dict_response_without_kwargs_model() -> None:
+    # The regression: a dict response with no kwargs["model"] must still resolve.
+    resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+    assert _model_from({}, resp) == "gpt-4o"
+
+
+def test_model_from_prefers_kwargs() -> None:
+    resp = {"model": "gpt-4o"}
+    assert _model_from({"model": "claude-opus-4-5"}, resp) == "claude-opus-4-5"
+
+
+def test_usage_from_dict_and_object() -> None:
+    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7)
+    assert _usage_from(_ObjResponse("gpt-4o", _Usage(5, 7))) == (5, 7)
+
+
+def test_record_response_accrues_dict_response() -> None:
+    # End-to-end of the fix: a dict LiteLLM response with no kwargs model is
+    # priced and accrued (previously it was silently skipped → unenforced).
+    guard = BudgetGuard(limit_usd=1.0)
+    resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
+    _record_response(guard, {}, resp)
+    assert guard.spent_usd == pytest.approx(0.0125)

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from floe_guard import BudgetGuard
+from floe_guard import BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
 from floe_guard.integrations.litellm import _model_from, _record_response, _usage_from
 
 
@@ -55,3 +55,30 @@ def test_record_response_accrues_dict_response() -> None:
     resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
     _record_response(guard, {}, resp)
     assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_usage_present_but_model_missing_fails_closed() -> None:
+    # The Major fix: tokens were spent but the model id is missing. This MUST go
+    # through record() (fail-closed → raise), not be silently skipped unmetered.
+    guard = BudgetGuard(limit_usd=1.0)  # fail_closed defaults to True
+    resp = {"usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            _record_response(guard, {}, resp)
+    assert guard.spent_usd == 0.0
+
+
+def test_usage_present_but_model_missing_fail_open_warns_and_skips() -> None:
+    guard = BudgetGuard(limit_usd=1.0, fail_closed=False)
+    resp = {"usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
+    with pytest.warns(UnpriceableModelWarning):
+        _record_response(guard, {}, resp)
+    assert guard.spent_usd == 0.0
+
+
+def test_no_usage_response_is_a_noop() -> None:
+    # A genuinely empty (no-usage) response: nothing spent, so no record/raise.
+    guard = BudgetGuard(limit_usd=1.0)
+    _record_response(guard, {}, {})  # no model, no usage
+    _record_response(guard, {}, {"usage": {"prompt_tokens": 0, "completion_tokens": 0}})
+    assert guard.spent_usd == 0.0

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,54 @@
+"""Tests for offline pricing — fail-closed resolution and token math."""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard.pricing import (
+    ManualPrice,
+    PricedModel,
+    price_tokens,
+    resolve_price,
+)
+
+
+def test_resolves_known_model_from_cost_map() -> None:
+    priced = resolve_price("gpt-4o")
+    assert priced is not None
+    assert priced.source == "cost_map"
+    assert priced.input_cost_per_token == pytest.approx(2.5e-6)
+    assert priced.output_cost_per_token == pytest.approx(1e-5)
+
+
+def test_strips_provider_prefix() -> None:
+    bare = resolve_price("gpt-4o")
+    prefixed = resolve_price("openai/gpt-4o")
+    assert prefixed is not None and bare is not None
+    assert prefixed.input_cost_per_token == bare.input_cost_per_token
+
+
+def test_unknown_model_is_unpriceable() -> None:
+    assert resolve_price("no-such-model-anywhere") is None
+
+
+def test_override_wins_over_cost_map() -> None:
+    priced = resolve_price("gpt-4o", {"gpt-4o": ManualPrice(1e-9, 2e-9)})
+    assert priced is not None
+    assert priced.source == "override"
+    assert priced.input_cost_per_token == 1e-9
+
+
+def test_override_with_non_finite_price_is_unpriceable() -> None:
+    # Fail closed: a malformed override (NaN/inf) must not be used.
+    assert resolve_price("x", {"x": ManualPrice(float("nan"), 1e-6)}) is None
+    assert resolve_price("y", {"y": ManualPrice(1e-6, float("inf"))}) is None
+
+
+def test_price_tokens_math() -> None:
+    priced = PricedModel(input_cost_per_token=1e-6, output_cost_per_token=2e-6, source="cost_map")
+    assert price_tokens(priced, 1_000, 500) == pytest.approx(1e-3 + 1e-3)
+
+
+def test_price_tokens_clamps_negative_counts() -> None:
+    priced = PricedModel(input_cost_per_token=1e-6, output_cost_per_token=2e-6, source="cost_map")
+    assert price_tokens(priced, -50, -50) == 0.0


### PR DESCRIPTION
Ships the Week-1 Minimum Lovable Version of **floe-guard** — a standalone, framework-agnostic local budget guardrail that hard-stops an agent **before its next LLM call** when it would cross a spend ceiling. Zero Floe account, no network, runs in-process.

## What is included

- **Core guard** (`src/floe_guard/guard.py`): `BudgetGuard.check()` runs before each call and raises `BudgetExceeded` (printing `BUDGET EXCEEDED — call blocked` with running total + ceiling); `record()` accrues `tokens × price` after each response. Enforcement lives in the call path, not on an event bus (a passive listener cannot halt a run).
- **Offline pricing** (`src/floe_guard/pricing.py`): vendored Floe LiteLLM cost map (`cost_map.json`). Fail-closed — BOTH input and output per-token prices must be finite, mirroring `floe-monorepo/.../llm-pricing.ts`. Unpriceable models **warn loudly and refuse** by default rather than silently allow unlimited spend; manual price override path (`ManualPrice` / `price_overrides` / per-call `price=`).
- **CrewAI adapter** (optional `[crewai]` extra): `guard_crew(guard)` enforces across the whole crew in one line (CrewAI runs on LiteLLM).
- **LiteLLM adapter** (optional `[litellm]` extra): `guarded_completion()` wrapper (guaranteed pre-call enforcement) + `budget_guard_callback()` CustomLogger.
- **Hosted upgrade hook** (`src/floe_guard/hosted.py`): documented no-op that detects `FLOE_API_KEY`; no fabricated endpoint.
- **`examples/runaway_loop.py`**: stub LLM, **no API key / no account**, demonstrates the stop.
- **README**: 5-line usage on the first screen, GIF placeholder (`docs/stop-the-loop.gif`, TODO: record), honest estimate-based framing, "Upgrade to hosted Floe" section.

## Verification

- `pytest` — 23 passing
- `python -m py_compile` — clean
- `examples/runaway_loop.py` — runs with no real key, prints the block message
- `ruff check` / `ruff format` — clean
- Wheel build confirms `cost_map.json` is packaged

## Notes / honest framing

The local guard is **estimate-based** (priced from a vendored cost map in-process), not wallet-reconciled. Hosted Floe is the un-bypassable, cross-vendor upgrade. No marketing superlatives or inflated metrics.

Day-1 scope = CrewAI + LiteLLM only; LangChain + Vercel AI SDK marked "coming next".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an in-process USD budget guard for LLM calls with pre-call blocking, optional fail-closed behavior, and remaining-balance reporting
  * Added adapters for LiteLLM and CrewAI to enforce budgets during requests
  * Added offline token pricing (with manual pricing overrides) and a hosted-enforcement availability check
* **Documentation**
  * Added README with “stop the loop” demo and integration guidance
  * Added Contributing and Security documentation; added a GIF placeholder
* **Tests**
  * Expanded coverage for guard blocking, pricing logic, and framework adapters, plus example validation
* **Chores**
  * Added packaging configuration, tooling setup, and vendored pricing data; added `.gitignore`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->