### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Upgrade pip and install build
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Install project with dev extras
+        if: hashFiles('tests/**') != ''
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        if: hashFiles('tests/**') != ''
+        run: pytest
+
+      - name: Read package metadata
+        id: meta
+        run: |
+          PKG_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
+          PKG_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version is already published
+        id: check
+        run: |
+          PKG_NAME="${{ steps.meta.outputs.name }}"
+          PKG_VERSION="${{ steps.meta.outputs.version }}"
+          HTTP_CODE=$(curl -sS --connect-timeout 10 --max-time 20 -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/$PKG_NAME/$PKG_VERSION/json")
+          case "$HTTP_CODE" in
+            200)
+              echo "$PKG_NAME==$PKG_VERSION already published on PyPI, skipping."
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "$PKG_NAME==$PKG_VERSION not found on PyPI, will publish."
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unexpected PyPI response (HTTP $HTTP_CODE). Failing to avoid incorrect publish."
+              exit 1
+              ;;
+          esac
+
+      - name: Build distribution
+        if: steps.check.outputs.should_publish == 'true'
+        run: python -m build
+
+      - name: Publish to PyPI
+        if: steps.check.outputs.should_publish == 'true'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,11 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:


### PR DESCRIPTION
Adds the org-standard PyPI publish workflow so future `floe-guard` releases are bump-and-merge.

## What it does
On push to `main` (or manual `workflow_dispatch`):
1. Installs the package with `.[dev]` extras and runs `pytest` (gated on `tests/**` existing).
2. Reads `name`/`version` from `pyproject.toml`.
3. Checks PyPI — **skips if the version is already published** (no double-publish), fails on unexpected HTTP codes.
4. Builds and publishes via `pypa/gh-action-pypi-publish@v1.14.0` using `secrets.PYPI_API_TOKEN`.

Mirrors `agentkit-actions-py/.github/workflows/publish.yml` exactly, minus that repo's coinbase-agentkit prereq install (floe-guard's `.[dev]` extra is self-contained). All actions SHA-pinned per the org hardening standard. `permissions: contents: read`.

## Prereqs (done)
- `0.1.0` already published manually to PyPI: https://pypi.org/project/floe-guard/0.1.0/
- `PYPI_API_TOKEN` secret set on this repo.

## Release flow after merge
Bump `version` in `pyproject.toml` → merge to `main` → CI publishes. The version guard means merging this PR with `0.1.0` unchanged is a safe no-op (it'll detect `0.1.0` is already live and skip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions publishing workflow that automatically builds and publishes the package to PyPI on pushes to `main`, with a manual run option.
  * The workflow includes safeguards to skip publishing when the target version already exists on PyPI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->