### PR TITLE
feat: wire hosted.py to the live credit-remaining endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,32 @@ Floe moves enforcement server-side against a real credit line:
 - **Cross-vendor** — one budget over LLM tokens *and* paid (x402) tool calls.
 - **Team budgets + analytics** — shared ceilings, per-agent isolation, spend history.
 
-Set `FLOE_API_KEY` and floe-guard exposes a hook to delegate enforcement to
-hosted Floe (see [`src/floe_guard/hosted.py`](src/floe_guard/hosted.py) — wiring
-the live endpoint is in progress; the local guard is fully functional today).
+Set `FLOE_API_KEY` (your agent key, `floe_<hex>`) and floe-guard can read your
+agent's **server-side remaining budget** from the live Floe endpoint:
+
+```python
+from floe_guard import hosted_enforcement_available, hosted_remaining_usd
+
+if hosted_enforcement_available():       # True when FLOE_API_KEY is set
+    remaining = hosted_remaining_usd()   # USD left, read from Floe's server
+```
+
+`hosted_remaining_usd()` GETs `/v1/agents/credit-remaining` and returns the USD
+remaining — the minimum of your auto-borrow headroom and your session spend
+remaining. It raises `HostedEnforcementError` on a bad/missing key (401), a
+closed or suspended agent (403), an unprovisioned agent (404), or a network
+failure.
+
+Env vars:
+
+- `FLOE_API_KEY` — your agent key. Required for the read.
+- `FLOE_API_BASE_URL` — override the API host (defaults to
+  `https://credit-api.floelabs.xyz`).
+
+Honest scope: this call only **reads** the remaining budget. The un-bypassable,
+cross-vendor *enforcement* is the hosted Floe product running server-side — not
+this client. Use the number to inform a local ceiling; the server stays the
+source of truth.
 
 → **[dev-dashboard.floelabs.xyz](https://dev-dashboard.floelabs.xyz)** ·
 **[floelabs.xyz](https://floelabs.xyz)**

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 from .errors import (
     BudgetExceeded,
     FloeGuardError,
+    HostedEnforcementError,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
 from .guard import BudgetGuard
+from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 
 __version__ = "0.1.0"
@@ -28,10 +30,13 @@ __all__ = [
     "BudgetGuard",
     "BudgetExceeded",
     "FloeGuardError",
+    "HostedEnforcementError",
     "UnpriceableModelError",
     "UnpriceableModelWarning",
     "ManualPrice",
     "PricedModel",
     "price_tokens",
     "resolve_price",
+    "hosted_enforcement_available",
+    "hosted_remaining_usd",
 ]

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -43,6 +43,16 @@ class UnpriceableModelError(FloeGuardError):
         )
 
 
+class HostedEnforcementError(FloeGuardError):
+    """Raised when a read against the hosted Floe budget endpoint fails.
+
+    Covers a missing API key, a non-200 response (401 bad/missing key, 403 agent
+    closed/suspended, 404 agent not provisioned), a network/timeout failure, or a
+    malformed response body. The message states plainly what went wrong — this
+    client only *reads* server-side remaining budget; it does not enforce.
+    """
+
+
 class UnpriceableModelWarning(UserWarning):
     """Warned (loudly) whenever an unpriceable model is seen.
 

--- a/src/floe_guard/hosted.py
+++ b/src/floe_guard/hosted.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from .errors import HostedEnforcementError
@@ -78,7 +79,16 @@ def hosted_remaining_usd(
             f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV}."
         )
 
-    base = (base_url or os.environ.get(FLOE_API_BASE_URL_ENV, "") or DEFAULT_BASE_URL).rstrip("/")
+    env_base = os.environ.get(FLOE_API_BASE_URL_ENV, "").strip()
+    base = ((base_url or "").strip() or env_base or DEFAULT_BASE_URL).rstrip("/")
+    parsed = urllib.parse.urlparse(base)
+    if parsed.scheme != "https" or not parsed.netloc:
+        # The request carries the Floe agent key as a bearer token — never send it
+        # over a non-https or malformed URL where it could leak to an arbitrary host.
+        raise HostedEnforcementError(
+            f"Refusing to send the Floe API key to {base!r}: "
+            "the base URL must be an https:// URL with a host."
+        )
     url = f"{base}{CREDIT_REMAINING_PATH}"
 
     request = urllib.request.Request(
@@ -92,7 +102,7 @@ def hosted_remaining_usd(
             body = response.read()
     except urllib.error.HTTPError as exc:
         raise HostedEnforcementError(_describe_http_error(exc)) from exc
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
         raise HostedEnforcementError(
             f"Could not reach hosted Floe at {url}: {exc}"
         ) from exc

--- a/src/floe_guard/hosted.py
+++ b/src/floe_guard/hosted.py
@@ -1,40 +1,156 @@
-"""Hosted Floe upgrade hook (stub — not wired to a live endpoint).
+"""Hosted Floe upgrade hook — reads server-side remaining budget.
 
 The local :class:`~floe_guard.BudgetGuard` is *estimate-based*: it prices tokens
 from a vendored cost map in your own process. A determined agent (or a bug) can
 run around it, and it only sees the one vendor you instrumented.
 
-Hosted Floe is the upgrade: enforcement moves server-side against a real credit
+Hosted Floe is the upgrade: enforcement lives server-side against a real credit
 line, so the ceiling is **un-bypassable** and spans **every vendor** (LLM tokens
 *and* paid x402 tool calls) under one budget, with team budgets and analytics.
 
-This module is intentionally a no-op stub. When ``FLOE_API_KEY`` is set,
-:func:`hosted_enforcement_available` reports it so callers can branch toward the
-hosted path. Wiring the actual delegation is tracked below — we do NOT ship a
-fabricated endpoint.
+This module is the read side of that upgrade. When ``FLOE_API_KEY`` is set,
+:func:`hosted_enforcement_available` reports it and :func:`hosted_remaining_usd`
+queries the live Floe endpoint for the agent's remaining server-side budget.
+
+Honest framing: this client only **reads** the remaining budget. The actual
+un-bypassable, cross-vendor *enforcement* is performed server-side by hosted Floe
+— not by this code. Use the returned number to inform a local ceiling; the
+server is the source of truth.
 
     Upgrade: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
 """
 
 from __future__ import annotations
 
+import json
 import os
+import urllib.error
+import urllib.request
+
+from .errors import HostedEnforcementError
 
 FLOE_API_KEY_ENV = "FLOE_API_KEY"
+FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
+DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
+CREDIT_REMAINING_PATH = "/v1/agents/credit-remaining"
+
+# USDC has 6 implied decimals; raw integer strings divide by this to get USD.
+_USDC_DECIMALS = 1_000_000
 
 
 def hosted_enforcement_available() -> bool:
     """True if a Floe API key is present in the environment.
 
-    Presence of a key is the signal that a caller *could* delegate enforcement to
-    hosted Floe. It does not itself perform any network call.
+    Presence of a key is the signal that a caller *could* read the hosted budget.
+    It does not itself perform any network call.
     """
     return bool(os.environ.get(FLOE_API_KEY_ENV, "").strip())
 
 
-# TODO(hosted-upgrade): when FLOE_API_KEY is set, delegate enforcement to hosted
-# Floe instead of (or alongside) the local estimate. The hosted path debits a
-# real, server-side credit line — un-bypassable and cross-vendor — so the budget
-# holds even if the local process is bypassed. This requires the public hosted
-# budget API to be finalized; until then this stays a documented no-op rather
-# than a fabricated endpoint. See README "Upgrade to hosted Floe".
+def hosted_remaining_usd(
+    api_key: str | None = None,
+    *,
+    base_url: str | None = None,
+    timeout: float = 10.0,
+) -> float:
+    """Read the agent's remaining server-side budget from hosted Floe, in USD.
+
+    GETs ``/v1/agents/credit-remaining`` with ``Authorization: Bearer <key>`` and
+    returns the remaining budget as a USD float. "Remaining" is the **minimum** of
+    ``headroomToAutoBorrow`` and (when present) ``sessionSpendRemaining`` — both
+    are raw USDC strings (6 decimals) divided by 1e6.
+
+    This is a *read* only. Enforcement still happens server-side in Floe.
+
+    Args:
+        api_key: agent key (``floe_<hex>``). Defaults to ``FLOE_API_KEY`` env var.
+        base_url: API base. Defaults to ``FLOE_API_BASE_URL`` env var, else the
+            production host.
+        timeout: socket timeout in seconds.
+
+    Raises:
+        HostedEnforcementError: missing key, non-200 (401/403/404 surfaced with
+            the server's ``error`` field), network/timeout, or malformed JSON.
+    """
+    key = (api_key or os.environ.get(FLOE_API_KEY_ENV, "")).strip()
+    if not key:
+        raise HostedEnforcementError(
+            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV}."
+        )
+
+    base = (base_url or os.environ.get(FLOE_API_BASE_URL_ENV, "") or DEFAULT_BASE_URL).rstrip("/")
+    url = f"{base}{CREDIT_REMAINING_PATH}"
+
+    request = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"Authorization": f"Bearer {key}", "Accept": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        raise HostedEnforcementError(_describe_http_error(exc)) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise HostedEnforcementError(
+            f"Could not reach hosted Floe at {url}: {exc}"
+        ) from exc
+
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError) as exc:
+        raise HostedEnforcementError(
+            f"Malformed JSON from hosted Floe at {url}: {exc}"
+        ) from exc
+
+    return _remaining_usd_from_payload(payload, url)
+
+
+def _remaining_usd_from_payload(payload: object, url: str) -> float:
+    if not isinstance(payload, dict):
+        raise HostedEnforcementError(
+            f"Unexpected response shape from hosted Floe at {url}: expected an object."
+        )
+
+    headroom = _usd_from_raw(payload.get("headroomToAutoBorrow"), "headroomToAutoBorrow", url)
+
+    session_raw = payload.get("sessionSpendRemaining")
+    if session_raw is None:
+        return headroom
+
+    session = _usd_from_raw(session_raw, "sessionSpendRemaining", url)
+    return min(headroom, session)
+
+
+def _usd_from_raw(value: object, field: str, url: str) -> float:
+    try:
+        return int(str(value)) / _USDC_DECIMALS
+    except (ValueError, TypeError) as exc:
+        raise HostedEnforcementError(
+            f"Invalid {field!r} ({value!r}) from hosted Floe at {url}: {exc}"
+        ) from exc
+
+
+def _describe_http_error(exc: urllib.error.HTTPError) -> str:
+    server_error = _server_error_field(exc)
+    detail = f" ({server_error})" if server_error else ""
+    if exc.code == 401:
+        return f"Hosted Floe rejected the API key (401 unauthorized){detail}."
+    if exc.code == 403:
+        return f"Hosted Floe agent is closed or suspended (403 forbidden){detail}."
+    if exc.code == 404:
+        return f"Hosted Floe agent has no credit limit / not provisioned (404){detail}."
+    return f"Hosted Floe returned HTTP {exc.code}{detail}."
+
+
+def _server_error_field(exc: urllib.error.HTTPError) -> str | None:
+    try:
+        data = json.loads(exc.read())
+    except Exception:
+        return None
+    if isinstance(data, dict):
+        value = data.get("error")
+        if isinstance(value, str):
+            return value
+    return None

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -117,7 +117,8 @@ def test_unsafe_base_url_refuses_to_send_key(bad_base: str) -> None:
     urlopen.assert_not_called()
 
 
-def test_whitespace_base_url_falls_back_to_default() -> None:
+def test_whitespace_base_url_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_BASE_URL", raising=False)
     payload = {"headroomToAutoBorrow": "1000000", "sessionSpendRemaining": None}
     with mock.patch(
         "urllib.request.urlopen", return_value=_ok_response(payload)

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -1,10 +1,46 @@
-"""The hosted upgrade hook is a documented no-op until FLOE_API_KEY is set."""
+"""The hosted hook reads server-side remaining budget from the live endpoint.
+
+These tests never hit the network: ``urllib.request.urlopen`` is mocked.
+"""
 
 from __future__ import annotations
 
+import io
+import json
+import urllib.error
+from unittest import mock
+
 import pytest
 
-from floe_guard.hosted import hosted_enforcement_available
+from floe_guard.errors import HostedEnforcementError
+from floe_guard.hosted import (
+    hosted_enforcement_available,
+    hosted_remaining_usd,
+)
+
+
+def _ok_response(payload: dict[str, object]) -> mock.MagicMock:
+    """A context-manager mock that returns ``payload`` as JSON bytes on read()."""
+    body = json.dumps(payload).encode()
+    resp = mock.MagicMock()
+    resp.read.return_value = body
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _http_error(code: int, payload: dict[str, object] | None = None) -> urllib.error.HTTPError:
+    body = json.dumps(payload).encode() if payload is not None else b""
+    return urllib.error.HTTPError(
+        url="https://credit-api.floelabs.xyz/v1/agents/credit-remaining",
+        code=code,
+        msg="error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+# ── availability ────────────────────────────────────────────────────────────
 
 
 def test_no_key_means_no_hosted_enforcement(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -15,3 +51,100 @@ def test_no_key_means_no_hosted_enforcement(monkeypatch: pytest.MonkeyPatch) -> 
 def test_key_present_signals_hosted_path(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FLOE_API_KEY", "floe_test_key")
     assert hosted_enforcement_available() is True
+
+
+# ── happy path ──────────────────────────────────────────────────────────────
+
+
+def test_remaining_takes_min_when_session_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLOE_API_KEY", "floe_test_key")
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": "2000000"}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        assert hosted_remaining_usd() == 2.0
+
+
+def test_remaining_uses_headroom_when_session_null(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLOE_API_KEY", "floe_test_key")
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": None}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        assert hosted_remaining_usd() == 5.0
+
+
+def test_remaining_uses_headroom_when_session_smaller(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLOE_API_KEY", "floe_test_key")
+    payload = {"headroomToAutoBorrow": "1500000", "sessionSpendRemaining": "9000000"}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        assert hosted_remaining_usd() == 1.5
+
+
+def test_explicit_api_key_sends_bearer_header() -> None:
+    payload = {"headroomToAutoBorrow": "1000000", "sessionSpendRemaining": None}
+    with mock.patch(
+        "urllib.request.urlopen", return_value=_ok_response(payload)
+    ) as urlopen:
+        hosted_remaining_usd(api_key="floe_abc")
+    request = urlopen.call_args.args[0]
+    assert request.get_header("Authorization") == "Bearer floe_abc"
+    assert request.full_url.endswith("/v1/agents/credit-remaining")
+
+
+def test_base_url_override_is_used() -> None:
+    payload = {"headroomToAutoBorrow": "1000000", "sessionSpendRemaining": None}
+    with mock.patch(
+        "urllib.request.urlopen", return_value=_ok_response(payload)
+    ) as urlopen:
+        hosted_remaining_usd(api_key="floe_abc", base_url="https://staging.example.com/")
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://staging.example.com/v1/agents/credit-remaining"
+
+
+# ── errors ──────────────────────────────────────────────────────────────────
+
+
+def test_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with pytest.raises(HostedEnforcementError, match="No Floe API key"):
+        hosted_remaining_usd()
+
+
+@pytest.mark.parametrize(
+    ("code", "needle"),
+    [
+        (401, "401"),
+        (403, "403"),
+        (404, "404"),
+    ],
+)
+def test_http_status_raises(code: int, needle: str) -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=_http_error(code, {"error": "x"})):
+        with pytest.raises(HostedEnforcementError, match=needle):
+            hosted_remaining_usd(api_key="floe_abc")
+
+
+def test_404_surfaces_server_error_field() -> None:
+    err = _http_error(404, {"error": "no_credit_limit"})
+    with mock.patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(HostedEnforcementError, match="no_credit_limit"):
+            hosted_remaining_usd(api_key="floe_abc")
+
+
+def test_timeout_raises() -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")):
+        with pytest.raises(HostedEnforcementError, match="Could not reach"):
+            hosted_remaining_usd(api_key="floe_abc")
+
+
+def test_network_error_raises() -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("down")):
+        with pytest.raises(HostedEnforcementError, match="Could not reach"):
+            hosted_remaining_usd(api_key="floe_abc")
+
+
+def test_malformed_json_raises() -> None:
+    resp = mock.MagicMock()
+    resp.read.return_value = b"not json{"
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    with mock.patch("urllib.request.urlopen", return_value=resp):
+        with pytest.raises(HostedEnforcementError, match="Malformed JSON"):
+            hosted_remaining_usd(api_key="floe_abc")

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -98,6 +98,35 @@ def test_base_url_override_is_used() -> None:
     assert request.full_url == "https://staging.example.com/v1/agents/credit-remaining"
 
 
+@pytest.mark.parametrize(
+    "bad_base",
+    [
+        "http://credit-api.floelabs.xyz",  # non-https — would leak the bearer token
+        "file:///etc/passwd",
+        "ftp://example.com",
+        "not-a-url",
+        "https://",  # scheme but no host
+    ],
+)
+def test_unsafe_base_url_refuses_to_send_key(bad_base: str) -> None:
+    # The agent key is sent as a bearer token; a non-https/malformed base URL must
+    # be rejected BEFORE any request is made.
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(HostedEnforcementError, match="https"):
+            hosted_remaining_usd(api_key="floe_abc", base_url=bad_base)
+    urlopen.assert_not_called()
+
+
+def test_whitespace_base_url_falls_back_to_default() -> None:
+    payload = {"headroomToAutoBorrow": "1000000", "sessionSpendRemaining": None}
+    with mock.patch(
+        "urllib.request.urlopen", return_value=_ok_response(payload)
+    ) as urlopen:
+        hosted_remaining_usd(api_key="floe_abc", base_url="   ")
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://credit-api.floelabs.xyz/v1/agents/credit-remaining"
+
+
 # ── errors ──────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Replaces the `hosted.py` no-op stub with a real read client against the verified Floe endpoint, so when `FLOE_API_KEY` is set, floe-guard can read server-side remaining budget instead of only estimating locally.

## What
- `hosted_remaining_usd(api_key=None, *, base_url=None, timeout=10.0) -> float` — GETs `GET /v1/agents/credit-remaining` with `Authorization: Bearer <floe_key>` (stdlib `urllib` only, **no new dependency**). Returns `min(headroomToAutoBorrow, sessionSpendRemaining-if-set) / 1e6`.
- `hosted_enforcement_available()` kept (env key present).
- `FLOE_API_BASE_URL` env override (default `https://credit-api.floelabs.xyz`).
- New `HostedEnforcementError` surfacing 401 (bad/missing key) / 403 (closed/suspended) / 404 (`no_credit_limit`) / network/timeout / malformed JSON.

## Honest scope
This call only **reads** remaining budget. The un-bypassable, cross-vendor *enforcement* is the hosted Floe product running server-side — not this client. README "Upgrade to hosted Floe" updated to say exactly that. No response fields invented (only `headroomToAutoBorrow` + `sessionSpendRemaining` are read).

## Tests
44 passed (Python 3.13), ruff clean. All HTTP mocked via `urllib.request.urlopen` — no network. Covers availability, happy-path min() logic, bearer header, base-url override, 401/403/404, timeout, network error, malformed JSON.

## Endpoint provenance
Verified against `floe-monorepo/apps/api`: route `apps/api/src/routes/agents.ts:111`, agent-key auth `apps/api/src/middleware/api-key-auth.ts:78`, service `balance-service.ts:227`. Endpoint returns 401 unauthenticated on the live host (confirmed).

## Follow-up (not in this PR)
`BudgetGuard` is left untouched — this is a read helper, not auto-seeding the local ceiling from the server number. Coupling the in-process guard to a network call should be an explicit opt-in, not assumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hosted remaining-budget reading via `hosted_remaining_usd`, configurable with environment variables and base URL override.
  * Exposed hosted-related symbols in the public API, including a new `HostedEnforcementError` for read failures.
* **Documentation**
  * Updated README to describe required configuration (`FLOE_API_KEY`, optional `FLOE_API_BASE_URL`) and the hosted “remaining” behavior and error cases.
* **Tests**
  * Expanded hosted budgeting tests with mocked requests, success-path selection logic, request header/URL assertions, and error handling coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->