### PR TITLE
ci: add PR test + lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.13'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]"
+      - name: Ruff
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      # Install the framework extras so the adapter handler tests actually run
+      # (instead of skipping). langchain-core covers the LangChain handler tests.
+      - run: pip install -e ".[dev,langchain]"
+      - name: Pytest
+        run: pytest -q
+
+  test-bare:
+    # Locks the dependency-free contract: the package and its test suite must
+    # work with NO framework extra installed (handler tests skip cleanly, no
+    # import errors). This is what publish.yml runs before releasing.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.13'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]"
+      - name: Pytest (no extras)
+        run: pytest -q


### PR DESCRIPTION
The repo had no PR CI — `publish.yml` only runs on push to `main`, so tests/lint never ran on pull requests. The only PR checks were the merge-conflict check and CodeRabbit. This adds real status checks.

## What runs (on `pull_request` and push to `main`)
- **`lint`** — `ruff check .` (Python 3.13).
- **`test`** — `pytest` matrix over Python **3.10–3.13** (the `requires-python` range), with `.[dev,langchain]` installed so the adapter **handler tests actually run** instead of skipping. `fail-fast: false`.
- **`test-bare`** — `pytest` with only `.[dev]` (no framework extras). Locks the dependency-free contract: the package + suite must work with no extra installed (handler tests skip cleanly, no import errors). This is exactly the class of bug just caught on PR #3, and it's what `publish.yml` relies on before releasing.

## Hardening (matches the org standard)
- Actions SHA-pinned (same pins as `publish.yml`).
- `persist-credentials: false`, `permissions: contents: read`, `timeout-minutes`, and `concurrency` with `cancel-in-progress` to drop superseded runs.

## Follow-up (needs a repo admin — can't be done from a workflow file)
To make these **required** (block merge on red), enable branch protection on `main`: Settings → Branches → add a rule requiring the `lint`, `test`, and `test-bare` checks to pass. Until then they run and show status but don't gate merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated continuous integration workflows to ensure code quality and compatibility across Python versions during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->