### PR TITLE
ci: npm publish workflow + cost-map drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Python and JS cost maps must match
-        run: diff src/floe_guard/cost_map.json js/src/cost_map.json
+        # -q keeps the failure concise (the map is ~700 lines); the message says
+        # what to do rather than dumping the whole diff.
+        run: |
+          diff -q src/floe_guard/cost_map.json js/src/cost_map.json \
+            || { echo "::error::cost_map.json drifted between src/floe_guard/ and js/src/ — re-sync the two copies."; exit 1; }
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,20 @@ jobs:
       - name: Ruff
         run: ruff check .
 
+  cost-map-sync:
+    # The LiteLLM cost map is vendored in two places — the Python package
+    # (src/floe_guard/cost_map.json) and the JS package (js/src/cost_map.json).
+    # They must stay byte-identical; fail loudly if they drift so any refresh
+    # updates both.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Python and JS cost maps must match
+        run: diff src/floe_guard/cost_map.json js/src/cost_map.json
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,70 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+    # The npm package lives in js/; only publish when it (or this workflow) changes.
+    paths:
+      - 'js/**'
+      - '.github/workflows/publish-npm.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: js
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Check if version is already published
+        id: check
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "name=$PKG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "$PKG_NAME@$PKG_VERSION" version > /dev/null 2>npm_view.err; then
+            echo "$PKG_NAME@$PKG_VERSION already published on npm, skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          elif grep -q 'E404' npm_view.err; then
+            echo "$PKG_NAME@$PKG_VERSION not found on npm, will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm view failed unexpectedly; aborting publish check." >&2
+            cat npm_view.err >&2
+            exit 1
+          fi
+
+      - name: Publish
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,7 +31,8 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          # Node 22: satisfies the test toolchain (vitest 4 / vite need >=20.19).
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          # Node 22: satisfies the test toolchain (vitest 4 / vite need >=20.19).
+          # Node 22: current LTS, comfortably covers the JS toolchain (Vite/Vitest).
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Re-lands two infra pieces that were authored on the PR #6 branch but missed the merge (PR #6 merged before the commit landed, so they never reached `main`).

## `publish-npm.yml` — ships the `js/` package to npm
- On push to `main`, **paths-filtered to `js/**`** (doesn't run on Python-only changes; `publish.yml` covers PyPI).
- `npm ci` → build → test → **version-guard** (`npm view`, skip if published, E404 → publish) → `npm publish --access public` with `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`.
- Node **22** for the test step (vitest 4 / vite require ≥20.19). SHA-pinned, `persist-credentials: false`, `permissions: contents: read`, timeout, concurrency.

**Needs `NPM_TOKEN` secret** (npm automation or granular token) before it can publish. Once set + merged, it publishes `floe-guard@0.1.0` to npm (name verified available).

## `ci.yml` — `cost-map-sync` job
Fails if `src/floe_guard/cost_map.json` and `js/src/cost_map.json` drift. The two are currently byte-identical.

> Note: this only keeps floe-guard's **two copies consistent with each other**. Both are manual vendored snapshots of floe-monorepo's `apps/api/src/services/llm-cost-map.json` (which *does* auto-refresh via `update-llm-cost-map.yml`). Keeping floe-guard's copies in sync with that **upstream** refresh is a separate, larger question — see the PR discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / CI**
  * Improved the CI pipeline by adding a consistency check to ensure vendored LiteLLM cost map files remain byte-identical.
* **Chores / Release Automation**
  * Added an npm publishing workflow that builds and tests the package, only publishes from the appropriate directory, and automatically skips publishing if the exact version already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->