### PR TITLE
ci: ignore all JS major bumps in Dependabot (not just ai)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,11 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     ignore:
-      # The Vercel AI SDK middleware targets the v4 LanguageModelV1 interface.
-      # ai v5/v6 are breaking API changes (LanguageModelV2Middleware, renamed
-      # usage fields) — supporting them is a deliberate migration, not an auto-
-      # bump. Major bumps repeatedly broke main, so pin to v4 majors here.
-      # (Honored by Dependabot security updates too.)
-      - dependency-name: "ai"
+      # Major bumps of the JS dev tooling are breaking changes that need a
+      # deliberate migration, not an auto-bump — they have repeatedly broken the
+      # build: ai v5 removed LanguageModelV1Middleware; TypeScript 6 turns the
+      # baseUrl deprecation into a hard error (TS5101) in the tsup dts build.
+      # Defer ALL majors to a human; patch/minor (incl. security fixes within a
+      # major) still flow. (Honored by Dependabot security updates too.)
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Re-lands the broadened ignore that was orphaned when #14 merged ~1 minute before the commit landed (main currently ignores only `ai` majors).

Three breaking major bumps in a row — ai v5 (broke main, #13), ai v6 (#11), TypeScript 6 (#15, breaks the tsup dts build via `TS5101: baseUrl deprecated`) — show that auto-bumping dev-tooling majors isn't safe for this package. Change the ignore from `ai` only to `*` (all dependencies), **major updates only**. Patch/minor — including security fixes within a major — still flow. Honored by Dependabot security updates too.

Adopting any major (ai v5, TS 6, …) becomes a deliberate, reviewed migration.