### PR TITLE
Fix BudgetGuard concurrency race: atomic reserve()/settle() so the ceiling holds under parallel crews (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ vendored cost map *inside your process*:
 - The cost map can drift as vendors change prices — refresh it like any snapshot.
 - It only sees the vendors you instrument.
 - A determined agent or a bug could route around an in-process check.
+- Under heavy or cold-start concurrency it bounds steady-state spend, not the
+  first parallel wave. Reservations size from the last call's cost (`0` until the
+  first `record()`), so the opening fan-out has nothing to estimate from. Pass a
+  known per-call max to `reserve()` to bound it, or use hosted Floe for a hard cap
+  under arbitrary concurrency.
 
 It's genuinely useful on its own, and it's honest about its limits. No inflated
 metrics, no "zero defaults" claims — it's a free local stop, not a vault.

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -274,6 +274,10 @@ export class BudgetGuard {
     return {
       nearLimit: usedBps >= this.nearLimitBps,
       usedBps,
+      // Settled budget: limit minus accrued spend, deliberately NOT net of
+      // in-flight reservations. Unlike the remainingUsd getter (which subtracts
+      // `reserved`), the advisory is a soft utilization signal about money already
+      // spent, while the getter reports what a new call can still claim.
       remainingUsd: Math.max(0, this.limitUsd - this.spentUsd),
       limitUsd: this.limitUsd,
       spentUsd: this.spentUsd,

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -190,6 +190,11 @@ export class BudgetGuard {
     options: { reserved?: number; price?: ManualPrice } = {},
   ): number {
     const reserved = options.reserved ?? 0;
+    // A bad reserved handle would corrupt this.reserved and break the ceiling for
+    // OTHER in-flight calls (negative → phantom hold; Infinity → clears all holds).
+    if (!Number.isFinite(reserved) || reserved < 0) {
+      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
+    }
     let overrides = this.priceOverrides;
     if (options.price !== undefined) {
       overrides = { ...(overrides ?? {}), [model]: options.price };
@@ -259,6 +264,11 @@ export class BudgetGuard {
    * before producing usage). Safe to call with `0`.
    */
   release(reserved: number): void {
+    // Validate before the zero-check so a NaN handle throws instead of being
+    // silently dropped (a leak); a bad handle corrupts the in-flight tally.
+    if (!Number.isFinite(reserved) || reserved < 0) {
+      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
+    }
     if (!reserved) return;
     this.reserved = Math.max(0, this.reserved - reserved);
   }

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -132,10 +132,16 @@ export class BudgetGuard {
    * `settle()`, which hold the estimate across the await.
    */
   check(estimatedNextCost?: number): void {
-    const estimate =
-      estimatedNextCost === undefined
-        ? this.lastCost
-        : Math.max(0, estimatedNextCost);
+    const rawEstimate =
+      estimatedNextCost === undefined ? this.lastCost : estimatedNextCost;
+    if (!Number.isFinite(rawEstimate)) {
+      // NaN/Infinity would poison the comparisons and fail-open — reject it
+      // (parity with the constructor's Number.isFinite guard).
+      throw new RangeError(
+        `estimatedNextCost must be a finite number, got ${rawEstimate}`,
+      );
+    }
+    const estimate = Math.max(0, rawEstimate);
     const committed = this.spentUsd + this.reserved;
     if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
       this.onBlock(this.spentUsd, this.limitUsd);
@@ -154,8 +160,14 @@ export class BudgetGuard {
    * `estimatedCost` defaults to the last call's cost.
    */
   reserve(estimatedCost?: number): number {
-    const estimate =
-      estimatedCost === undefined ? this.lastCost : Math.max(0, estimatedCost);
+    const rawEstimate = estimatedCost === undefined ? this.lastCost : estimatedCost;
+    if (!Number.isFinite(rawEstimate)) {
+      // NaN would poison this.reserved and fail-open the ceiling — reject it.
+      throw new RangeError(
+        `estimatedCost must be a finite number, got ${rawEstimate}`,
+      );
+    }
+    const estimate = Math.max(0, rawEstimate);
     const committed = this.spentUsd + this.reserved;
     if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
       this.onBlock(this.spentUsd, this.limitUsd);

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -9,6 +9,16 @@
  * 2. Call {@link BudgetGuard.record} AFTER every response, with the token usage.
  *    It prices the tokens offline and accrues the USD into a running total.
  *
+ * **Concurrency.** `check()` then `record()` is a check-then-act with an `await`
+ * in between. Fire several model calls at once (e.g. `Promise.all`) and they all
+ * `check()` against the same under-limit total before any `record()` lands, so
+ * the ceiling is blown (see issue #18). {@link BudgetGuard.reserve} /
+ * {@link BudgetGuard.settle} close that gap: `reserve()` holds the estimated cost
+ * in flight (synchronously, before the await), so parallel callers each take
+ * their own slice of the ceiling. JS is single-threaded, so an in-flight counter
+ * is enough — no lock needed. The middleware uses it; `check`/`record` are
+ * unchanged.
+ *
  * This is a faithful port of `src/floe_guard/guard.py` — same prediction logic,
  * same epsilon handling, same fail-closed default.
  */
@@ -49,6 +59,8 @@ export class BudgetGuard {
   private readonly onBlock: (spentUsd: number, limitUsd: number) => void;
   /** Cost of the most recent priced call, used to predict the next one. */
   private lastCost = 0;
+  /** USD held for in-flight calls (reserved, not yet settled). Counts toward the ceiling. */
+  private reserved = 0;
 
   /**
    * @param limitUsd the spend ceiling, in USD. `0` blocks the very first call.
@@ -72,39 +84,60 @@ export class BudgetGuard {
    *
    * Call this immediately before each LLM request. The "next call" is estimated
    * from the last recorded call's cost (override with `estimatedNextCost`); the
-   * first call is always allowed unless the ceiling is already met. A check on
-   * the running total catches an overshoot if the estimate was too low.
+   * first call is always allowed unless the ceiling is already met. In-flight
+   * reservations count toward the total, so this stays correct alongside
+   * {@link BudgetGuard.reserve}.
+   *
+   * Note: `check` is a non-binding peek. For parallel calls, use `reserve()` /
+   * `settle()`, which hold the estimate across the await.
    */
   check(estimatedNextCost?: number): void {
     const estimate =
       estimatedNextCost === undefined
         ? this.lastCost
         : Math.max(0, estimatedNextCost);
-    const projected = this.spentUsd + estimate;
-    // Compare with an epsilon so float rounding in the running total doesn't
-    // block a call early or let one slip past the ceiling.
-    if (
-      this.spentUsd > this.limitUsd - EPS ||
-      projected > this.limitUsd + EPS
-    ) {
+    const committed = this.spentUsd + this.reserved;
+    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
       this.onBlock(this.spentUsd, this.limitUsd);
       throw new BudgetExceeded(this.spentUsd, this.limitUsd);
     }
   }
 
   /**
-   * Price one response's tokens offline and add the cost to the total.
+   * Atomically check the ceiling AND hold the estimated cost in flight.
    *
-   * Returns the USD cost of this call. If the model is unpriceable and no `price`
-   * is given, behaviour depends on `failClosed`: warn + throw (default), or
-   * warn + skip accrual.
+   * The concurrency-safe enforcement path: call before the request and hold the
+   * returned reservation across the await, so parallel callers can't all clear
+   * the same stale total. Throws {@link BudgetExceeded} (without reserving) if
+   * the reservation would cross the ceiling. Returns the reservation handle to
+   * pass to {@link BudgetGuard.settle} (or {@link BudgetGuard.release} on error).
+   * `estimatedCost` defaults to the last call's cost.
    */
-  record(
+  reserve(estimatedCost?: number): number {
+    const estimate =
+      estimatedCost === undefined ? this.lastCost : Math.max(0, estimatedCost);
+    const committed = this.spentUsd + this.reserved;
+    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
+      this.onBlock(this.spentUsd, this.limitUsd);
+      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
+    }
+    this.reserved += estimate;
+    return estimate;
+  }
+
+  /**
+   * Release a reservation and record the actual cost. `record` is `settle` with
+   * no reservation. Returns the USD cost of this call; unpriceable-model handling
+   * matches {@link BudgetGuard.record}, and any held reservation is released even
+   * on the warn-and-skip path.
+   */
+  settle(
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { price?: ManualPrice } = {},
+    options: { reserved?: number; price?: ManualPrice } = {},
   ): number {
+    const reserved = options.reserved ?? 0;
     let overrides = this.priceOverrides;
     if (options.price !== undefined) {
       overrides = { ...(overrides ?? {}), [model]: options.price };
@@ -120,10 +153,15 @@ export class BudgetGuard {
       if (this.failClosed) {
         throw new UnpriceableModelError(model);
       }
+      // Opted into un-metered spend for this model: free the hold, accrue $0.
+      this.release(reserved);
       return 0;
     }
 
     const cost = priceTokens(priced, promptTokens, completionTokens);
+    if (reserved) {
+      this.reserved = Math.max(0, this.reserved - reserved);
+    }
     this.spentUsd += cost;
     // Clamp a sub-epsilon float overshoot back to the limit so the running total
     // never reports as having crossed the ceiling by a rounding artifact.
@@ -134,9 +172,37 @@ export class BudgetGuard {
     return cost;
   }
 
-  /** USD left before the ceiling (never negative). */
+  /**
+   * Price one response's tokens offline and add the cost to the total.
+   *
+   * Returns the USD cost of this call. If the model is unpriceable and no `price`
+   * is given, behaviour depends on `failClosed`: warn + throw (default), or
+   * warn + skip accrual.
+   */
+  record(
+    model: string,
+    promptTokens: number,
+    completionTokens: number,
+    options: { price?: ManualPrice } = {},
+  ): number {
+    return this.settle(model, promptTokens, completionTokens, {
+      reserved: 0,
+      price: options.price,
+    });
+  }
+
+  /**
+   * Drop an in-flight reservation without recording spend (e.g. the call failed
+   * before producing usage). Safe to call with `0`.
+   */
+  release(reserved: number): void {
+    if (!reserved) return;
+    this.reserved = Math.max(0, this.reserved - reserved);
+  }
+
+  /** USD left before the ceiling, net of in-flight reservations (never negative). */
   get remainingUsd(): number {
-    return Math.max(0, this.limitUsd - this.spentUsd);
+    return Math.max(0, this.limitUsd - this.spentUsd - this.reserved);
   }
 }
 

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -200,7 +200,16 @@ export class BudgetGuard {
       return 0;
     }
 
-    const cost = priceTokens(priced, promptTokens, completionTokens);
+    let cost: number;
+    try {
+      cost = priceTokens(priced, promptTokens, completionTokens);
+    } catch (err) {
+      // priceTokens can throw (e.g. non-finite costs). Release the in-flight
+      // hold before re-throwing so `reserved` doesn't leak and shrink
+      // remainingUsd permanently — same fail-safe as the unpriceable path above.
+      this.release(reserved);
+      throw err;
+    }
     if (reserved) {
       this.reserved = Math.max(0, this.reserved - reserved);
     }

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -150,11 +150,13 @@ export class BudgetGuard {
           `manual price given. The budget guard cannot enforce a ceiling on ` +
           `spend it cannot measure — pass { price } or set it in priceOverrides.`,
       );
+      // Release any held reservation on BOTH paths. Fail-closed must not leak
+      // the in-flight hold, or reserved grows permanently and remainingUsd
+      // shrinks until reserve() starts blocking everything.
+      this.release(reserved);
       if (this.failClosed) {
         throw new UnpriceableModelError(model);
       }
-      // Opted into un-metered spend for this model: free the hold, accrue $0.
-      this.release(reserved);
       return 0;
     }
 

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -53,56 +53,53 @@ export function budgetGuardMiddleware(
   return {
     async wrapGenerate({ doGenerate, model }) {
       const reserved = guard.reserve(); // throws BudgetExceeded before the call runs
-      let result: Awaited<ReturnType<typeof doGenerate>>;
       try {
-        result = await doGenerate();
+        const result = await doGenerate();
+        guard.settle(
+          model.modelId,
+          result.usage.promptTokens,
+          result.usage.completionTokens,
+          { reserved },
+        );
+        return result;
       } catch (err) {
-        guard.release(reserved); // call failed — give the budget back
+        guard.release(reserved); // call (or pricing) failed — give the budget back
         throw err;
       }
-      guard.settle(
-        model.modelId,
-        result.usage.promptTokens,
-        result.usage.completionTokens,
-        { reserved },
-      );
-      return result;
     },
 
     async wrapStream({ doStream, model }) {
       const reserved = guard.reserve(); // throws BudgetExceeded before the stream starts
-      let started: Awaited<ReturnType<typeof doStream>>;
       try {
-        started = await doStream();
+        const { stream, ...rest } = await doStream();
+
+        let settled = false;
+        const guarded = stream.pipeThrough(
+          new TransformStream<StreamPart, StreamPart>({
+            transform(chunk, controller) {
+              if (chunk.type === "finish") {
+                guard.settle(
+                  model.modelId,
+                  chunk.usage.promptTokens,
+                  chunk.usage.completionTokens,
+                  { reserved },
+                );
+                settled = true;
+              }
+              controller.enqueue(chunk);
+            },
+            flush() {
+              // Stream ended without a finish/usage part — free the held budget.
+              if (!settled) guard.release(reserved);
+            },
+          }),
+        );
+
+        return { stream: guarded, ...rest };
       } catch (err) {
         guard.release(reserved);
         throw err;
       }
-      const { stream, ...rest } = started;
-
-      let settled = false;
-      const guarded = stream.pipeThrough(
-        new TransformStream<StreamPart, StreamPart>({
-          transform(chunk, controller) {
-            if (chunk.type === "finish") {
-              guard.settle(
-                model.modelId,
-                chunk.usage.promptTokens,
-                chunk.usage.completionTokens,
-                { reserved },
-              );
-              settled = true;
-            }
-            controller.enqueue(chunk);
-          },
-          flush() {
-            // Stream ended without a finish/usage part — free the held budget.
-            if (!settled) guard.release(reserved);
-          },
-        }),
-      );
-
-      return { stream: guarded, ...rest };
     },
   };
 }

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -5,10 +5,16 @@
  * is TypeScript-only, so it ships as its own npm package.
  *
  * Verified against `ai@4.3.19` (`LanguageModelV1Middleware`):
- *   - `wrapGenerate({ doGenerate, model })` — we `check()` (throws to hard-stop)
- *     BEFORE calling `doGenerate()`, then `record()` from `result.usage`.
- *   - `wrapStream({ doStream, model })` — we `check()` BEFORE `doStream()`, then
- *     read `usage` from the `finish` part as the stream drains.
+ *   - `wrapGenerate({ doGenerate, model })` — we `reserve()` (throws to hard-stop)
+ *     BEFORE calling `doGenerate()`, hold the reservation across the await, then
+ *     `settle()` from `result.usage`.
+ *   - `wrapStream({ doStream, model })` — we `reserve()` BEFORE `doStream()`, then
+ *     `settle()` from the `finish` part as the stream drains.
+ *
+ * Reserving before the await is what makes parallel calls (`Promise.all` over
+ * several generations) honour the ceiling: each holds its slice instead of all
+ * reading the same stale total (issue #18). The reservation is released if the
+ * call throws, or if a stream ends without reporting usage.
  *
  * The model id used for pricing comes from `model.modelId`.
  */
@@ -46,31 +52,52 @@ export function budgetGuardMiddleware(
 ): LanguageModelV1Middleware {
   return {
     async wrapGenerate({ doGenerate, model }) {
-      guard.check(); // throws BudgetExceeded before the call runs
-      const result = await doGenerate();
-      guard.record(
+      const reserved = guard.reserve(); // throws BudgetExceeded before the call runs
+      let result: Awaited<ReturnType<typeof doGenerate>>;
+      try {
+        result = await doGenerate();
+      } catch (err) {
+        guard.release(reserved); // call failed — give the budget back
+        throw err;
+      }
+      guard.settle(
         model.modelId,
         result.usage.promptTokens,
         result.usage.completionTokens,
+        { reserved },
       );
       return result;
     },
 
     async wrapStream({ doStream, model }) {
-      guard.check(); // throws BudgetExceeded before the stream starts
-      const { stream, ...rest } = await doStream();
+      const reserved = guard.reserve(); // throws BudgetExceeded before the stream starts
+      let started: Awaited<ReturnType<typeof doStream>>;
+      try {
+        started = await doStream();
+      } catch (err) {
+        guard.release(reserved);
+        throw err;
+      }
+      const { stream, ...rest } = started;
 
+      let settled = false;
       const guarded = stream.pipeThrough(
         new TransformStream<StreamPart, StreamPart>({
           transform(chunk, controller) {
             if (chunk.type === "finish") {
-              guard.record(
+              guard.settle(
                 model.modelId,
                 chunk.usage.promptTokens,
                 chunk.usage.completionTokens,
+                { reserved },
               );
+              settled = true;
             }
             controller.enqueue(chunk);
+          },
+          flush() {
+            // Stream ended without a finish/usage part — free the held budget.
+            if (!settled) guard.release(reserved);
           },
         }),
       );

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -78,12 +78,20 @@ export function budgetGuardMiddleware(
           new TransformStream<StreamPart, StreamPart>({
             transform(chunk, controller) {
               if (chunk.type === "finish") {
-                guard.settle(
-                  model.modelId,
-                  chunk.usage.promptTokens,
-                  chunk.usage.completionTokens,
-                  { reserved },
-                );
+                try {
+                  guard.settle(
+                    model.modelId,
+                    chunk.usage.promptTokens,
+                    chunk.usage.completionTokens,
+                    { reserved },
+                  );
+                } catch (err) {
+                  // settle()/usage access can throw (e.g. non-finite usage). A
+                  // transform error means flush() won't run, so release the held
+                  // budget here to avoid leaking it, then surface the error.
+                  guard.release(reserved);
+                  throw err;
+                }
                 settled = true;
               }
               controller.enqueue(chunk);

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -128,7 +128,9 @@ export function budgetGuardMiddleware(
               guard.release(reserved);
             }
           },
-        }),
+          // `cancel` is valid per the Streams spec and supported in Node 18+, but
+          // TS's Transformer lib type lags and omits it — cast to keep the type check.
+        } as Transformer<StreamPart, StreamPart>),
       );
 
       return { stream: guarded, ...rest };

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -53,61 +53,85 @@ export function budgetGuardMiddleware(
   return {
     async wrapGenerate({ doGenerate, model }) {
       const reserved = guard.reserve(); // throws BudgetExceeded before the call runs
+      let result: Awaited<ReturnType<typeof doGenerate>>;
       try {
-        const result = await doGenerate();
-        guard.settle(
-          model.modelId,
-          result.usage.promptTokens,
-          result.usage.completionTokens,
-          { reserved },
-        );
+        result = await doGenerate();
+      } catch (err) {
+        guard.release(reserved); // the call failed before settle() took ownership
+        throw err;
+      }
+      // From here settle() OWNS the reservation: it releases the hold on its own
+      // throw (unpriceable / non-finite cost) and consumes it on success. Releasing
+      // again would double-subtract and clear a concurrent call's in-flight hold.
+      let handled = false;
+      try {
+        const { promptTokens, completionTokens } = result.usage;
+        handled = true;
+        guard.settle(model.modelId, promptTokens, completionTokens, { reserved });
         return result;
       } catch (err) {
-        guard.release(reserved); // call (or pricing) failed — give the budget back
+        if (!handled) guard.release(reserved); // failed reading usage, before settle()
         throw err;
       }
     },
 
     async wrapStream({ doStream, model }) {
       const reserved = guard.reserve(); // throws BudgetExceeded before the stream starts
+      let streamResult: Awaited<ReturnType<typeof doStream>>;
       try {
-        const { stream, ...rest } = await doStream();
-
-        let settled = false;
-        const guarded = stream.pipeThrough(
-          new TransformStream<StreamPart, StreamPart>({
-            transform(chunk, controller) {
-              if (chunk.type === "finish") {
-                try {
-                  guard.settle(
-                    model.modelId,
-                    chunk.usage.promptTokens,
-                    chunk.usage.completionTokens,
-                    { reserved },
-                  );
-                } catch (err) {
-                  // settle()/usage access can throw (e.g. non-finite usage). A
-                  // transform error means flush() won't run, so release the held
-                  // budget here to avoid leaking it, then surface the error.
-                  guard.release(reserved);
-                  throw err;
-                }
-                settled = true;
-              }
-              controller.enqueue(chunk);
-            },
-            flush() {
-              // Stream ended without a finish/usage part — free the held budget.
-              if (!settled) guard.release(reserved);
-            },
-          }),
-        );
-
-        return { stream: guarded, ...rest };
+        streamResult = await doStream();
       } catch (err) {
-        guard.release(reserved);
+        guard.release(reserved); // the call failed before settle() took ownership
         throw err;
       }
+      const { stream, ...rest } = streamResult;
+
+      // `handled` flips once the reservation is disposed — settled on the finish
+      // part, or released exactly once if the stream produced no usage (flush) or
+      // ended early via error/cancellation (cancel). settle() owns disposal once
+      // called, so nothing else may release after `handled` is set, or we'd
+      // double-subtract and clear a concurrent call's hold.
+      let handled = false;
+      const guarded = stream.pipeThrough(
+        new TransformStream<StreamPart, StreamPart>({
+          transform(chunk, controller) {
+            if (chunk.type === "finish" && !handled) {
+              try {
+                const { promptTokens, completionTokens } = chunk.usage;
+                handled = true;
+                guard.settle(model.modelId, promptTokens, completionTokens, { reserved });
+              } catch (err) {
+                // Release only if we never reached settle() (e.g. usage missing).
+                // If settle() itself threw, it already released its own hold.
+                if (!handled) {
+                  handled = true;
+                  guard.release(reserved);
+                }
+                throw err;
+              }
+            }
+            controller.enqueue(chunk);
+          },
+          flush() {
+            // Clean close with no finish/usage part — free the held budget.
+            if (!handled) {
+              handled = true;
+              guard.release(reserved);
+            }
+          },
+          cancel() {
+            // Upstream error or consumer cancellation: flush() does not run here
+            // (Web Streams: flush and cancel are mutually exclusive), so release
+            // the still-held reservation.
+            if (!handled) {
+              handled = true;
+              guard.release(reserved);
+            }
+          },
+        }),
+      );
+
+      return { stream: guarded, ...rest };
     },
   };
 }

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -42,7 +42,9 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
 
     expect(guard.spentUsd).toBeLessThanOrEqual(0.1 + 1e-9); // ceiling held
     expect(blocked).toBeGreaterThan(0); // excess was actually stopped
-    expect(guard.remainingUsd).toBeGreaterThanOrEqual(0); // no leaked reservation
+    // no leaked reservation: the in-flight tally is back to zero (remainingUsd is
+    // clamped >= 0, so asserting only that would always pass — a tautology).
+    expect((guard as unknown as { reserved: number }).reserved).toBeCloseTo(0, 9);
   });
 
   it("wrapGenerate honours the ceiling across Promise.all", async () => {

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -96,4 +96,13 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
     );
     expect(guard.remainingUsd).toBe(base); // released, not leaked
   });
+
+  it("check()/reserve() reject a non-finite estimate (no fail-open / poisoned reserve)", () => {
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    for (const bad of [NaN, Infinity]) {
+      expect(() => guard.check(bad)).toThrow(RangeError);
+      expect(() => guard.reserve(bad)).toThrow(RangeError);
+    }
+    expect((guard as unknown as { reserved: number }).reserved).toBeCloseTo(0, 9); // nothing leaked
+  });
 });

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -105,4 +105,13 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
     }
     expect((guard as unknown as { reserved: number }).reserved).toBeCloseTo(0, 9); // nothing leaked
   });
+
+  it("settle()/release() reject a bad reserved handle (no corruption of the in-flight tally)", () => {
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    for (const bad of [-0.01, NaN, Infinity]) {
+      expect(() => guard.release(bad)).toThrow(RangeError);
+      expect(() => guard.settle("gpt-4o", 1000, 1000, { reserved: bad })).toThrow(RangeError);
+    }
+    expect((guard as unknown as { reserved: number }).reserved).toBeCloseTo(0, 9); // uncorrupted
+  });
 });

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { BudgetExceeded, BudgetGuard, budgetGuardMiddleware } from "../src/index.js";
+import { BudgetExceeded, BudgetGuard, UnpriceableModelError, budgetGuardMiddleware } from "../src/index.js";
 
 function fakeModel(modelId: string) {
   return { modelId } as never;
@@ -78,5 +78,18 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
     const before = guard.remainingUsd;
     guard.release(reserved);
     expect(guard.remainingUsd).toBeGreaterThanOrEqual(before);
+  });
+
+  it("releases the reservation when settle() hits an unpriceable model (fail-closed)", () => {
+    // Regression for the #19 review: fail-closed must not leak the in-flight hold.
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    guard.record("gpt-4o", 1000, 1000);
+    const base = guard.remainingUsd;
+    const reserved = guard.reserve();
+    expect(guard.remainingUsd).toBeLessThan(base);
+    expect(() => guard.settle("totally-made-up-model-x", 100, 100, { reserved })).toThrow(
+      UnpriceableModelError,
+    );
+    expect(guard.remainingUsd).toBe(base); // released, not leaked
   });
 });

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -76,10 +76,12 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
   it("release() returns in-flight budget when a call fails", () => {
     const guard = new BudgetGuard(0.1, { onBlock: () => {} });
     guard.record("gpt-4o", 1000, 1000);
+    const before = guard.remainingUsd; // baseline BEFORE the hold
     const reserved = guard.reserve();
-    const before = guard.remainingUsd;
+    expect(guard.remainingUsd).toBeLessThan(before); // the hold actually moved the needle
     guard.release(reserved);
-    expect(guard.remainingUsd).toBeGreaterThanOrEqual(before);
+    expect(guard.remainingUsd).toBeCloseTo(before, 9); // fully restored, not just >=
+    expect((guard as unknown as { reserved: number }).reserved).toBeCloseTo(0, 9); // no hold left
   });
 
   it("releases the reservation when settle() hits an unpriceable model (fail-closed)", () => {

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The ceiling must hold when calls run in parallel (regression for issue #18).
+ *
+ * `check()`/`record()` is a check-then-act with an await in between. Fire several
+ * generations at once and they all `check()` against the same under-limit total
+ * before any `record()` lands. `reserve()`/`settle()` hold the estimate in flight
+ * (synchronously, before the await), so parallel callers each take their slice.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { BudgetExceeded, BudgetGuard, budgetGuardMiddleware } from "../src/index.js";
+
+function fakeModel(modelId: string) {
+  return { modelId } as never;
+}
+const fakeParams = {} as never;
+const tick = () => new Promise((resolve) => setTimeout(resolve, 5));
+
+describe("BudgetGuard — concurrency (issue #18)", () => {
+  it("reserve()/settle() holds the ceiling under parallel calls", async () => {
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    guard.record("gpt-4o", 1000, 1000); // warm: realistic next-call estimate
+
+    let blocked = 0;
+    const agent = async () => {
+      let reserved: number;
+      try {
+        reserved = guard.reserve();
+      } catch (err) {
+        if (err instanceof BudgetExceeded) {
+          blocked++;
+          return;
+        }
+        throw err;
+      }
+      await tick(); // API latency — the window the old race exploited
+      guard.settle("gpt-4o", 1000, 1000, { reserved });
+    };
+
+    await Promise.all(Array.from({ length: 16 }, agent));
+
+    expect(guard.spentUsd).toBeLessThanOrEqual(0.1 + 1e-9); // ceiling held
+    expect(blocked).toBeGreaterThan(0); // excess was actually stopped
+    expect(guard.remainingUsd).toBeGreaterThanOrEqual(0); // no leaked reservation
+  });
+
+  it("wrapGenerate honours the ceiling across Promise.all", async () => {
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    const mw = budgetGuardMiddleware(guard);
+    const doGenerate = vi.fn(async () => {
+      await tick();
+      return { usage: { promptTokens: 1000, completionTokens: 1000 } };
+    });
+    const launch = () =>
+      mw.wrapGenerate!({
+        doGenerate: doGenerate as never,
+        doStream: vi.fn() as never,
+        params: fakeParams,
+        model: fakeModel("gpt-4o"),
+      });
+
+    await launch(); // warm one call so the estimate is realistic
+
+    const results = await Promise.allSettled(Array.from({ length: 16 }, launch));
+    const rejected = results.filter(
+      (r) => r.status === "rejected" && r.reason instanceof BudgetExceeded,
+    ).length;
+
+    expect(rejected).toBeGreaterThan(0); // parallel fan-out is gated, not raced
+    expect(guard.spentUsd).toBeLessThanOrEqual(0.1 + 1e-9); // ceiling held
+  });
+
+  it("release() returns in-flight budget when a call fails", () => {
+    const guard = new BudgetGuard(0.1, { onBlock: () => {} });
+    guard.record("gpt-4o", 1000, 1000);
+    const reserved = guard.reserve();
+    const before = guard.remainingUsd;
+    guard.release(reserved);
+    expect(guard.remainingUsd).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -274,6 +274,11 @@ class BudgetGuard:
         return BudgetAdvisory(
             near_limit=used_bps >= self.near_limit_bps,
             used_bps=used_bps,
+            # Settled budget: limit minus accrued spend, deliberately NOT net of
+            # in-flight reservations. This differs from the remaining_usd property
+            # (which subtracts _reserved): the advisory is a soft utilization signal
+            # about money already spent, while the property reports what a new call
+            # can still claim.
             remaining_usd=max(0.0, self.limit_usd - self.spent_usd),
             limit_usd=self.limit_usd,
             spent_usd=self.spent_usd,

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -155,10 +155,12 @@ class BudgetGuard:
                 UnpriceableModelWarning,
                 stacklevel=2,
             )
+            # Release any held reservation on BOTH paths. Fail-closed must not
+            # leak the in-flight hold, or _reserved grows permanently and
+            # remaining_usd shrinks until reserve() starts blocking everything.
+            self.release(reserved)
             if self.fail_closed:
                 raise UnpriceableModelError(model)
-            # Opted into un-metered spend for this model: free the hold, accrue $0.
-            self.release(reserved)
             return 0.0
 
         cost = price_tokens(priced, prompt_tokens, completion_tokens)

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -189,6 +189,10 @@ class BudgetGuard:
         raise when ``fail_closed``, else warn + skip), and any held reservation
         is released even on the skip path.
         """
+        # A bad reserved handle would corrupt _reserved and break the ceiling for
+        # OTHER in-flight calls (negative → phantom hold; inf → clears all holds).
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
         priced = self._resolve(model, price)
         if priced is None:
             warnings.warn(
@@ -246,6 +250,11 @@ class BudgetGuard:
     def release(self, reserved: float) -> None:
         """Drop an in-flight reservation without recording spend (e.g. the call
         failed before producing usage). Safe to call with ``0``."""
+        # Validate before the zero-check so a NaN handle raises instead of being
+        # silently dropped (which would leak the hold). A bad handle here corrupts
+        # _reserved for other in-flight calls.
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
         if not reserved:
             return
         with self._lock:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -11,6 +11,15 @@ Why a call-path wrapper and not an event listener: a passive event-bus listener
 is notified *after* the fact and cannot halt the run. To actually stop spend, the
 guard has to sit in front of the next call. That is the whole point.
 
+**Concurrency.** ``check()`` then ``record()`` is two non-atomic steps. When calls
+run in parallel — the default for a CrewAI crew (async tasks,
+``kickoff_for_each_async``, hierarchical tool calls) — several can read the same
+under-limit total, all clear ``check()``, then all run, and the ceiling is blown
+(see issue #18). :meth:`reserve` / :meth:`settle` close that gap: ``reserve``
+atomically checks the ceiling *and* holds the estimated cost in-flight, so N
+parallel callers can't all clear a stale total. The framework adapters use it;
+the sequential ``check`` / ``record`` API is unchanged.
+
 This is **estimate-based**: it prices tokens from a vendored cost map, it does
 not reconcile against a wallet. Hosted Floe is the un-bypassable, cross-vendor
 upgrade (see the README).
@@ -19,6 +28,7 @@ upgrade (see the README).
 from __future__ import annotations
 
 import sys
+import threading
 import warnings
 from collections.abc import Callable
 
@@ -48,6 +58,10 @@ class BudgetGuard:
         on_block: optional callback invoked with ``(spent_usd, limit_usd)`` right
             before :class:`BudgetExceeded` is raised. Defaults to printing the
             ``BUDGET EXCEEDED — call blocked`` banner to stderr.
+
+    Thread-safe: the running total and in-flight reservations are guarded by a
+    lock, so the guard can back a parallel crew (use :meth:`reserve` /
+    :meth:`settle`).
     """
 
     def __init__(
@@ -68,6 +82,10 @@ class BudgetGuard:
         # Cost of the most recent priced call, used to predict the next one so we
         # can block BEFORE the crossing call runs (not one call too late).
         self._last_cost = 0.0
+        # USD held for calls that are in flight (reserved but not yet settled).
+        # Counted against the ceiling so concurrent callers can't overshoot.
+        self._reserved = 0.0
+        self._lock = threading.Lock()
 
     # ── enforcement ───────────────────────────────────────────────────────────
 
@@ -78,15 +96,82 @@ class BudgetGuard:
         estimated from the last recorded call's cost (override with
         ``estimated_next_cost``); the first call is always allowed unless the
         ceiling is already met. A belt-and-suspenders check on the running total
-        catches an overshoot if the estimate was too low.
+        catches an overshoot if the estimate was too low. In-flight reservations
+        count toward the total, so this stays correct alongside :meth:`reserve`.
+
+        Note: ``check`` is a non-binding peek. For parallel calls, use
+        :meth:`reserve` / :meth:`settle`, which hold the estimate atomically.
         """
-        estimate = self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
-        projected = self.spent_usd + estimate
-        # Compare with an epsilon so float rounding in the running total doesn't
-        # block a call early or let one slip past the ceiling.
-        if self.spent_usd > self.limit_usd - _EPS or projected > self.limit_usd + _EPS:
-            self._on_block(self.spent_usd, self.limit_usd)
-            raise BudgetExceeded(self.spent_usd, self.limit_usd)
+        if self._would_cross(estimated_next_cost):
+            self._block()
+
+    def reserve(self, estimated_cost: float | None = None) -> float:
+        """Atomically check the ceiling AND hold the estimated cost in-flight.
+
+        This is the concurrency-safe enforcement path. Each parallel caller
+        reserves before its call, so N callers can't all clear the same stale
+        total and overshoot. Raises :class:`BudgetExceeded` (without reserving)
+        if the reservation would cross the ceiling.
+
+        Returns a reservation handle (the USD amount held) to pass to
+        :meth:`settle` after the response, or to :meth:`release` if the call
+        fails. ``estimated_cost`` defaults to the last call's cost.
+        """
+        with self._lock:
+            estimate = self._last_cost if estimated_cost is None else max(0.0, estimated_cost)
+            committed = self.spent_usd + self._reserved
+            if committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS:
+                spent, limit = self.spent_usd, self.limit_usd
+            else:
+                self._reserved += estimate
+                return estimate
+        # Blocked — notify and raise outside the lock.
+        self._on_block(spent, limit)
+        raise BudgetExceeded(spent, limit)
+
+    def settle(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        reserved: float = 0.0,
+        price: ManualPrice | None = None,
+    ) -> float:
+        """Release a reservation and record the actual cost. Concurrency-safe.
+
+        ``record`` is ``settle`` with no reservation. Returns the USD cost of
+        this call. Unpriceable-model handling matches :meth:`record` (warn +
+        raise when ``fail_closed``, else warn + skip), and any held reservation
+        is released even on the skip path.
+        """
+        priced = self._resolve(model, price)
+        if priced is None:
+            warnings.warn(
+                f"Cannot price model {model!r}: not in the bundled cost map and no "
+                f"manual price given. The budget guard cannot enforce a ceiling on "
+                f"spend it cannot measure — pass price=ManualPrice(...) or set it in "
+                f"price_overrides.",
+                UnpriceableModelWarning,
+                stacklevel=2,
+            )
+            if self.fail_closed:
+                raise UnpriceableModelError(model)
+            # Opted into un-metered spend for this model: free the hold, accrue $0.
+            self.release(reserved)
+            return 0.0
+
+        cost = price_tokens(priced, prompt_tokens, completion_tokens)
+        with self._lock:
+            if reserved:
+                self._reserved = max(0.0, self._reserved - reserved)
+            self.spent_usd += cost
+            # Clamp a sub-epsilon float overshoot back to the limit so the running
+            # total never reports as having crossed the ceiling by a rounding artifact.
+            if 0.0 < self.spent_usd - self.limit_usd < _EPS:
+                self.spent_usd = self.limit_usd
+            self._last_cost = cost
+        return cost
 
     def record(
         self,
@@ -102,37 +187,39 @@ class BudgetGuard:
         ``price`` is given, behaviour depends on ``fail_closed`` (see the class
         docstring): warn + raise (default), or warn + skip accrual.
         """
-        overrides = self.price_overrides
-        if price is not None:
-            overrides = {**(overrides or {}), model: price}
+        return self.settle(model, prompt_tokens, completion_tokens, reserved=0.0, price=price)
 
-        priced = resolve_price(model, overrides)
-        if priced is None:
-            warnings.warn(
-                f"Cannot price model {model!r}: not in the bundled cost map and no "
-                f"manual price given. The budget guard cannot enforce a ceiling on "
-                f"spend it cannot measure — pass price=ManualPrice(...) or set it in "
-                f"price_overrides.",
-                UnpriceableModelWarning,
-                stacklevel=2,
-            )
-            if self.fail_closed:
-                raise UnpriceableModelError(model)
-            return 0.0
-
-        cost = price_tokens(priced, prompt_tokens, completion_tokens)
-        self.spent_usd += cost
-        # Clamp a sub-epsilon float overshoot back to the limit so the running
-        # total never reports as having crossed the ceiling by a rounding artifact.
-        if 0.0 < self.spent_usd - self.limit_usd < _EPS:
-            self.spent_usd = self.limit_usd
-        self._last_cost = cost
-        return cost
+    def release(self, reserved: float) -> None:
+        """Drop an in-flight reservation without recording spend (e.g. the call
+        failed before producing usage). Safe to call with ``0``."""
+        if not reserved:
+            return
+        with self._lock:
+            self._reserved = max(0.0, self._reserved - reserved)
 
     @property
     def remaining_usd(self) -> float:
-        """USD left before the ceiling (never negative)."""
-        return max(0.0, self.limit_usd - self.spent_usd)
+        """USD left before the ceiling, net of in-flight reservations (never negative)."""
+        with self._lock:
+            return max(0.0, self.limit_usd - self.spent_usd - self._reserved)
+
+    # ── internals ──────────────────────────────────────────────────────────────
+
+    def _would_cross(self, estimated_next_cost: float | None) -> bool:
+        with self._lock:
+            estimate = self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
+            committed = self.spent_usd + self._reserved
+            return committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS
+
+    def _block(self) -> None:
+        self._on_block(self.spent_usd, self.limit_usd)
+        raise BudgetExceeded(self.spent_usd, self.limit_usd)
+
+    def _resolve(self, model: str, price: ManualPrice | None):
+        overrides = self.price_overrides
+        if price is not None:
+            overrides = {**(overrides or {}), model: price}
+        return resolve_price(model, overrides)
 
 
 def _default_on_block(spent_usd: float, limit_usd: float) -> None:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -144,6 +144,7 @@ class BudgetGuard:
         Note: ``check`` is a non-binding peek. For parallel calls, use
         :meth:`reserve` / :meth:`settle`, which hold the estimate atomically.
         """
+        self._validate_estimate(estimated_next_cost)
         if self._would_cross(estimated_next_cost):
             self._block()
 
@@ -159,6 +160,7 @@ class BudgetGuard:
         :meth:`settle` after the response, or to :meth:`release` if the call
         fails. ``estimated_cost`` defaults to the last call's cost.
         """
+        self._validate_estimate(estimated_cost)
         with self._lock:
             estimate = self._last_cost if estimated_cost is None else max(0.0, estimated_cost)
             committed = self.spent_usd + self._reserved
@@ -285,6 +287,13 @@ class BudgetGuard:
         )
 
     # ── internals ──────────────────────────────────────────────────────────────
+
+    def _validate_estimate(self, estimated: float | None) -> None:
+        # NaN/inf would poison the ceiling comparisons and fail-open (or poison
+        # _reserved) — reject a non-finite caller-supplied estimate up front,
+        # matching the constructor's math.isfinite guard and the TS Number.isFinite.
+        if estimated is not None and not math.isfinite(estimated):
+            raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:
         with self._lock:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -207,7 +207,9 @@ class BudgetGuard:
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:
         with self._lock:
-            estimate = self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
+            estimate = (
+                self._last_cost if estimated_next_cost is None else max(0.0, estimated_next_cost)
+            )
             committed = self.spent_usd + self._reserved
             return committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -205,7 +205,15 @@ class BudgetGuard:
                 raise UnpriceableModelError(model)
             return 0.0
 
-        cost = price_tokens(priced, prompt_tokens, completion_tokens)
+        try:
+            cost = price_tokens(priced, prompt_tokens, completion_tokens)
+        except Exception:
+            # price_tokens can raise (e.g. non-finite token counts). Release the
+            # in-flight hold before propagating so _reserved doesn't leak and
+            # shrink remaining_usd permanently — same fail-safe as the unpriceable
+            # path above.
+            self.release(reserved)
+            raise
         with self._lock:
             if reserved:
                 self._reserved = max(0.0, self._reserved - reserved)

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -4,19 +4,23 @@ Two ways to wire the guard into LiteLLM:
 
 1. :func:`guarded_completion` / :func:`guarded_acompletion` — a thin wrapper
    around ``litellm.completion``. This is the **guaranteed** enforcement path:
-   the guard's ``check()`` runs before the call in your own code, so a blocked
-   call simply never reaches LiteLLM.
+   the guard reserves the call's budget before the request, so a blocked call
+   never reaches LiteLLM.
 
 2. :class:`BudgetGuardCallback` — a LiteLLM ``CustomLogger`` you register with
-   ``litellm.callbacks``. It checks before the call (``log_pre_api_call``) and
-   records spend after (``log_success_event``). Use this when you cannot wrap the
+   ``litellm.callbacks``. It reserves before the call (``log_pre_api_call``) and
+   settles spend after (``log_success_event``). Use this when you cannot wrap the
    call site yourself (e.g. CrewAI, which calls ``litellm.completion`` for you).
 
-Both route every priced response through the same :class:`~floe_guard.BudgetGuard`.
+Both reserve before the call and settle after, so the ceiling holds even when a
+crew fans calls out in parallel (issue #18) — not just on a single sequential
+loop. Every priced response routes through the same
+:class:`~floe_guard.BudgetGuard`.
 """
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 from ..guard import BudgetGuard
@@ -55,38 +59,50 @@ def _usage_from(response: Any) -> tuple[int, int]:
     return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
 
 
-def _record_response(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> None:
+def _record_response(
+    guard: BudgetGuard, kwargs: dict[str, Any], response: Any, *, reserved: float = 0.0
+) -> None:
     model = _model_from(kwargs, response)
     prompt_tokens, completion_tokens = _usage_from(response)
     if prompt_tokens <= 0 and completion_tokens <= 0:
-        # No tokens were spent (e.g. a usage-less event) — nothing to meter.
+        # No tokens were spent (e.g. a usage-less event) — nothing to meter, so
+        # free any reservation we were holding for this call.
+        guard.release(reserved)
         return
-    # There IS spend to account for. Route it through record() even when the
+    # There IS spend to account for. Route it through settle() even when the
     # model id is missing, so the guard's configured policy applies (fail-closed
     # → warn + raise; fail-open → warn + skip). Silently skipping here would let
     # a real, completed call go unmetered and skew the next check().
-    guard.record(model, prompt_tokens, completion_tokens)
+    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
 def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
-    """``litellm.completion`` with a pre-call budget check and post-call accrual.
+    """``litellm.completion`` with a pre-call budget reservation and post-call accrual.
 
     Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
     would be crossed — the request never reaches LiteLLM.
     """
     litellm = _require_litellm()
-    guard.check()
-    response = litellm.completion(**kwargs)
-    _record_response(guard, kwargs, response)
+    reserved = guard.reserve()
+    try:
+        response = litellm.completion(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
     return response
 
 
 async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`."""
     litellm = _require_litellm()
-    guard.check()
-    response = await litellm.acompletion(**kwargs)
-    _record_response(guard, kwargs, response)
+    reserved = guard.reserve()
+    try:
+        response = await litellm.acompletion(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
     return response
 
 
@@ -98,9 +114,11 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         import litellm
         litellm.callbacks = [budget_guard_callback(guard)]
 
-    ``log_pre_api_call`` runs ``guard.check()`` (raising
-    :class:`~floe_guard.BudgetExceeded` to abort), and ``log_success_event``
-    records the response's token cost.
+    ``log_pre_api_call`` reserves the call's budget (raising
+    :class:`~floe_guard.BudgetExceeded` to abort), ``log_success_event`` settles
+    the response's actual token cost, and ``log_failure_event`` releases the
+    reservation. Reservations are keyed per call, so parallel crew calls each
+    hold their own slice of the ceiling instead of racing one shared total.
     """
     litellm = _require_litellm()
     from litellm.integrations.custom_logger import CustomLogger
@@ -109,22 +127,50 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
+            self._reservations: dict[Any, float] = {}
+            self._rlock = threading.Lock()
+
+        @staticmethod
+        def _key(kwargs: Any) -> Any:
+            # LiteLLM stamps a stable call id on kwargs for both pre/post events;
+            # fall back to the kwargs object identity if it is ever absent.
+            call_id = (kwargs or {}).get("litellm_call_id") if isinstance(kwargs, dict) else None
+            return call_id if call_id is not None else id(kwargs)
+
+        def _hold(self, kwargs: Any) -> None:
+            reserved = self.guard.reserve()  # raises BudgetExceeded -> aborts the call
+            with self._rlock:
+                self._reservations[self._key(kwargs)] = reserved
+
+        def _pop(self, kwargs: Any) -> float:
+            with self._rlock:
+                return self._reservations.pop(self._key(kwargs), 0.0)
 
         def log_pre_api_call(self, model: Any, messages: Any, kwargs: Any) -> None:
-            self.guard.check()
+            self._hold(kwargs)
 
         def log_success_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
         ) -> None:
-            _record_response(self.guard, kwargs, response_obj)
+            _record_response(self.guard, kwargs, response_obj, reserved=self._pop(kwargs))
+
+        def log_failure_event(
+            self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
+        ) -> None:
+            self.guard.release(self._pop(kwargs))
 
         async def async_log_pre_api_call(self, model: Any, messages: Any, kwargs: Any) -> None:
-            self.guard.check()
+            self._hold(kwargs)
 
         async def async_log_success_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
         ) -> None:
-            _record_response(self.guard, kwargs, response_obj)
+            _record_response(self.guard, kwargs, response_obj, reserved=self._pop(kwargs))
+
+        async def async_log_failure_event(
+            self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
+        ) -> None:
+            self.guard.release(self._pop(kwargs))
 
     _ = litellm  # adapter import already validated litellm is present
     return BudgetGuardCallback()

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -60,8 +60,12 @@ def _usage_from(response: Any) -> tuple[int, int]:
 
 
 def _record_response(
-    guard: BudgetGuard, kwargs: dict[str, Any], response: Any, *, reserved: float = 0.0
+    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
 ) -> None:
+    # LiteLLM hooks pass kwargs as Any; normalize so a None/non-dict can't crash
+    # the metering callback on .get() (matches the _key() fallback).
+    if not isinstance(kwargs, dict):
+        kwargs = {}
     model = _model_from(kwargs, response)
     prompt_tokens, completion_tokens = _usage_from(response)
     if prompt_tokens <= 0 and completion_tokens <= 0:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,71 @@
+"""The ceiling must hold when calls run in parallel (regression for issue #18).
+
+Sequentially, check()/record() stops a runaway loop. But a CrewAI crew fans
+calls out in parallel (async tasks, kickoff_for_each_async, hierarchical tool
+calls), and check()/record() are not atomic — several callers can read the same
+under-limit total, all clear the gate, then all run. reserve()/settle() hold the
+estimate in-flight under a lock, so the ceiling holds under fan-out.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # 1k in + 1k out = $0.0125 / call
+
+
+def test_reserve_settle_holds_ceiling_under_parallel_calls() -> None:
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    # Warm one call so the next-call estimate is realistic (~$0.0125).
+    guard.record(MODEL, 1_000, 1_000)
+
+    blocked: list[int] = []
+
+    def agent(i: int) -> None:
+        try:
+            reserved = guard.reserve()
+        except BudgetExceeded:
+            blocked.append(i)
+            return
+        time.sleep(0.02)  # API latency — the window the old race exploited
+        guard.settle(MODEL, 1_000, 1_000, reserved=reserved)
+
+    threads = [threading.Thread(target=agent, args=(i,)) for i in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # The guarantee: 16 concurrent agents never push spend past the ceiling...
+    assert guard.spent_usd <= guard.limit_usd + 1e-9
+    # ...and the excess was actually stopped, not silently allowed.
+    assert blocked
+    # No reservations leaked.
+    assert guard.remaining_usd >= 0.0
+
+
+def test_legacy_check_record_path_is_unchanged() -> None:
+    # The sequential API behaves exactly as before: $0.05 / $0.0125 -> 4 calls.
+    guard = BudgetGuard(limit_usd=0.05, on_block=lambda *_: None)
+    calls = 0
+    for _ in range(1000):
+        try:
+            guard.check()
+        except BudgetExceeded:
+            break
+        guard.record(MODEL, 1_000, 1_000)
+        calls += 1
+    assert calls == 4
+    assert guard.spent_usd <= guard.limit_usd
+
+
+def test_release_frees_inflight_budget() -> None:
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+    reserved = guard.reserve()
+    before = guard.remaining_usd
+    guard.release(reserved)  # call failed, give the budget back
+    assert guard.remaining_usd >= before

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -50,8 +50,9 @@ def test_reserve_settle_holds_ceiling_under_parallel_calls() -> None:
     assert guard.spent_usd <= guard.limit_usd + 1e-9
     # ...and the excess was actually stopped, not silently allowed.
     assert blocked
-    # No reservations leaked.
-    assert guard.remaining_usd >= 0.0
+    # No reservations leaked: the in-flight tally is back to zero. (remaining_usd
+    # is clamped >= 0, so asserting only that would always pass — a tautology.)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
 
 
 def test_legacy_check_record_path_is_unchanged() -> None:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -106,3 +106,15 @@ def test_unpriceable_fail_closed_releases_the_reservation() -> None:
         with pytest.raises(UnpriceableModelError):
             guard.settle("totally-made-up-model-x", 100, 100, reserved=reserved)
     assert guard.remaining_usd == base  # released, not leaked
+
+
+def test_settle_and_release_reject_bad_reserved_handle() -> None:
+    # A bad reserved handle would corrupt _reserved and break the ceiling for
+    # OTHER in-flight calls (negative phantom hold; inf clears all holds).
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    for bad in (-0.01, float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            guard.release(bad)
+        with pytest.raises(ValueError):
+            guard.settle(MODEL, 1_000, 1_000, reserved=bad)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)  # nothing corrupted

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -12,7 +12,14 @@ from __future__ import annotations
 import threading
 import time
 
-from floe_guard import BudgetExceeded, BudgetGuard
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
 
 MODEL = "gpt-4o"  # 1k in + 1k out = $0.0125 / call
 
@@ -69,3 +76,18 @@ def test_release_frees_inflight_budget() -> None:
     before = guard.remaining_usd
     guard.release(reserved)  # call failed, give the budget back
     assert guard.remaining_usd >= before
+
+
+def test_unpriceable_fail_closed_releases_the_reservation() -> None:
+    # Regression for the #19 review: settle() on an unpriceable model under
+    # fail_closed must release the in-flight reservation before it raises, or
+    # _reserved leaks and remaining_usd shrinks permanently until reserve() blocks.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+    base = guard.remaining_usd
+    reserved = guard.reserve()
+    assert guard.remaining_usd < base  # hold is in flight
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            guard.settle("totally-made-up-model-x", 100, 100, reserved=reserved)
+    assert guard.remaining_usd == base  # released, not leaked

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -73,10 +73,24 @@ def test_legacy_check_record_path_is_unchanged() -> None:
 def test_release_frees_inflight_budget() -> None:
     guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
     guard.record(MODEL, 1_000, 1_000)
+    base = guard.remaining_usd
     reserved = guard.reserve()
-    before = guard.remaining_usd
+    assert guard.remaining_usd < base  # the hold is counted against the ceiling
     guard.release(reserved)  # call failed, give the budget back
-    assert guard.remaining_usd >= before
+    # Full restoration — a no-op release would leave remaining < base and fail here.
+    assert guard.remaining_usd == pytest.approx(base, abs=1e-9)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+
+
+def test_check_and_reserve_reject_non_finite_estimate() -> None:
+    # NaN/inf estimates must not fail-open the ceiling or poison _reserved.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            guard.check(bad)
+        with pytest.raises(ValueError):
+            guard.reserve(bad)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)  # nothing leaked
 
 
 def test_unpriceable_fail_closed_releases_the_reservation() -> None:

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -95,3 +95,12 @@ def test_usageless_response_releases_the_reservation() -> None:
     assert guard.spent_usd == 0.0
     assert guard.remaining_usd == pytest.approx(base, abs=1e-9)
     assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+
+
+def test_record_response_tolerates_non_dict_kwargs() -> None:
+    # LiteLLM hooks pass kwargs as Any; a None/non-dict must not crash the
+    # metering callback on .get(). The model resolves from the response instead.
+    guard = BudgetGuard(limit_usd=1.0)
+    resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
+    _record_response(guard, None, resp)  # type: ignore[arg-type]
+    assert guard.spent_usd > 0

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -82,3 +82,16 @@ def test_no_usage_response_is_a_noop() -> None:
     _record_response(guard, {}, {})  # no model, no usage
     _record_response(guard, {}, {"usage": {"prompt_tokens": 0, "completion_tokens": 0}})
     assert guard.spent_usd == 0.0
+
+
+def test_usageless_response_releases_the_reservation() -> None:
+    # A usage-less response must free the in-flight reservation, or the callback
+    # path leaks _reserved and remaining_usd shrinks permanently.
+    guard = BudgetGuard(limit_usd=1.0)
+    base = guard.remaining_usd
+    reserved = guard.reserve(0.01)  # explicit estimate (fresh guard has no last cost)
+    assert guard.remaining_usd < base  # hold counted against the ceiling
+    _record_response(guard, {}, {}, reserved=reserved)  # no usage -> release
+    assert guard.spent_usd == 0.0
+    assert guard.remaining_usd == pytest.approx(base, abs=1e-9)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)


### PR DESCRIPTION
Fixes #18.

## Problem
check() then record() is a check-then-act with the call in between, and nothing held the in-flight cost. Under a parallel crew (async tasks, kickoff_for_each_async, hierarchical tool calls) several calls clear the same under-limit total before any record() lands, and the ceiling is blown.

## Fix
An atomic reserve() -> settle() path that holds the estimate in flight, so parallel callers each take their own slice of the ceiling.

**Python**
- BudgetGuard: reserve()/settle()/release() behind a threading.Lock plus a _reserved in-flight tally. check()/record() behaviour is unchanged (record() delegates to settle(reserved=0)); remaining_usd nets out reservations. The lock guards only the synchronous bookkeeping, never the network call.
- LiteLLM adapter (the CrewAI path): the callback reserves on log_pre_api_call, settles on log_success_event, releases on log_failure_event, keyed per litellm_call_id. guarded_completion/acompletion reserve then settle, with release-on-error.
- tests/test_concurrency.py: the 16-thread repro from the issue as a regression (red before, green after), plus a check that the sequential path is unchanged.

**JS (parity; single-threaded, so an in-flight counter, no lock)**
- guard.ts: reserve()/settle()/release() plus a reserved tally; check()/record() unchanged.
- middleware.ts: wrapGenerate/wrapStream reserve before the await, settle after, release on error (or a stream that ends without usage).
- test/concurrency.test.ts: ceiling holds across Promise.all.

**Docs**
- README "Honest about what this is": the local guard bounds steady-state concurrency, not the cold-start first wave (reservations size from the last cost, 0 until the first record()); pass a per-call max to reserve() to bound it, or use hosted Floe for a hard cap under arbitrary concurrency.

## Honoring your review notes
- Lock scope is exactly as you described: a plain Lock around the synchronous reserve/settle, no await/IO inside, so it serializes threads and asyncio alike and is never held across the call.
- Cold-start residual is documented, not overclaimed. A perfect cap on the first concurrent batch needs a caller-supplied max-cost-per-call (supported via reserve(estimated_cost=...)) or the hosted path.
- check()/record() and the 5-line crew hook are unchanged.

## Verified
- Python: the 16-thread repro now caps at $0.1000 (9/16 blocked) against $0.2125 / 0 blocked before; legacy sequential still stops at 8.
- JS: same behaviour confirmed in-runtime.

cc @achris7 for review, as requested. Thanks again for the detailed direction on the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a concurrency-safe budget reservation lifecycle (reserve/settle/release) to cap in-flight spend across overlapping LLM calls.
  * Updated generate/stream middleware and the LiteLLM integration to reserve before calls and settle/release after metering.
* **Bug Fixes**
  * Prevented budget overages from parallel requests; remaining budget now reflects in-flight reservations.
  * Ensured unpriceable-model failures release held reservations to avoid budget leaks.
* **Documentation**
  * Expanded README guidance on concurrency behavior and bounding initial fan-out.
* **Tests**
  * Added/updated concurrency regression tests and adapter coverage for usage-less responses and invalid handles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->