### PR TITLE
feat: context-aware spend advisory (BudgetGuard.advisory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ guard = BudgetGuard(
 # or, set fail_closed=False to warn-and-skip for models you accept un-metered.
 ```
 
+## Context-aware budgeting
+
+The hard-stop is the guarantee; `advisory()` is the *upside*. Read it before a
+step to let your agent **adapt** as it nears the cap — taper to a cheaper model,
+shrink the task, or wrap up — instead of getting cut off mid-run.
+
+```python
+guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)   # flag at 70% used
+
+adv = guard.advisory()
+# BudgetAdvisory(near_limit=False, used_bps=125, remaining_usd=0.0987, ...)
+model = "gpt-4o-mini" if adv.near_limit else "gpt-4o"        # downshift near the cap
+
+guard.check()                  # still the hard line — taper or not, this holds
+response = call_your_llm(model)
+guard.record(model, response.usage.prompt_tokens, response.usage.completion_tokens)
+```
+
+`advisory()` returns `near_limit`, `used_bps` (utilization in basis points),
+`remaining_usd`, and the budget totals. It's a **soft** signal — the model may
+ignore it; `check()` is what enforces the ceiling. See
+[`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
+(no API key).
+
+This is the **same advisory shape** hosted Floe returns on every proxied call
+(the `X-Floe-Budget-Advisory` header), so the logic you write here ports
+unchanged — hosted just answers across *every* vendor and cap with server-truth
+balances and rolling-window reset timing, which a single local budget can't know.
+The TS package exposes the identical `guard.advisory()`.
+
 ## Framework adapters (optional extras)
 
 ### CrewAI

--- a/examples/budget_aware.py
+++ b/examples/budget_aware.py
@@ -1,0 +1,66 @@
+"""Context-aware budgeting — the agent tapers as it nears the cap.
+
+No API key, no account, no network. A stub LLM returns fixed token usage; before
+each step the agent reads ``BudgetGuard.advisory()`` and, once ``near_limit``
+trips, switches to a cheaper model so it keeps making progress and finishes on
+budget instead of slamming into the hard-stop mid-task.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee. (Hosted Floe returns the same advisory shape, but across every
+vendor/cap with server-truth balances — your taper logic ports unchanged.)
+
+Run:  python examples/budget_aware.py
+"""
+from __future__ import annotations
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+FULL = ("gpt-4o", 1000, 1000)  # ~$0.0125 / call
+CHEAP = ("gpt-4o-mini", 1000, 1000)  # ~$0.0008 / call
+
+
+def stub_llm(model: tuple[str, int, int]) -> dict[str, object]:
+    """A fake LLM call — no network, no key."""
+    name, pt, ct = model
+    return {"model": name, "prompt_tokens": pt, "completion_tokens": ct}
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to downshift before the ceiling.
+    guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+
+    step = 0
+    tapered = False
+    while True:
+        step += 1
+        adv = guard.advisory()
+        # Context-aware: downshift to the cheap model once we're near the cap.
+        model = CHEAP if adv.near_limit else FULL
+        if adv.near_limit and not tapered:
+            tapered = True
+            print(
+                f"  [advisory] {adv.used_bps / 100:.0f}% used, "
+                f"${adv.remaining_usd:.4f} left → tapering to {model[0]}\n"
+            )
+
+        try:
+            guard.check()  # the hard guarantee — taper or not, this holds the line
+        except BudgetExceeded:
+            print(
+                f"\nStopped at step {step}. "
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            )
+            break
+
+        response = stub_llm(model)
+        cost = guard.record(
+            str(response["model"]),
+            int(response["prompt_tokens"]),  # type: ignore[arg-type]
+            int(response["completion_tokens"]),  # type: ignore[arg-type]
+        )
+        print(f"  step {step:>2}: {model[0]:<12} +${cost:.4f}  (total ${guard.spent_usd:.4f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/js/README.md
+++ b/js/README.md
@@ -44,6 +44,20 @@ const guard = new BudgetGuard(5.0, {
 });
 ```
 
+## Context-aware budgeting
+
+`guard.advisory()` returns a soft signal you can act on before a call — `nearLimit`,
+`usedBps`, `remainingUsd` — so the agent can taper near the cap instead of being
+cut off. The hard-stop (`check`) is still the guarantee. This is the same shape
+the Python package exposes and that hosted Floe returns on every proxied call
+(`X-Floe-Budget-Advisory`), so the logic ports unchanged to the hosted path.
+
+```ts
+const guard = new BudgetGuard(0.1, { nearLimitBps: 7000 }); // flag at 70% used
+const adv = guard.advisory();
+const model = adv.nearLimit ? openai("gpt-4o-mini") : openai("gpt-4o");
+```
+
 ## Verified against
 
 `ai@4` (`LanguageModelV1Middleware` via `wrapLanguageModel` /

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -185,10 +185,13 @@ export class BudgetGuard {
    * {@link BudgetGuard.check} is what enforces the ceiling.
    */
   advisory(): BudgetAdvisory {
+    // Floor (not round) so usedBps never over-reports utilization and nearLimit
+    // flips exactly when the threshold is reached; the epsilon absorbs float noise
+    // and Math.floor matches Python's int() exactly (round() would diverge).
     const usedBps =
       this.limitUsd <= 0
         ? 10000
-        : Math.max(0, Math.min(10000, Math.round((this.spentUsd / this.limitUsd) * 10000)));
+        : Math.max(0, Math.min(10000, Math.floor((this.spentUsd / this.limitUsd) * 10000 + 1e-9)));
     return {
       nearLimit: usedBps >= this.nearLimitBps,
       usedBps,

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -92,7 +92,9 @@ export class BudgetGuard {
         `limitUsd must be a finite, non-negative number, got ${limitUsd}`,
       );
     }
-    const nearLimitBps = options.nearLimitBps ?? 8000;
+    // `=== undefined` (not `??`) so an explicit null is rejected by validation
+    // rather than silently defaulting — matches Python, which rejects None.
+    const nearLimitBps = options.nearLimitBps === undefined ? 8000 : options.nearLimitBps;
     if (!Number.isInteger(nearLimitBps) || nearLimitBps < 0 || nearLimitBps > 10000) {
       throw new RangeError(
         `nearLimitBps must be an integer in 0..10000, got ${nearLimitBps}`,

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -38,6 +38,36 @@ export interface BudgetGuardOptions {
    * `BUDGET EXCEEDED — call blocked` banner to stderr.
    */
   onBlock?: (spentUsd: number, limitUsd: number) => void;
+  /**
+   * Utilization (basis points, 0..10000) at which {@link BudgetGuard.advisory}
+   * flags `nearLimit` so an agent can taper before the hard-stop. Default 8000.
+   */
+  nearLimitBps?: number;
+}
+
+/**
+ * A context-aware spend signal for the single local budget.
+ *
+ * Mirrors the core fields of hosted Floe's `X-Floe-Budget-Advisory` header, so
+ * agent logic that reads it (taper as you approach the cap, stop at it) ports
+ * unchanged to the hosted path. Hosted adds what a local, single-budget guard
+ * cannot know: which of several caps is tightest (`scope` across
+ * `credit_line | session | task | api | vendor`), cross-vendor reasoning,
+ * server-truth balances, and rolling-window reset timing.
+ *
+ * This is a **soft** signal — the model may ignore it. The hard-stop
+ * ({@link BudgetGuard.check}) is what enforces the ceiling; the advisory is
+ * upside (let the agent finish on budget rather than be cut off).
+ */
+export interface BudgetAdvisory {
+  nearLimit: boolean;
+  /** Utilization in basis points, 0..10000 (8500 = 85%). */
+  usedBps: number;
+  remainingUsd: number;
+  limitUsd: number;
+  spentUsd: number;
+  /** Hosted reports the tightest cap across all scopes; local is always "local". */
+  scope: "local";
 }
 
 export class BudgetGuard {
@@ -45,6 +75,7 @@ export class BudgetGuard {
   spentUsd = 0;
   priceOverrides?: Record<string, ManualPrice>;
   failClosed: boolean;
+  nearLimitBps: number;
 
   private readonly onBlock: (spentUsd: number, limitUsd: number) => void;
   /** Cost of the most recent priced call, used to predict the next one. */
@@ -61,10 +92,17 @@ export class BudgetGuard {
         `limitUsd must be a finite, non-negative number, got ${limitUsd}`,
       );
     }
+    const nearLimitBps = options.nearLimitBps ?? 8000;
+    if (!Number.isInteger(nearLimitBps) || nearLimitBps < 0 || nearLimitBps > 10000) {
+      throw new RangeError(
+        `nearLimitBps must be an integer in 0..10000, got ${nearLimitBps}`,
+      );
+    }
     this.limitUsd = limitUsd;
     this.priceOverrides = options.priceOverrides;
     this.failClosed = options.failClosed ?? true;
     this.onBlock = options.onBlock ?? defaultOnBlock;
+    this.nearLimitBps = nearLimitBps;
   }
 
   /**
@@ -137,6 +175,28 @@ export class BudgetGuard {
   /** USD left before the ceiling (never negative). */
   get remainingUsd(): number {
     return Math.max(0, this.limitUsd - this.spentUsd);
+  }
+
+  /**
+   * Context-aware spend advisory for this budget — see {@link BudgetAdvisory}.
+   *
+   * `nearLimit` flips once utilization reaches `nearLimitBps` (default 80%), so an
+   * agent can taper *before* the hard-stop. Advisory only: read it to adapt;
+   * {@link BudgetGuard.check} is what enforces the ceiling.
+   */
+  advisory(): BudgetAdvisory {
+    const usedBps =
+      this.limitUsd <= 0
+        ? 10000
+        : Math.max(0, Math.min(10000, Math.round((this.spentUsd / this.limitUsd) * 10000)));
+    return {
+      nearLimit: usedBps >= this.nearLimitBps,
+      usedBps,
+      remainingUsd: Math.max(0, this.limitUsd - this.spentUsd),
+      limitUsd: this.limitUsd,
+      spentUsd: this.spentUsd,
+      scope: "local",
+    };
   }
 }
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -6,7 +6,11 @@
  * package `floe-guard` (pip) carries the LiteLLM / CrewAI / LangChain adapters.
  */
 
-export { BudgetGuard, type BudgetGuardOptions } from "./guard.js";
+export {
+  BudgetGuard,
+  type BudgetGuardOptions,
+  type BudgetAdvisory,
+} from "./guard.js";
 export {
   FloeGuardError,
   BudgetExceeded,

--- a/js/test/advisory.test.ts
+++ b/js/test/advisory.test.ts
@@ -55,4 +55,13 @@ describe("BudgetGuard.advisory", () => {
     expect(() => new BudgetGuard(1.0, { nearLimitBps: 10001 })).toThrow(RangeError);
     expect(() => new BudgetGuard(1.0, { nearLimitBps: 8000.5 })).toThrow(RangeError);
   });
+
+  it("rejects an explicit null nearLimitBps instead of silently defaulting", () => {
+    // undefined → default 8000; null is an explicit bad value → reject (matches
+    // Python rejecting None).
+    expect(new BudgetGuard(1.0, { nearLimitBps: undefined }).nearLimitBps).toBe(8000);
+    expect(
+      () => new BudgetGuard(1.0, { nearLimitBps: null as unknown as number }),
+    ).toThrow(RangeError);
+  });
 });

--- a/js/test/advisory.test.ts
+++ b/js/test/advisory.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { BudgetGuard } from "../src/index.js";
+
+describe("BudgetGuard.advisory", () => {
+  it("a fresh guard is far from the limit", () => {
+    const a = new BudgetGuard(1.0).advisory();
+    expect(a.nearLimit).toBe(false);
+    expect(a.usedBps).toBe(0);
+    expect(a.remainingUsd).toBe(1.0);
+    expect(a.scope).toBe("local");
+  });
+
+  it("nearLimit flips at the default 80% threshold", () => {
+    const g = new BudgetGuard(1.0);
+    g.spentUsd = 0.79;
+    expect(g.advisory().nearLimit).toBe(false);
+    g.spentUsd = 0.8;
+    const a = g.advisory();
+    expect(a.nearLimit).toBe(true);
+    expect(a.usedBps).toBe(8000);
+    expect(a.remainingUsd).toBeCloseTo(0.2, 9);
+  });
+
+  it("honors a custom nearLimitBps", () => {
+    const g = new BudgetGuard(1.0, { nearLimitBps: 5000 });
+    g.spentUsd = 0.5;
+    expect(g.advisory().nearLimit).toBe(true);
+  });
+
+  it("clamps usedBps when over the limit and never reports negative remaining", () => {
+    const g = new BudgetGuard(1.0);
+    g.spentUsd = 1.5;
+    const a = g.advisory();
+    expect(a.usedBps).toBe(10000);
+    expect(a.remainingUsd).toBe(0);
+  });
+
+  it("a zero limit reads as fully used", () => {
+    const a = new BudgetGuard(0).advisory();
+    expect(a.usedBps).toBe(10000);
+    expect(a.nearLimit).toBe(true);
+  });
+
+  it("rejects an out-of-range nearLimitBps", () => {
+    expect(() => new BudgetGuard(1.0, { nearLimitBps: -1 })).toThrow(RangeError);
+    expect(() => new BudgetGuard(1.0, { nearLimitBps: 10001 })).toThrow(RangeError);
+  });
+});

--- a/js/test/advisory.test.ts
+++ b/js/test/advisory.test.ts
@@ -42,8 +42,17 @@ describe("BudgetGuard.advisory", () => {
     expect(a.nearLimit).toBe(true);
   });
 
-  it("rejects an out-of-range nearLimitBps", () => {
+  it("floors usedBps rather than rounding (no early nearLimit, Python parity)", () => {
+    const g = new BudgetGuard(1.0, { nearLimitBps: 8000 });
+    g.spentUsd = 0.79999; // 79.999%
+    const a = g.advisory();
+    expect(a.usedBps).toBe(7999); // floored, not rounded up to 8000
+    expect(a.nearLimit).toBe(false); // 80% not actually reached yet
+  });
+
+  it("rejects an out-of-range or non-integer nearLimitBps", () => {
     expect(() => new BudgetGuard(1.0, { nearLimitBps: -1 })).toThrow(RangeError);
     expect(() => new BudgetGuard(1.0, { nearLimitBps: 10001 })).toThrow(RangeError);
+    expect(() => new BudgetGuard(1.0, { nearLimitBps: 8000.5 })).toThrow(RangeError);
   });
 });

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -20,7 +20,7 @@ from .errors import (
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
-from .guard import BudgetGuard
+from .guard import BudgetAdvisory, BudgetGuard
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 
@@ -28,6 +28,7 @@ __version__ = "0.1.0"
 
 __all__ = [
     "BudgetGuard",
+    "BudgetAdvisory",
     "BudgetExceeded",
     "FloeGuardError",
     "HostedEnforcementError",

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -18,6 +18,7 @@ upgrade (see the README).
 
 from __future__ import annotations
 
+import math
 import sys
 import warnings
 from collections.abc import Callable
@@ -87,8 +88,11 @@ class BudgetGuard:
         on_block: Callable[[float, float], None] | None = None,
         near_limit_bps: int = 8000,
     ) -> None:
-        if limit_usd < 0:
-            raise ValueError(f"limit_usd must not be negative, got {limit_usd!r}")
+        if not math.isfinite(limit_usd) or limit_usd < 0:
+            # NaN/inf would make every check() comparison evaluate False and
+            # silently disable the guard — reject them (matches the JS
+            # Number.isFinite contract).
+            raise ValueError(f"limit_usd must be a finite, non-negative number, got {limit_usd!r}")
         # Require a real int (bool is an int subclass in Python — exclude it) in
         # 0..10000, matching the TS Number.isInteger check for cross-language parity.
         if (

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import sys
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from .errors import (
     BudgetExceeded,
@@ -31,6 +32,30 @@ from .pricing import ManualPrice, price_tokens, resolve_price
 
 # Tolerance for float rounding in the running spend total (well below $0.000001).
 _EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class BudgetAdvisory:
+    """A context-aware spend signal for the single local budget.
+
+    Mirrors the core fields of hosted Floe's ``X-Floe-Budget-Advisory`` header, so
+    agent logic that reads it (taper as you approach the cap, stop at it) ports
+    unchanged to the hosted path. Hosted adds what a local, single-budget guard
+    cannot know: which of several caps is tightest (``scope`` across
+    ``credit_line | session | task | api | vendor``), cross-vendor reasoning,
+    server-truth balances, and rolling-window reset timing.
+
+    This is a **soft** signal — the model may ignore it. The hard-stop
+    (:meth:`BudgetGuard.check`) is what actually enforces the ceiling; the
+    advisory is upside (let the agent finish on budget rather than be cut off).
+    """
+
+    near_limit: bool
+    used_bps: int  # utilization in basis points, 0..10000 (8500 = 85%)
+    remaining_usd: float
+    limit_usd: float
+    spent_usd: float
+    scope: str = "local"  # hosted reports the tightest cap across all scopes
 
 
 class BudgetGuard:
@@ -48,6 +73,9 @@ class BudgetGuard:
         on_block: optional callback invoked with ``(spent_usd, limit_usd)`` right
             before :class:`BudgetExceeded` is raised. Defaults to printing the
             ``BUDGET EXCEEDED — call blocked`` banner to stderr.
+        near_limit_bps: utilization (basis points, 0..10000) at which
+            :meth:`advisory` flags ``near_limit`` so an agent can taper before the
+            hard-stop. Defaults to ``8000`` (80%).
     """
 
     def __init__(
@@ -57,13 +85,17 @@ class BudgetGuard:
         price_overrides: dict[str, ManualPrice] | None = None,
         fail_closed: bool = True,
         on_block: Callable[[float, float], None] | None = None,
+        near_limit_bps: int = 8000,
     ) -> None:
         if limit_usd < 0:
             raise ValueError(f"limit_usd must not be negative, got {limit_usd!r}")
+        if not 0 <= near_limit_bps <= 10000:
+            raise ValueError(f"near_limit_bps must be in 0..10000, got {near_limit_bps!r}")
         self.limit_usd = float(limit_usd)
         self.price_overrides = price_overrides
         self.fail_closed = fail_closed
         self._on_block = on_block or _default_on_block
+        self.near_limit_bps = near_limit_bps
         self.spent_usd = 0.0
         # Cost of the most recent priced call, used to predict the next one so we
         # can block BEFORE the crossing call runs (not one call too late).
@@ -133,6 +165,25 @@ class BudgetGuard:
     def remaining_usd(self) -> float:
         """USD left before the ceiling (never negative)."""
         return max(0.0, self.limit_usd - self.spent_usd)
+
+    def advisory(self) -> BudgetAdvisory:
+        """Context-aware spend advisory for this budget — see :class:`BudgetAdvisory`.
+
+        ``near_limit`` flips once utilization reaches ``near_limit_bps`` (default
+        80%), so an agent can taper *before* the hard-stop. Advisory only: read it
+        to adapt; :meth:`check` is what enforces the ceiling.
+        """
+        if self.limit_usd <= 0.0:
+            used_bps = 10000
+        else:
+            used_bps = max(0, min(10000, round(self.spent_usd / self.limit_usd * 10000)))
+        return BudgetAdvisory(
+            near_limit=used_bps >= self.near_limit_bps,
+            used_bps=used_bps,
+            remaining_usd=max(0.0, self.limit_usd - self.spent_usd),
+            limit_usd=self.limit_usd,
+            spent_usd=self.spent_usd,
+        )
 
 
 def _default_on_block(spent_usd: float, limit_usd: float) -> None:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -89,8 +89,14 @@ class BudgetGuard:
     ) -> None:
         if limit_usd < 0:
             raise ValueError(f"limit_usd must not be negative, got {limit_usd!r}")
-        if not 0 <= near_limit_bps <= 10000:
-            raise ValueError(f"near_limit_bps must be in 0..10000, got {near_limit_bps!r}")
+        # Require a real int (bool is an int subclass in Python — exclude it) in
+        # 0..10000, matching the TS Number.isInteger check for cross-language parity.
+        if (
+            isinstance(near_limit_bps, bool)
+            or not isinstance(near_limit_bps, int)
+            or not 0 <= near_limit_bps <= 10000
+        ):
+            raise ValueError(f"near_limit_bps must be an int in 0..10000, got {near_limit_bps!r}")
         self.limit_usd = float(limit_usd)
         self.price_overrides = price_overrides
         self.fail_closed = fail_closed
@@ -176,7 +182,12 @@ class BudgetGuard:
         if self.limit_usd <= 0.0:
             used_bps = 10000
         else:
-            used_bps = max(0, min(10000, round(self.spent_usd / self.limit_usd * 10000)))
+            # Floor (not round) so used_bps never over-reports utilization and
+            # near_limit flips exactly when the threshold is reached, not a hair
+            # early. The tiny epsilon absorbs float noise (0.7*10000 = 6999.9999…),
+            # and floor matches JS Math.floor exactly — round() would diverge
+            # (Python banker's rounding vs JS ties-up).
+            used_bps = max(0, min(10000, int(self.spent_usd / self.limit_usd * 10000 + 1e-9)))
         return BudgetAdvisory(
             near_limit=used_bps >= self.near_limit_bps,
             used_bps=used_bps,

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -1,0 +1,53 @@
+"""Tests for the context-aware spend advisory (BudgetGuard.advisory)."""
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import BudgetAdvisory, BudgetGuard
+
+
+def test_fresh_guard_is_far_from_limit() -> None:
+    a = BudgetGuard(limit_usd=1.00).advisory()
+    assert isinstance(a, BudgetAdvisory)
+    assert a.near_limit is False
+    assert a.used_bps == 0
+    assert a.remaining_usd == 1.00
+    assert a.scope == "local"
+
+
+def test_near_limit_flips_at_default_threshold() -> None:
+    g = BudgetGuard(limit_usd=1.00)  # default near_limit_bps = 8000 (80%)
+    g.spent_usd = 0.79
+    assert g.advisory().near_limit is False
+    g.spent_usd = 0.80
+    a = g.advisory()
+    assert a.near_limit is True
+    assert a.used_bps == 8000
+    assert a.remaining_usd == pytest.approx(0.20)
+
+
+def test_custom_near_limit_threshold() -> None:
+    g = BudgetGuard(limit_usd=1.00, near_limit_bps=5000)  # 50%
+    g.spent_usd = 0.50
+    assert g.advisory().near_limit is True
+
+
+def test_used_bps_clamped_when_over_limit() -> None:
+    g = BudgetGuard(limit_usd=1.00)
+    g.spent_usd = 1.50  # overshoot
+    a = g.advisory()
+    assert a.used_bps == 10000  # clamped, not 15000
+    assert a.remaining_usd == 0.0  # never negative
+
+
+def test_zero_limit_reads_fully_used() -> None:
+    a = BudgetGuard(limit_usd=0).advisory()
+    assert a.used_bps == 10000
+    assert a.near_limit is True
+
+
+def test_invalid_near_limit_bps_rejected() -> None:
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.00, near_limit_bps=-1)
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.00, near_limit_bps=10001)

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -46,8 +46,26 @@ def test_zero_limit_reads_fully_used() -> None:
     assert a.near_limit is True
 
 
+def test_used_bps_floors_not_rounds() -> None:
+    # 79.999% used: floors to 7999 (not rounded up to 8000), so near_limit does
+    # NOT flip before 80% is actually reached. Also keeps Python/JS parity.
+    g = BudgetGuard(limit_usd=1.00, near_limit_bps=8000)
+    g.spent_usd = 0.79999
+    a = g.advisory()
+    assert a.used_bps == 7999
+    assert a.near_limit is False
+
+
 def test_invalid_near_limit_bps_rejected() -> None:
     with pytest.raises(ValueError):
         BudgetGuard(limit_usd=1.00, near_limit_bps=-1)
     with pytest.raises(ValueError):
         BudgetGuard(limit_usd=1.00, near_limit_bps=10001)
+
+
+def test_non_int_near_limit_bps_rejected() -> None:
+    # Floats and bools (bool is an int subclass) are rejected, matching JS.
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.00, near_limit_bps=8000.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.00, near_limit_bps=True)  # type: ignore[arg-type]

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -131,3 +131,12 @@ def test_remaining_usd() -> None:
     guard = BudgetGuard(limit_usd=1.00)
     guard.record(MODEL, 1_000, 1_000)
     assert guard.remaining_usd == pytest.approx(1.00 - 0.0125)
+
+
+def test_non_finite_limit_rejected() -> None:
+    # NaN/inf would make every check() comparison False and silently disable the
+    # guard — must be rejected (parity with the JS Number.isFinite contract).
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=float("nan"))
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=float("inf"))


### PR DESCRIPTION
Adds a **soft, context-aware advisory** alongside floe-guard's hard-stop, so an agent can *adapt* as it nears the cap (taper to a cheaper model, shrink the task, wrap up) instead of being cut off mid-run.

## What
- **`BudgetGuard.advisory()` → `BudgetAdvisory`** `{ near_limit, used_bps, remaining_usd, limit_usd, spent_usd, scope }`, plus a `near_limit_bps` knob (default `8000` = 80%).
- **TS parity:** `guard.advisory()` returns the identical fields (`nearLimit`, `usedBps`, …); `BudgetAdvisory` exported.
- **`examples/budget_aware.py`** — runnable, no API key: the agent runs gpt-4o until 70% used, then tapers to gpt-4o-mini and finishes **39 steps** of work under a $0.10 cap (vs 8 without tapering), hard-stop still holds at $0.0998.
- Tests (Python `test_advisory.py` + JS `advisory.test.ts`), README + js/README sections.

## Why this shape
It deliberately mirrors hosted Floe's `X-Floe-Budget-Advisory` header, so taper logic written against the local guard **ports unchanged** to the hosted path — hosted just answers across *every* vendor and cap with server-truth balances and rolling-window reset timing, which a single in-process budget can't know. That's the open-core line: same interface, the local one is honestly single-cap/estimate-based, the upgrade is a one-liner.

## Honesty kept
The advisory is a **soft** signal (the model may ignore it). `check()` is the guarantee; the advisory is upside. `scope` is always `"local"` here; multi-cap `tightest` reasoning is hosted-only.

## Verified
Python 66 passed, ruff clean; JS 13 passed, build + typecheck clean.

Note: builds on `main` (independent of the in-flight concurrency PR #19). When #19 lands, `advisory()` can optionally net out in-flight reservations — a one-line follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware budgeting via a new `advisory()` method that reports utilization and a `nearLimit` soft warning before hard enforcement.
  * Enabled budget “tapering”/adaptive behavior by switching models when `nearLimit` is true, while still using `check()` to enforce the limit.
  * Introduced configurable `nearLimitBps` / `near_limit_bps` threshold (default 80%); included `BudgetAdvisory` output with fields like `usedBps` and `remainingUsd`.

* **Bug Fixes**
  * Improved utilization calculations with flooring and clamping to avoid premature triggers and negative remaining amounts.

* **Documentation**
  * Updated Python and TypeScript READMEs with a “Context-aware budgeting” section and usage examples.

* **Tests**
  * Added comprehensive unit tests for `advisory()` behavior and validation, including limit edge cases and invalid `nearLimitBps` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->