### PR TITLE
docs: add 'Why floe-guard?' (objection-handling for adoption)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ This rigs a loop against a **stub LLM** — no real API key, no account, no netw
 It prices each fake `gpt-4o` call offline and the guard halts the loop after a few
 iterations. This is the reproducible "stop the loop" demo.
 
+## Why floe-guard?
+
+You can already *see* what your agent spends — the problem is seeing it too late.
+floe-guard is the part that **stops the call**, not the part that reports the damage.
+
+- **`max_tokens` / `max_rpm`** cap size and rate, not **dollars** — a cheap model
+  stuck in a loop still drains the budget.
+- **Usage logs and provider dashboards** tell you what you spent *after* it's gone.
+  floe-guard refuses the call *before* it crosses your ceiling.
+- **A cost callback that just logs** is notified after the fact and can't halt the
+  run — enforcement has to stand in front of the next call. That's where it lives.
+- **A hand-rolled `spent += cost` counter races under parallel agents** (CrewAI
+  fan-out, `asyncio`, `Promise.all`): N calls read the same under-limit total and
+  all fire. floe-guard reserves atomically (`reserve()`/`settle()`), so the ceiling
+  holds under concurrency.
+
+The whole job: a hard stop **before** the next call, that **holds under fan-out** —
+no account, no network, no crypto.
+
 ## How it works
 
 The guard sits **in the call path**, not on an event bus. A passive listener is


### PR DESCRIPTION
Adds the one section the README was missing for adoption: the **'why not just X?'** a dev asks before picking it up.

Handles the four real alternatives — `max_tokens`/`max_rpm` (caps size/rate, not dollars), usage logs/dashboards (after-the-fact), a logging cost callback (can't halt the run), and a hand-rolled `spent += cost` counter (races under parallel agents — floe-guard reserves atomically). Ends on the one-line differentiator: a hard stop **before** the next call that **holds under fan-out**.

All claims accurate to shipped `main` (the concurrency point is real now that reserve/settle landed via #19). Placed before 'How it works' so a skimming dev hits the 'why' early.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Why floe-guard?" section to README explaining the enforcement-first approach to cost control, detailing how atomic reservations prevent budget overruns that post-hoc callbacks and provider dashboards cannot stop, ensuring meaningful cost ceilings in concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->