### PR TITLE
feat(integrations): add OpenAI and Anthropic SDK adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,46 @@ llm.invoke("hello")            # checks budget before the call, records spend af
 The handler checks the budget on LLM start (raising `BudgetExceeded` aborts the
 call before it runs) and records token usage on LLM end.
 
+### OpenAI
+
+```bash
+pip install floe-guard[openai]
+```
+
+```python
+from openai import OpenAI
+from floe_guard import BudgetGuard
+from floe_guard.integrations.openai import guarded_completion
+
+guard = BudgetGuard(limit_usd=1.00)
+client = OpenAI()
+response = guarded_completion(guard, client, model="gpt-4o", messages=[...])
+```
+
+`guarded_completion` reserves the budget before the call (raising
+`BudgetExceeded` so a blocked call never reaches OpenAI) and records spend after.
+Use `guarded_acompletion` with an `AsyncOpenAI` client for async.
+
+### Anthropic
+
+```bash
+pip install floe-guard[anthropic]
+```
+
+```python
+from anthropic import Anthropic
+from floe_guard import BudgetGuard
+from floe_guard.integrations.anthropic import guarded_completion
+
+guard = BudgetGuard(limit_usd=1.00)
+client = Anthropic()
+response = guarded_completion(guard, client, model="claude-3-7-sonnet-20250219", max_tokens=1024, messages=[...])
+```
+
+Same reserve-before / record-after contract as the OpenAI adapter; Anthropic's
+`input_tokens` / `output_tokens` are mapped onto the guard's prompt/completion
+pricing. Use `guarded_acompletion` with an `AsyncAnthropic` client for async.
+
 ### Vercel AI SDK
 
 The Vercel AI SDK is TypeScript-only, so it ships as a separate npm package that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = []
 litellm = ["litellm>=1.0"]
 crewai = ["crewai>=0.30", "litellm>=1.0"]
 langchain = ["langchain-core>=0.3"]
+openai = ["openai>=1.0"]
+anthropic = ["anthropic>=0.40"]
 dev = ["pytest>=7.0", "ruff>=0.4"]
 
 [project.urls]

--- a/src/floe_guard/integrations/anthropic.py
+++ b/src/floe_guard/integrations/anthropic.py
@@ -22,6 +22,12 @@ from __future__ import annotations
 from typing import Any
 
 from ..guard import BudgetGuard
+from ..pricing import resolve_price
+
+# Anthropic prompt-cache pricing multipliers, relative to the base input rate:
+# 5-minute cache writes bill at ~1.25x, cache reads at ~0.1x. See _usage_from.
+_CACHE_WRITE_WEIGHT = 1.25
+_CACHE_READ_WEIGHT = 0.1
 
 
 def _model_from(kwargs: dict[str, Any], response: Any) -> str:
@@ -41,6 +47,15 @@ def _usage_from(response: Any) -> tuple[int, int]:
     Anthropic reports ``usage.input_tokens`` / ``usage.output_tokens``; the guard
     settles on the OpenAI-style ``(prompt_tokens, completion_tokens)`` pair, so
     input maps to prompt and output to completion.
+
+    Prompt caching: ``input_tokens`` counts only the *fresh* prompt tokens —
+    cached tokens are reported separately as ``cache_creation_input_tokens``
+    (billed ~1.25x base input) and ``cache_read_input_tokens`` (~0.1x). Dropping
+    them would under-meter a cached call, and a budget guard must never
+    under-count. Since the guard prices with a flat per-model input rate, we fold
+    the cache tokens into the prompt bucket at their *effective* weight so the
+    metered cost approximates the real spend (an estimate, not exact cache-aware
+    pricing — safe-direction).
     """
     usage = getattr(response, "usage", None)
     if usage is None and isinstance(response, dict):
@@ -48,7 +63,38 @@ def _usage_from(response: Any) -> tuple[int, int]:
     if usage is None:
         return 0, 0
     get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
-    return int(get("input_tokens", 0) or 0), int(get("output_tokens", 0) or 0)
+    input_tokens = int(get("input_tokens", 0) or 0)
+    output_tokens = int(get("output_tokens", 0) or 0)
+    cache_write = int(get("cache_creation_input_tokens", 0) or 0)
+    cache_read = int(get("cache_read_input_tokens", 0) or 0)
+    prompt_tokens = (
+        input_tokens
+        + round(cache_write * _CACHE_WRITE_WEIGHT)
+        + round(cache_read * _CACHE_READ_WEIGHT)
+    )
+    return prompt_tokens, output_tokens
+
+
+def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> str:
+    """Pick the model id to settle against.
+
+    The served model (``response.model``) is the source of truth (issue #23). But
+    if that served id can't be priced and the requested alias can, settle on the
+    alias instead, so a provider snapshot newer than the bundled cost map doesn't
+    fail-closed a call that would otherwise price cleanly. If neither prices, keep
+    the served id so the guard still fail-closes on a real id.
+    """
+    served = _model_from(kwargs, response)
+    requested = str(kwargs.get("model") or "")
+    if (
+        served
+        and requested
+        and served != requested
+        and resolve_price(served, guard.price_overrides) is None
+        and resolve_price(requested, guard.price_overrides) is not None
+    ):
+        return requested
+    return served
 
 
 def _record_response(
@@ -56,7 +102,7 @@ def _record_response(
 ) -> None:
     if not isinstance(kwargs, dict):
         kwargs = {}
-    model = _model_from(kwargs, response)
+    model = _settle_model(guard, kwargs, response)
     prompt_tokens, completion_tokens = _usage_from(response)
     if prompt_tokens <= 0 and completion_tokens <= 0:
         # No tokens spent — free the reservation.

--- a/src/floe_guard/integrations/anthropic.py
+++ b/src/floe_guard/integrations/anthropic.py
@@ -25,11 +25,13 @@ from ..guard import BudgetGuard
 
 
 def _model_from(kwargs: dict[str, Any], response: Any) -> str:
-    model = kwargs.get("model")
+    # Prefer the model the response was actually served by, falling back to the
+    # request's model= only when the response omits it.
+    model = getattr(response, "model", None)
+    if model is None and isinstance(response, dict):
+        model = response.get("model")
     if not model:
-        model = getattr(response, "model", None)
-        if model is None and isinstance(response, dict):
-            model = response.get("model")
+        model = kwargs.get("model")
     return str(model or "")
 
 
@@ -67,6 +69,16 @@ def _record_response(
     guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
+def _reject_streaming(kwargs: dict[str, Any]) -> None:
+    if kwargs.get("stream"):
+        raise ValueError(
+            "floe-guard's Anthropic adapter does not support stream=True: a streamed "
+            "response has no final usage to meter, so the call would go unaccounted. "
+            "Use a non-streaming call, or meter the stream yourself with "
+            "guard.reserve()/guard.settle()."
+        )
+
+
 def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     """``client.messages.create`` with a budget reservation and accrual.
 
@@ -75,7 +87,11 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
 
     ``client`` is an ``anthropic.Anthropic`` instance; ``kwargs`` are forwarded
     to ``messages.create`` (e.g. ``model=``, ``max_tokens=``, ``messages=``).
+
+    Streaming is not supported: a streamed response has no final ``usage`` to
+    settle from, so ``stream=True`` raises ``ValueError``.
     """
+    _reject_streaming(kwargs)
     reserved = guard.reserve()
     try:
         response = client.messages.create(**kwargs)
@@ -89,8 +105,10 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
 async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`.
 
-    ``client`` is an ``anthropic.AsyncAnthropic`` instance.
+    ``client`` is an ``anthropic.AsyncAnthropic`` instance. Streaming is not
+    supported (see :func:`guarded_completion`); ``stream=True`` raises ``ValueError``.
     """
+    _reject_streaming(kwargs)
     reserved = guard.reserve()
     try:
         response = await client.messages.create(**kwargs)

--- a/src/floe_guard/integrations/anthropic.py
+++ b/src/floe_guard/integrations/anthropic.py
@@ -1,0 +1,107 @@
+"""Anthropic Python SDK adapter (optional extra: ``pip install floe-guard[anthropic]``).
+
+:func:`guarded_completion` / :func:`guarded_acompletion` wrap a call to the
+Anthropic SDK's ``client.messages.create`` with a pre-call budget reservation
+and post-call accrual. This is the **guaranteed** enforcement path: the guard
+reserves the call's budget before the request, so a blocked call never reaches
+Anthropic.
+
+Like the OpenAI adapter there is no callback variant — wrapping the call site is
+the enforcement surface. The contract matches the other adapters: ``reserve()``
+before the call, ``settle(model, prompt_tokens, completion_tokens, reserved=...)``
+after, ``release()`` on exception. Reserving before the await lets parallel calls
+each hold their own slice of the ceiling (issue #18).
+
+The one Anthropic-specific bit: usage is reported as ``usage.input_tokens`` /
+``usage.output_tokens``, which we map onto the ``(prompt_tokens, completion_tokens)``
+shape the guard settles on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..guard import BudgetGuard
+
+
+def _model_from(kwargs: dict[str, Any], response: Any) -> str:
+    model = kwargs.get("model")
+    if not model:
+        model = getattr(response, "model", None)
+        if model is None and isinstance(response, dict):
+            model = response.get("model")
+    return str(model or "")
+
+
+def _usage_from(response: Any) -> tuple[int, int]:
+    """Map an Anthropic message's usage onto (prompt_tokens, completion_tokens).
+
+    Anthropic reports ``usage.input_tokens`` / ``usage.output_tokens``; the guard
+    settles on the OpenAI-style ``(prompt_tokens, completion_tokens)`` pair, so
+    input maps to prompt and output to completion.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage")
+    if usage is None:
+        return 0, 0
+    get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
+    return int(get("input_tokens", 0) or 0), int(get("output_tokens", 0) or 0)
+
+
+def _record_response(
+    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
+) -> None:
+    if not isinstance(kwargs, dict):
+        kwargs = {}
+    model = _model_from(kwargs, response)
+    prompt_tokens, completion_tokens = _usage_from(response)
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        # No tokens spent — free the reservation.
+        guard.release(reserved)
+        return
+    # There IS spend to account for. Route it through settle() even when the
+    # model id is missing, so the guard's policy applies (fail-closed → warn +
+    # raise; fail-open → warn + skip) rather than letting a completed call go
+    # unmetered and skew the next check().
+    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
+
+
+def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """``client.messages.create`` with a budget reservation and accrual.
+
+    Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
+    would be crossed — the request never reaches Anthropic.
+
+    ``client`` is an ``anthropic.Anthropic`` instance; ``kwargs`` are forwarded
+    to ``messages.create`` (e.g. ``model=``, ``max_tokens=``, ``messages=``).
+    """
+    reserved = guard.reserve()
+    try:
+        response = client.messages.create(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """Async counterpart of :func:`guarded_completion`.
+
+    ``client`` is an ``anthropic.AsyncAnthropic`` instance.
+    """
+    reserved = guard.reserve()
+    try:
+        response = await client.messages.create(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+__all__ = [
+    "guarded_completion",
+    "guarded_acompletion",
+]

--- a/src/floe_guard/integrations/openai.py
+++ b/src/floe_guard/integrations/openai.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..guard import BudgetGuard
+from ..pricing import resolve_price
 
 
 def _model_from(kwargs: dict[str, Any], response: Any) -> str:
@@ -50,12 +51,35 @@ def _usage_from(response: Any) -> tuple[int, int]:
     return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
 
 
+def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> str:
+    """Pick the model id to settle against.
+
+    The served model (``response.model``) is the source of truth (issue #23) —
+    it reflects OpenAI's canonical/substituted id. But if that served id can't be
+    priced and the requested alias can, settle on the alias instead, so a
+    provider snapshot newer than the bundled cost map doesn't fail-closed a call
+    that would otherwise price cleanly. If neither prices, keep the served id so
+    the guard still fail-closes on a real id.
+    """
+    served = _model_from(kwargs, response)
+    requested = str(kwargs.get("model") or "")
+    if (
+        served
+        and requested
+        and served != requested
+        and resolve_price(served, guard.price_overrides) is None
+        and resolve_price(requested, guard.price_overrides) is not None
+    ):
+        return requested
+    return served
+
+
 def _record_response(
     guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
 ) -> None:
     if not isinstance(kwargs, dict):
         kwargs = {}
-    model = _model_from(kwargs, response)
+    model = _settle_model(guard, kwargs, response)
     prompt_tokens, completion_tokens = _usage_from(response)
     if prompt_tokens <= 0 and completion_tokens <= 0:
         # No tokens spent (e.g. a usage-less response) — free the reservation.

--- a/src/floe_guard/integrations/openai.py
+++ b/src/floe_guard/integrations/openai.py
@@ -1,0 +1,105 @@
+"""OpenAI Python SDK adapter (optional extra: ``pip install floe-guard[openai]``).
+
+:func:`guarded_completion` / :func:`guarded_acompletion` wrap a call to the
+OpenAI SDK's ``client.chat.completions.create`` with a pre-call budget
+reservation and post-call accrual. This is the **guaranteed** enforcement path:
+the guard reserves the call's budget before the request, so a blocked call never
+reaches OpenAI.
+
+The OpenAI SDK has no global callback hook, so unlike the LiteLLM adapter there
+is no callback variant — wrapping the call site is the enforcement surface.
+
+The contract matches the LiteLLM adapter: ``reserve()`` before the call,
+``settle(model, prompt_tokens, completion_tokens, reserved=...)`` after, and
+``release()`` on exception. Reserving before the await means parallel calls each
+hold their own slice of the ceiling instead of racing one shared total (issue
+#18). Unpriceable models stay fail-closed (the guard's configured policy).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..guard import BudgetGuard
+
+
+def _model_from(kwargs: dict[str, Any], response: Any) -> str:
+    model = kwargs.get("model")
+    if not model:
+        model = getattr(response, "model", None)
+        if model is None and isinstance(response, dict):
+            model = response.get("model")
+    return str(model or "")
+
+
+def _usage_from(response: Any) -> tuple[int, int]:
+    """Pull (prompt_tokens, completion_tokens) from an OpenAI chat completion.
+
+    OpenAI reports ``usage.prompt_tokens`` / ``usage.completion_tokens`` — the
+    same shape the guard settles on, so no remapping is needed.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage")
+    if usage is None:
+        return 0, 0
+    get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
+    return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
+
+
+def _record_response(
+    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
+) -> None:
+    if not isinstance(kwargs, dict):
+        kwargs = {}
+    model = _model_from(kwargs, response)
+    prompt_tokens, completion_tokens = _usage_from(response)
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        # No tokens spent (e.g. a usage-less response) — free the reservation.
+        guard.release(reserved)
+        return
+    # There IS spend to account for. Route it through settle() even when the
+    # model id is missing, so the guard's policy applies (fail-closed → warn +
+    # raise; fail-open → warn + skip) rather than letting a completed call go
+    # unmetered and skew the next check().
+    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
+
+
+def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """``client.chat.completions.create`` with a budget reservation and accrual.
+
+    Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
+    would be crossed — the request never reaches OpenAI.
+
+    ``client`` is an ``openai.OpenAI`` instance; ``kwargs`` are forwarded to
+    ``chat.completions.create`` (e.g. ``model=``, ``messages=``).
+    """
+    reserved = guard.reserve()
+    try:
+        response = client.chat.completions.create(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """Async counterpart of :func:`guarded_completion`.
+
+    ``client`` is an ``openai.AsyncOpenAI`` instance.
+    """
+    reserved = guard.reserve()
+    try:
+        response = await client.chat.completions.create(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+__all__ = [
+    "guarded_completion",
+    "guarded_acompletion",
+]

--- a/src/floe_guard/integrations/openai.py
+++ b/src/floe_guard/integrations/openai.py
@@ -24,11 +24,14 @@ from ..guard import BudgetGuard
 
 
 def _model_from(kwargs: dict[str, Any], response: Any) -> str:
-    model = kwargs.get("model")
+    # Prefer the model the response was actually served by — OpenAI can return a
+    # resolved/canonical id that differs from the requested alias — and fall back
+    # to the request's model= only when the response omits it.
+    model = getattr(response, "model", None)
+    if model is None and isinstance(response, dict):
+        model = response.get("model")
     if not model:
-        model = getattr(response, "model", None)
-        if model is None and isinstance(response, dict):
-            model = response.get("model")
+        model = kwargs.get("model")
     return str(model or "")
 
 
@@ -65,6 +68,16 @@ def _record_response(
     guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
+def _reject_streaming(kwargs: dict[str, Any]) -> None:
+    if kwargs.get("stream"):
+        raise ValueError(
+            "floe-guard's OpenAI adapter does not support stream=True: a streamed "
+            "response has no final usage to meter, so the call would go unaccounted. "
+            "Use a non-streaming call, or meter the stream yourself with "
+            "guard.reserve()/guard.settle()."
+        )
+
+
 def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     """``client.chat.completions.create`` with a budget reservation and accrual.
 
@@ -73,7 +86,12 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
 
     ``client`` is an ``openai.OpenAI`` instance; ``kwargs`` are forwarded to
     ``chat.completions.create`` (e.g. ``model=``, ``messages=``).
+
+    Streaming is not supported: a streamed response has no final ``usage`` to
+    settle from, so the call would silently go unmetered. Passing ``stream=True``
+    raises ``ValueError``.
     """
+    _reject_streaming(kwargs)
     reserved = guard.reserve()
     try:
         response = client.chat.completions.create(**kwargs)
@@ -87,8 +105,10 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
 async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`.
 
-    ``client`` is an ``openai.AsyncOpenAI`` instance.
+    ``client`` is an ``openai.AsyncOpenAI`` instance. Streaming is not supported
+    (see :func:`guarded_completion`); ``stream=True`` raises ``ValueError``.
     """
+    _reject_streaming(kwargs)
     reserved = guard.reserve()
     try:
         response = await client.chat.completions.create(**kwargs)

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -16,6 +16,7 @@ from floe_guard import BudgetExceeded, BudgetGuard, UnpriceableModelError, Unpri
 from floe_guard.integrations.anthropic import (
     _model_from,
     _record_response,
+    _settle_model,
     _usage_from,
     guarded_acompletion,
     guarded_completion,
@@ -70,11 +71,36 @@ def test_usage_maps_input_output_to_prompt_completion() -> None:
     assert _usage_from({"usage": {"input_tokens": 5, "output_tokens": 7}}) == (5, 7)
 
 
+def test_usage_folds_prompt_cache_tokens() -> None:
+    # Cached calls must not be under-metered: cache write ~1.25x, read ~0.1x,
+    # folded into the prompt bucket. 100 + round(200*1.25) + round(1000*0.1).
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_creation_input_tokens": 200,
+        "cache_read_input_tokens": 1000,
+    }
+    assert _usage_from({"usage": usage}) == (100 + 250 + 100, 50)
+    # No cache fields → unchanged (the object path getattr-defaults to 0).
+    assert _usage_from(_Response(_MODEL, _Usage(5, 7))) == (5, 7)
+
+
 def test_model_from_prefers_response_then_kwargs() -> None:
     # The response's served model wins; the kwarg is only a fallback.
     resp = _Response(_MODEL, _Usage(1, 1))
     assert _model_from({"model": "claude-3-haiku-20240307"}, resp) == _MODEL
     assert _model_from({"model": _MODEL}, {"usage": {}}) == _MODEL
+
+
+def test_settle_model_falls_back_to_priceable_alias() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    # Served snapshot isn't in the bundled cost map, but the requested alias is:
+    # settle on the alias so the call isn't fail-closed for a stale map.
+    unpriced_served = _Response("claude-3-7-sonnet-20260101", _Usage(1, 1))
+    assert _settle_model(guard, {"model": _MODEL}, unpriced_served) == _MODEL
+    # Served id IS priceable → it wins (source of truth).
+    priced_served = _Response(_MODEL, _Usage(1, 1))
+    assert _settle_model(guard, {"model": "claude-3-haiku-20240307"}, priced_served) == _MODEL
 
 
 def test_record_response_accrues() -> None:

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -70,10 +70,11 @@ def test_usage_maps_input_output_to_prompt_completion() -> None:
     assert _usage_from({"usage": {"input_tokens": 5, "output_tokens": 7}}) == (5, 7)
 
 
-def test_model_from_prefers_kwargs_then_response() -> None:
+def test_model_from_prefers_response_then_kwargs() -> None:
+    # The response's served model wins; the kwarg is only a fallback.
     resp = _Response(_MODEL, _Usage(1, 1))
-    assert _model_from({"model": "claude-3-haiku-20240307"}, resp) == "claude-3-haiku-20240307"
-    assert _model_from({}, resp) == _MODEL
+    assert _model_from({"model": "claude-3-haiku-20240307"}, resp) == _MODEL
+    assert _model_from({"model": _MODEL}, {"usage": {}}) == _MODEL
 
 
 def test_record_response_accrues() -> None:
@@ -146,3 +147,20 @@ def test_unpriceable_model_fails_closed() -> None:
         with pytest.raises(UnpriceableModelError):
             _record_response(guard, {}, resp)
     assert guard.spent_usd == 0.0
+
+
+def test_streaming_is_rejected_before_the_call() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    messages = _Messages(_Response(_MODEL, _Usage(1, 1)))
+    client = _Client(messages)
+    with pytest.raises(ValueError, match="stream"):
+        guarded_completion(guard, client, model=_MODEL, max_tokens=64, messages=[], stream=True)
+    assert messages.called is False
+    assert guard.spent_usd == 0.0
+
+
+def test_usageless_response_releases_the_reservation() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    _record_response(guard, {}, _Response(_MODEL, _Usage(0, 0)), reserved=0.5)
+    assert guard.spent_usd == 0.0
+    assert guard.remaining_usd == pytest.approx(1.0)

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,148 @@
+"""Anthropic adapter tests that need no ``anthropic`` install.
+
+The Anthropic SDK response/client shapes are duck-typed with dataclasses. These
+cover the input/output -> prompt/completion usage mapping, the accrual contract,
+and the hard-stop (a blocked call never reaches the client) without the extra.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from floe_guard import BudgetExceeded, BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
+from floe_guard.integrations.anthropic import (
+    _model_from,
+    _record_response,
+    _usage_from,
+    guarded_acompletion,
+    guarded_completion,
+)
+
+
+@dataclass
+class _Usage:
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass
+class _Response:
+    model: str
+    usage: _Usage
+
+
+class _Messages:
+    """Stub of ``client.messages`` that records whether it was called."""
+
+    def __init__(self, response: _Response) -> None:
+        self._response = response
+        self.called = False
+
+    def create(self, **kwargs: object) -> _Response:
+        self.called = True
+        return self._response
+
+
+class _AsyncMessages:
+    def __init__(self, response: _Response) -> None:
+        self._response = response
+        self.called = False
+
+    async def create(self, **kwargs: object) -> _Response:
+        self.called = True
+        return self._response
+
+
+class _Client:
+    def __init__(self, messages: object) -> None:
+        self.messages = messages
+
+
+_MODEL = "claude-3-7-sonnet-20250219"  # present in the bundled cost map
+
+
+def test_usage_maps_input_output_to_prompt_completion() -> None:
+    # The Anthropic-specific bit: input_tokens -> prompt, output_tokens -> completion.
+    assert _usage_from(_Response(_MODEL, _Usage(5, 7))) == (5, 7)
+    assert _usage_from({"usage": {"input_tokens": 5, "output_tokens": 7}}) == (5, 7)
+
+
+def test_model_from_prefers_kwargs_then_response() -> None:
+    resp = _Response(_MODEL, _Usage(1, 1))
+    assert _model_from({"model": "claude-3-haiku-20240307"}, resp) == "claude-3-haiku-20240307"
+    assert _model_from({}, resp) == _MODEL
+
+
+def test_record_response_accrues() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    resp = _Response(_MODEL, _Usage(1_000, 1_000))
+    _record_response(guard, {}, resp)
+    assert guard.spent_usd > 0.0  # priced from the bundled cost map
+
+
+def test_guarded_completion_records_and_calls_client() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    messages = _Messages(_Response(_MODEL, _Usage(1_000, 1_000)))
+    client = _Client(messages)
+    resp = guarded_completion(guard, client, model=_MODEL, max_tokens=64, messages=[])
+    assert messages.called is True
+    assert resp.model == _MODEL
+    assert guard.spent_usd > 0.0
+
+
+def test_guarded_acompletion_records_and_calls_client() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    messages = _AsyncMessages(_Response(_MODEL, _Usage(1_000, 1_000)))
+    client = _Client(messages)
+    asyncio.run(guarded_acompletion(guard, client, model=_MODEL, max_tokens=64, messages=[]))
+    assert messages.called is True
+    assert guard.spent_usd > 0.0
+
+
+def test_hard_stop_blocks_call_before_it_reaches_client() -> None:
+    # First, price one call to learn its cost, then set a guard whose ceiling is
+    # exactly that cost: the first call spends it, the second must block before
+    # the client is reached.
+    probe = BudgetGuard(limit_usd=10.0)
+    _record_response(probe, {}, _Response(_MODEL, _Usage(1_000, 1_000)))
+    one_call = probe.spent_usd
+
+    guard = BudgetGuard(limit_usd=one_call)
+    messages = _Messages(_Response(_MODEL, _Usage(1_000, 1_000)))
+    client = _Client(messages)
+    guarded_completion(
+        guard, client, model=_MODEL, max_tokens=64, messages=[]
+    )  # spends the ceiling
+    messages.called = False
+
+    with pytest.raises(BudgetExceeded):
+        guarded_completion(guard, client, model=_MODEL, max_tokens=64, messages=[])
+    assert messages.called is False  # blocked before reaching the client
+
+
+def test_hard_stop_async_blocks_call() -> None:
+    probe = BudgetGuard(limit_usd=10.0)
+    _record_response(probe, {}, _Response(_MODEL, _Usage(1_000, 1_000)))
+    one_call = probe.spent_usd
+
+    guard = BudgetGuard(limit_usd=one_call)
+    messages = _AsyncMessages(_Response(_MODEL, _Usage(1_000, 1_000)))
+    client = _Client(messages)
+    asyncio.run(guarded_acompletion(guard, client, model=_MODEL, max_tokens=64, messages=[]))
+    messages.called = False
+
+    with pytest.raises(BudgetExceeded):
+        asyncio.run(guarded_acompletion(guard, client, model=_MODEL, max_tokens=64, messages=[]))
+    assert messages.called is False
+
+
+def test_unpriceable_model_fails_closed() -> None:
+    guard = BudgetGuard(limit_usd=1.0)  # fail_closed defaults to True
+    resp = _Response("totally-made-up-model", _Usage(1_000, 1_000))
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            _record_response(guard, {}, resp)
+    assert guard.spent_usd == 0.0

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,147 @@
+"""OpenAI adapter tests that need no ``openai`` install.
+
+The OpenAI SDK response/client shapes are duck-typed with dataclasses, so the
+reservation/accrual contract — and the hard-stop (a blocked call never reaches
+the client) — is covered even in CI without the optional extra.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from floe_guard import BudgetExceeded, BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
+from floe_guard.integrations.openai import (
+    _model_from,
+    _record_response,
+    _usage_from,
+    guarded_acompletion,
+    guarded_completion,
+)
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass
+class _Response:
+    model: str
+    usage: _Usage
+
+
+class _Completions:
+    """Stub of ``client.chat.completions`` that records whether it was called."""
+
+    def __init__(self, response: _Response) -> None:
+        self._response = response
+        self.called = False
+
+    def create(self, **kwargs: object) -> _Response:
+        self.called = True
+        return self._response
+
+
+class _AsyncCompletions:
+    def __init__(self, response: _Response) -> None:
+        self._response = response
+        self.called = False
+
+    async def create(self, **kwargs: object) -> _Response:
+        self.called = True
+        return self._response
+
+
+class _Chat:
+    def __init__(self, completions: object) -> None:
+        self.completions = completions
+
+
+class _Client:
+    def __init__(self, completions: object) -> None:
+        self.chat = _Chat(completions)
+
+
+def _client(response: _Response) -> _Client:
+    return _Client(_Completions(response))
+
+
+def _async_client(response: _Response) -> _Client:
+    return _Client(_AsyncCompletions(response))
+
+
+def test_usage_from_object_and_dict() -> None:
+    assert _usage_from(_Response("gpt-4o", _Usage(5, 7))) == (5, 7)
+    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7)
+
+
+def test_model_from_prefers_kwargs_then_response() -> None:
+    resp = _Response("gpt-4o", _Usage(1, 1))
+    assert _model_from({"model": "gpt-4o-mini"}, resp) == "gpt-4o-mini"
+    assert _model_from({}, resp) == "gpt-4o"
+
+
+def test_record_response_accrues() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    resp = _Response("gpt-4o", _Usage(1_000, 1_000))
+    _record_response(guard, {}, resp)
+    assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_guarded_completion_records_and_calls_client() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    completions = _Completions(_Response("gpt-4o", _Usage(1_000, 1_000)))
+    client = _Client(completions)
+    resp = guarded_completion(guard, client, model="gpt-4o", messages=[])
+    assert completions.called is True
+    assert resp.model == "gpt-4o"
+    assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_guarded_acompletion_records_and_calls_client() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    completions = _AsyncCompletions(_Response("gpt-4o", _Usage(1_000, 1_000)))
+    client = _Client(completions)
+    resp = asyncio.run(guarded_acompletion(guard, client, model="gpt-4o", messages=[]))
+    assert completions.called is True
+    assert resp.model == "gpt-4o"
+    assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_hard_stop_blocks_call_before_it_reaches_client() -> None:
+    # Spend up to the ceiling, then the next reserve() must raise BEFORE the
+    # client is ever called — the request never reaches OpenAI.
+    guard = BudgetGuard(limit_usd=0.0125)
+    completions = _Completions(_Response("gpt-4o", _Usage(1_000, 1_000)))
+    client = _Client(completions)
+    guarded_completion(guard, client, model="gpt-4o", messages=[])  # spends exactly the ceiling
+    completions.called = False
+
+    with pytest.raises(BudgetExceeded):
+        guarded_completion(guard, client, model="gpt-4o", messages=[])
+    assert completions.called is False  # blocked before reaching the client
+
+
+def test_hard_stop_async_blocks_call() -> None:
+    guard = BudgetGuard(limit_usd=0.0125)
+    completions = _AsyncCompletions(_Response("gpt-4o", _Usage(1_000, 1_000)))
+    client = _Client(completions)
+    asyncio.run(guarded_acompletion(guard, client, model="gpt-4o", messages=[]))
+    completions.called = False
+
+    with pytest.raises(BudgetExceeded):
+        asyncio.run(guarded_acompletion(guard, client, model="gpt-4o", messages=[]))
+    assert completions.called is False
+
+
+def test_unpriceable_model_fails_closed() -> None:
+    guard = BudgetGuard(limit_usd=1.0)  # fail_closed defaults to True
+    resp = _Response("totally-made-up-model", _Usage(1_000, 1_000))
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            _record_response(guard, {}, resp)
+    assert guard.spent_usd == 0.0

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -16,6 +16,7 @@ from floe_guard import BudgetExceeded, BudgetGuard, UnpriceableModelError, Unpri
 from floe_guard.integrations.openai import (
     _model_from,
     _record_response,
+    _settle_model,
     _usage_from,
     guarded_acompletion,
     guarded_completion,
@@ -85,6 +86,17 @@ def test_model_from_prefers_response_then_kwargs() -> None:
     resp = _Response("gpt-4o-2024-08-06", _Usage(1, 1))
     assert _model_from({"model": "gpt-4o"}, resp) == "gpt-4o-2024-08-06"
     assert _model_from({"model": "gpt-4o"}, {"usage": {}}) == "gpt-4o"
+
+
+def test_settle_model_falls_back_to_priceable_alias() -> None:
+    guard = BudgetGuard(limit_usd=10.0)
+    # Served snapshot isn't in the bundled cost map, but the requested alias is:
+    # settle on the alias so a stale map doesn't fail-closed an otherwise-priced call.
+    unpriced_served = _Response("gpt-4o-2099-01-01", _Usage(1, 1))
+    assert _settle_model(guard, {"model": "gpt-4o"}, unpriced_served) == "gpt-4o"
+    # Served id IS priceable → it wins (source of truth).
+    priced_served = _Response("gpt-4o-2024-08-06", _Usage(1, 1))
+    assert _settle_model(guard, {"model": "gpt-4o"}, priced_served) == "gpt-4o-2024-08-06"
 
 
 def test_record_response_accrues() -> None:

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -79,10 +79,12 @@ def test_usage_from_object_and_dict() -> None:
     assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7)
 
 
-def test_model_from_prefers_kwargs_then_response() -> None:
-    resp = _Response("gpt-4o", _Usage(1, 1))
-    assert _model_from({"model": "gpt-4o-mini"}, resp) == "gpt-4o-mini"
-    assert _model_from({}, resp) == "gpt-4o"
+def test_model_from_prefers_response_then_kwargs() -> None:
+    # The response's served model wins over the requested alias; the kwarg is
+    # only a fallback when the response omits the model.
+    resp = _Response("gpt-4o-2024-08-06", _Usage(1, 1))
+    assert _model_from({"model": "gpt-4o"}, resp) == "gpt-4o-2024-08-06"
+    assert _model_from({"model": "gpt-4o"}, {"usage": {}}) == "gpt-4o"
 
 
 def test_record_response_accrues() -> None:
@@ -145,3 +147,24 @@ def test_unpriceable_model_fails_closed() -> None:
         with pytest.raises(UnpriceableModelError):
             _record_response(guard, {}, resp)
     assert guard.spent_usd == 0.0
+
+
+def test_streaming_is_rejected_before_the_call() -> None:
+    # A streamed response has no final usage to settle, so it would go unmetered.
+    # Reject it up front, before reserving or calling the client.
+    guard = BudgetGuard(limit_usd=1.0)
+    completions = _Completions(_Response("gpt-4o", _Usage(1, 1)))
+    client = _Client(completions)
+    with pytest.raises(ValueError, match="stream"):
+        guarded_completion(guard, client, model="gpt-4o", messages=[], stream=True)
+    assert completions.called is False
+    assert guard.spent_usd == 0.0
+
+
+def test_usageless_response_releases_the_reservation() -> None:
+    # A response that reports no usage must free the in-flight reservation, or
+    # remaining_usd would shrink permanently for later calls.
+    guard = BudgetGuard(limit_usd=1.0)
+    _record_response(guard, {}, _Response("gpt-4o", _Usage(0, 0)), reserved=0.5)
+    assert guard.spent_usd == 0.0
+    assert guard.remaining_usd == pytest.approx(1.0)


### PR DESCRIPTION
Closes #23.

Adds OpenAI and Anthropic Python SDK adapters, per the scope agreed in #23.

## What

Two new wrapper-only adapters under `src/floe_guard/integrations/`, each behind an optional extra (`pip install floe-guard[openai]` / `floe-guard[anthropic]`). The core stays dependency-free.

- `openai.py` — `guarded_completion(guard, client, **kwargs)` / `guarded_acompletion(...)` wrap `client.chat.completions.create`. OpenAI's `usage.prompt_tokens` / `completion_tokens` matches the guard's settle shape as-is.
- `anthropic.py` — same wrappers around `client.messages.create`. Anthropic reports `usage.input_tokens` / `output_tokens`, which are mapped onto `(prompt_tokens, completion_tokens)`.

Both follow the LiteLLM adapter's contract exactly: `reserve()` before the call (so a blocked call never reaches the provider), `settle(model, prompt_tokens, completion_tokens, reserved=...)` after, `release()` on exception. The model id comes from `response.model` with the `model=` kwarg as fallback. Unpriceable models stay fail-closed.

Wrapper-only (no callback variant) since neither SDK has a global callback hook — wrapping the call site is the guaranteed-enforcement surface. JS is intentionally out of scope here (can be a follow-up).

## Tests

`tests/test_openai_adapter.py` and `tests/test_anthropic_adapter.py` duck-type the SDK response and client shapes with dataclasses, so they run without either SDK installed (`pip install -e ".[dev]"` is enough). They cover: usage parsing (incl. the Anthropic input/output mapping), model resolution, accrual, sync + async happy paths, the hard-stop (a blocked call never reaches the client), and fail-closed on unpriceable models.

## Checks

- `pytest` — 91 passed, 2 skipped.
- `ruff check .` — clean.
- New files pass `ruff format --check`.

(Note: a few pre-existing files report `ruff format` drift under newer ruff; I left them untouched to keep this PR scoped to the adapters.)

Opened as a draft per CONTRIBUTING — happy to adjust anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added budget-enforced OpenAI and Anthropic adapters with sync (`guarded_completion`) and async (`guarded_acompletion`) helpers.
  * Enforced hard-stop behavior when the budget limit is reached, preventing further calls.
  * Rejects `stream=True` since token usage can’t be metered for streamed responses.
* **Documentation**
  * Expanded README with installation steps, examples, and guidance for sync/async usage and token mapping.
* **Tests**
  * Added standalone OpenAI/Anthropic adapter test suites covering metering, budget blocking, unpriceable models, streaming rejection, and reservation release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->