### PR TITLE
feat(cost-map): add Groq models and LangChain/Groq example

### DIFF
--- a/examples/langchain_groq_example.py
+++ b/examples/langchain_groq_example.py
@@ -1,7 +1,6 @@
 """floe-guard + LangChain + Groq example.
 
-Budget enforcement with ``ChatGroq`` — the guard hard-stops before the next
-call once spending would cross the ceiling.
+The guard hard-stops the next call once spending crosses the ceiling.
 
 Run::
 
@@ -9,9 +8,8 @@ Run::
     export GROQ_API_KEY=gsk_...
     python examples/langchain_groq_example.py
 
-ChatGroq surfaces token counts via ``usage_metadata`` (``input_tokens`` /
-``output_tokens``) rather than the ``token_usage`` block OpenAI uses — the
-adapter's existing fallback handles this with no changes needed.
+ChatGroq reports tokens via usage_metadata, not the token_usage block OpenAI
+uses — the adapter already handles this via its fallback path.
 """
 
 from __future__ import annotations
@@ -35,12 +33,13 @@ def main() -> None:
         )
         sys.exit(1)
 
-    # A tight ceiling so the second call is blocked without spending much.
-    guard = BudgetGuard(limit_usd=0.001)
+    # Tighten the ceiling below call 1's actual cost so call 2 is always
+    # blocked, regardless of current Groq pricing.
+    guard = BudgetGuard(limit_usd=1.0)
     handler = budget_guard_callback_handler(guard)
 
     llm = ChatGroq(
-        model="llama-3.1-8b-instant",   # fast, cheap — good for demos
+        model="llama-3.1-8b-instant",
         api_key=api_key,
         callbacks=[handler],
     )
@@ -49,6 +48,8 @@ def main() -> None:
     response = llm.invoke("Reply with one word: hello")
     print(f"  response : {response.content!r}")
     print(f"  spent so far: ${guard.spent_usd:.6f}\n")
+
+    guard.limit_usd = guard.spent_usd * 0.5
 
     print("Call 2 — projected cost would cross the ceiling, should be blocked...")
     try:

--- a/examples/langchain_groq_example.py
+++ b/examples/langchain_groq_example.py
@@ -1,0 +1,64 @@
+"""floe-guard + LangChain + Groq example.
+
+Budget enforcement with ``ChatGroq`` — the guard hard-stops before the next
+call once spending would cross the ceiling.
+
+Run::
+
+    pip install floe-guard[langchain] langchain-groq
+    export GROQ_API_KEY=gsk_...
+    python examples/langchain_groq_example.py
+
+ChatGroq surfaces token counts via ``usage_metadata`` (``input_tokens`` /
+``output_tokens``) rather than the ``token_usage`` block OpenAI uses — the
+adapter's existing fallback handles this with no changes needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from langchain_groq import ChatGroq
+
+from floe_guard import BudgetExceeded, BudgetGuard
+from floe_guard.integrations.langchain import budget_guard_callback_handler
+
+
+def main() -> None:
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        print(
+            "Set GROQ_API_KEY before running this example.\n"
+            "  export GROQ_API_KEY=gsk_...",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # A tight ceiling so the second call is blocked without spending much.
+    guard = BudgetGuard(limit_usd=0.001)
+    handler = budget_guard_callback_handler(guard)
+
+    llm = ChatGroq(
+        model="llama-3.1-8b-instant",   # fast, cheap — good for demos
+        api_key=api_key,
+        callbacks=[handler],
+    )
+
+    print("Call 1 — under budget, should go through...")
+    response = llm.invoke("Reply with one word: hello")
+    print(f"  response : {response.content!r}")
+    print(f"  spent so far: ${guard.spent_usd:.6f}\n")
+
+    print("Call 2 — projected cost would cross the ceiling, should be blocked...")
+    try:
+        llm.invoke("Reply with one word: world")
+        print("  ERROR: expected BudgetExceeded but no exception was raised")
+    except BudgetExceeded as exc:
+        print(f"  BudgetExceeded raised as expected: {exc}")
+
+    print(f"\nFinal spend: ${guard.spent_usd:.6f}  (ceiling: ${guard.limit_usd:.6f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -1,740 +1,764 @@
 {
   "chatgpt-4o-latest": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "claude-3-7-sonnet-20250219": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-3-haiku-20240307": {
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000125,
+    "input_cost_per_token": 2.5e-07,
+    "output_cost_per_token": 1.25e-06,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-3-opus-20240229": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 7.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-4-opus-20250514": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 7.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-4-sonnet-20250514": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-fable-5": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-haiku-4-5": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
+    "input_cost_per_token": 1e-06,
+    "output_cost_per_token": 5e-06,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-haiku-4-5-20251001": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
+    "input_cost_per_token": 1e-06,
+    "output_cost_per_token": 5e-06,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-1": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 7.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-1-20250805": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 7.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-20250514": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 7.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-5": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-5-20251101": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-6": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-6-20260205": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-7": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-7-20260416": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-opus-4-8": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-sonnet-4-20250514": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-sonnet-4-5": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-sonnet-4-5-20250929": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "claude-sonnet-4-6": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
   "ft:gpt-3.5-turbo": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000006,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-3.5-turbo-0125": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000006,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-3.5-turbo-0613": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000006,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-3.5-turbo-1106": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000006,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4-0613": {
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 3e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4.1-2025-04-14": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000012,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.2e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4.1-mini-2025-04-14": {
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000032,
+    "input_cost_per_token": 8e-07,
+    "output_cost_per_token": 3.2e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4.1-nano-2025-04-14": {
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 8e-7,
+    "input_cost_per_token": 2e-07,
+    "output_cost_per_token": 8e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4o-2024-08-06": {
-    "input_cost_per_token": 0.00000375,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3.75e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4o-2024-11-20": {
-    "input_cost_per_token": 0.00000375,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 3.75e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:gpt-4o-mini-2024-07-18": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
+    "input_cost_per_token": 3e-07,
+    "output_cost_per_token": 1.2e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "ft:o4-mini-2025-04-16": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
+    "input_cost_per_token": 4e-06,
+    "output_cost_per_token": 1.6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-3.5-turbo": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
+    "input_cost_per_token": 5e-07,
+    "output_cost_per_token": 1.5e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-3.5-turbo-0125": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
+    "input_cost_per_token": 5e-07,
+    "output_cost_per_token": 1.5e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-3.5-turbo-1106": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000002,
+    "input_cost_per_token": 1e-06,
+    "output_cost_per_token": 2e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-3.5-turbo-16k": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000004,
+    "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4": {
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 3e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-0125-preview": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-0314": {
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 3e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-0613": {
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 3e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-1106-preview": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-turbo": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-turbo-2024-04-09": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4-turbo-preview": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
+    "input_cost_per_token": 2e-06,
+    "output_cost_per_token": 8e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1-2025-04-14": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
+    "input_cost_per_token": 2e-06,
+    "output_cost_per_token": 8e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1-mini": {
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
+    "input_cost_per_token": 4e-07,
+    "output_cost_per_token": 1.6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1-mini-2025-04-14": {
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
+    "input_cost_per_token": 4e-07,
+    "output_cost_per_token": 1.6e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1-nano": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
+    "input_cost_per_token": 1e-07,
+    "output_cost_per_token": 4e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4.1-nano-2025-04-14": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
+    "input_cost_per_token": 1e-07,
+    "output_cost_per_token": 4e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-2024-05-13": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-2024-08-06": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-2024-11-20": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-audio-preview": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-audio-preview-2024-12-17": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-audio-preview-2025-06-03": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-2024-07-18": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-audio-preview": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-audio-preview-2024-12-17": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-realtime-preview": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-search-preview": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-realtime-preview": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-realtime-preview-2025-06-03": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 2e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-search-preview": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-4o-search-preview-2025-03-11": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-2025-08-07": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-chat": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-chat-latest": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-mini": {
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
+    "input_cost_per_token": 2.5e-07,
+    "output_cost_per_token": 2e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-mini-2025-08-07": {
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
+    "input_cost_per_token": 2.5e-07,
+    "output_cost_per_token": 2e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-nano": {
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 4e-7,
+    "input_cost_per_token": 5e-08,
+    "output_cost_per_token": 4e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-nano-2025-08-07": {
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 4e-7,
+    "input_cost_per_token": 5e-08,
+    "output_cost_per_token": 4e-07,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-search-api": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5-search-api-2025-10-14": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.1": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.1-2025-11-13": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.1-chat-latest": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 1.25e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.2": {
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
+    "input_cost_per_token": 1.75e-06,
+    "output_cost_per_token": 1.4e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.2-2025-12-11": {
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
+    "input_cost_per_token": 1.75e-06,
+    "output_cost_per_token": 1.4e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.2-chat-latest": {
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
+    "input_cost_per_token": 1.75e-06,
+    "output_cost_per_token": 1.4e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.3-chat-latest": {
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
+    "input_cost_per_token": 1.75e-06,
+    "output_cost_per_token": 1.4e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4-2026-03-05": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1.5e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4-mini": {
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
+    "input_cost_per_token": 7.5e-07,
+    "output_cost_per_token": 4.5e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4-mini-2026-03-17": {
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
+    "input_cost_per_token": 7.5e-07,
+    "output_cost_per_token": 4.5e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4-nano": {
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
+    "input_cost_per_token": 2e-07,
+    "output_cost_per_token": 1.25e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.4-nano-2026-03-17": {
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
+    "input_cost_per_token": 2e-07,
+    "output_cost_per_token": 1.25e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.5": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-5.5-2026-04-23": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
+    "input_cost_per_token": 5e-06,
+    "output_cost_per_token": 3e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio-1.5": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio-2025-08-28": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
+    "input_cost_per_token": 2.5e-06,
+    "output_cost_per_token": 1e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio-mini-2025-10-06": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-audio-mini-2025-12-15": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
+    "input_cost_per_token": 4e-06,
+    "output_cost_per_token": 1.6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-1.5": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
+    "input_cost_per_token": 4e-06,
+    "output_cost_per_token": 1.6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-2": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
+    "input_cost_per_token": 4e-06,
+    "output_cost_per_token": 1.6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-2025-08-28": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
+    "input_cost_per_token": 4e-06,
+    "output_cost_per_token": 1.6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-mini-2025-10-06": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "gpt-realtime-mini-2025-12-15": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
+    "input_cost_per_token": 6e-07,
+    "output_cost_per_token": 2.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o1": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o1-2024-12-17": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
+    "input_cost_per_token": 1.5e-05,
+    "output_cost_per_token": 6e-05,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o3": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
+    "input_cost_per_token": 2e-06,
+    "output_cost_per_token": 8e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o3-2025-04-16": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
+    "input_cost_per_token": 2e-06,
+    "output_cost_per_token": 8e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o3-mini": {
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
+    "input_cost_per_token": 1.1e-06,
+    "output_cost_per_token": 4.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o3-mini-2025-01-31": {
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
+    "input_cost_per_token": 1.1e-06,
+    "output_cost_per_token": 4.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o4-mini": {
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
+    "input_cost_per_token": 1.1e-06,
+    "output_cost_per_token": 4.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "o4-mini-2025-04-16": {
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
+    "input_cost_per_token": 1.1e-06,
+    "output_cost_per_token": 4.4e-06,
     "litellm_provider": "openai",
     "mode": "chat"
   },
   "text-embedding-3-large": {
-    "input_cost_per_token": 1.3e-7,
+    "input_cost_per_token": 1.3e-07,
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
   },
   "text-embedding-3-small": {
-    "input_cost_per_token": 2e-8,
+    "input_cost_per_token": 2e-08,
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
   },
   "text-embedding-ada-002": {
-    "input_cost_per_token": 1e-7,
+    "input_cost_per_token": 1e-07,
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
   },
   "text-embedding-ada-002-v2": {
-    "input_cost_per_token": 1e-7,
+    "input_cost_per_token": 1e-07,
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
+  },
+  "llama-3.1-8b-instant": {
+    "input_cost_per_token": 5e-08,
+    "output_cost_per_token": 8e-08,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "llama-3.3-70b-versatile": {
+    "input_cost_per_token": 5.9e-07,
+    "output_cost_per_token": 7.9e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input_cost_per_token": 1.1e-07,
+    "output_cost_per_token": 3.4e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "qwen/qwen3-32b": {
+    "input_cost_per_token": 2.9e-07,
+    "output_cost_per_token": 5.9e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
   }
 }

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -784,5 +784,17 @@
     "output_cost_per_token": 5.9e-07,
     "litellm_provider": "groq",
     "mode": "chat"
+  },
+  "llama-4-scout-17b-16e-instruct": {
+    "input_cost_per_token": 1.1e-07,
+    "output_cost_per_token": 3.4e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "qwen3-32b": {
+    "input_cost_per_token": 2.9e-07,
+    "output_cost_per_token": 5.9e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
   }
 }

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -760,5 +760,29 @@
     "output_cost_per_token": 5.9e-07,
     "litellm_provider": "groq",
     "mode": "chat"
+  },
+  "groq/llama-3.1-8b-instant": {
+    "input_cost_per_token": 5e-08,
+    "output_cost_per_token": 8e-08,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "groq/llama-3.3-70b-versatile": {
+    "input_cost_per_token": 5.9e-07,
+    "output_cost_per_token": 7.9e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "input_cost_per_token": 1.1e-07,
+    "output_cost_per_token": 3.4e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "groq/qwen/qwen3-32b": {
+    "input_cost_per_token": 2.9e-07,
+    "output_cost_per_token": 5.9e-07,
+    "litellm_provider": "groq",
+    "mode": "chat"
   }
 }

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -760,41 +760,5 @@
     "output_cost_per_token": 5.9e-07,
     "litellm_provider": "groq",
     "mode": "chat"
-  },
-  "groq/llama-3.1-8b-instant": {
-    "input_cost_per_token": 5e-08,
-    "output_cost_per_token": 8e-08,
-    "litellm_provider": "groq",
-    "mode": "chat"
-  },
-  "groq/llama-3.3-70b-versatile": {
-    "input_cost_per_token": 5.9e-07,
-    "output_cost_per_token": 7.9e-07,
-    "litellm_provider": "groq",
-    "mode": "chat"
-  },
-  "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
-    "input_cost_per_token": 1.1e-07,
-    "output_cost_per_token": 3.4e-07,
-    "litellm_provider": "groq",
-    "mode": "chat"
-  },
-  "groq/qwen/qwen3-32b": {
-    "input_cost_per_token": 2.9e-07,
-    "output_cost_per_token": 5.9e-07,
-    "litellm_provider": "groq",
-    "mode": "chat"
-  },
-  "llama-4-scout-17b-16e-instruct": {
-    "input_cost_per_token": 1.1e-07,
-    "output_cost_per_token": 3.4e-07,
-    "litellm_provider": "groq",
-    "mode": "chat"
-  },
-  "qwen3-32b": {
-    "input_cost_per_token": 2.9e-07,
-    "output_cost_per_token": 5.9e-07,
-    "litellm_provider": "groq",
-    "mode": "chat"
   }
 }

--- a/tests/test_langchain_groq_adapter.py
+++ b/tests/test_langchain_groq_adapter.py
@@ -1,0 +1,113 @@
+"""LangChain adapter tests for ChatGroq's token-usage shape.
+
+ChatGroq surfaces token counts via ``usage_metadata`` on the message
+(``input_tokens`` / ``output_tokens``) rather than the ``token_usage`` block
+OpenAI uses. These tests confirm the adapter's existing fallback handles it
+and verify the full allow → record → block lifecycle.
+
+Parsing helper tests run without a real API key or langchain install.
+Handler tests require ``langchain_core`` and are skipped without it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from floe_guard import BudgetExceeded, BudgetGuard
+from floe_guard.integrations.langchain import (
+    _model_from_result,
+    _record_result,
+    _usage_from_result,
+    budget_guard_callback_handler,
+)
+
+# Minimal stubs that mirror ChatGroq's LLMResult shape
+
+@dataclass
+class _Msg:
+    usage_metadata: dict
+
+
+@dataclass
+class _Gen:
+    message: _Msg
+
+
+@dataclass
+class _Result:
+    llm_output: dict | None = None
+    generations: list = field(default_factory=list)
+
+
+def _groq_result(
+    input_tokens: int, output_tokens: int, model: str = "llama-3.1-8b-instant"
+) -> _Result:
+    """Build a stub LLMResult in the shape ChatGroq emits.
+
+    ChatGroq sets ``model`` (not ``model_name``) in ``llm_output`` and surfaces
+    token counts via ``usage_metadata`` on the message rather than via a
+    ``token_usage`` block — the provider-agnostic shape.
+    """
+    return _Result(
+        llm_output={"model": model},
+        generations=[
+            [_Gen(_Msg({"input_tokens": input_tokens, "output_tokens": output_tokens}))]
+        ],
+    )
+
+
+# Parsing helpers — no langchain install required
+
+
+def test_model_from_groq_result() -> None:
+    # ChatGroq uses the key "model", not "model_name".
+    assert _model_from_result(_groq_result(5, 7)) == "llama-3.1-8b-instant"
+
+
+def test_usage_from_groq_result_via_usage_metadata() -> None:
+    # Token counts come from usage_metadata, not token_usage.
+    assert _usage_from_result(_groq_result(5, 7)) == (5, 7)
+
+
+def test_record_groq_result_accrues() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    # llama-3.1-8b-instant: $0.05/M prompt, $0.08/M completion
+    _record_result(guard, _groq_result(1_000, 1_000))
+    assert guard.spent_usd > 0.0
+
+
+def test_zero_usage_groq_result_is_noop() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    _record_result(guard, _groq_result(0, 0))
+    assert guard.spent_usd == 0.0
+
+
+
+# Full handler lifecycle — requires langchain_core
+
+
+def test_handler_allows_groq_call_under_budget_and_records() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0)
+    handler = budget_guard_callback_handler(guard)
+
+    handler.on_chat_model_start({}, [[]])  # under budget — no raise
+    handler.on_llm_end(_groq_result(1_000, 1_000))
+    assert guard.spent_usd > 0.0
+
+
+def test_handler_blocks_groq_call_before_crossing() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=0.0002)
+    handler = budget_guard_callback_handler(guard)
+
+    # First call goes through and primes _last_cost.
+    handler.on_chat_model_start({}, [[]])
+    handler.on_llm_end(_groq_result(1_000, 1_000))
+    assert guard.spent_usd > 0.0
+
+    # Second call's projected cost would cross the ceiling.
+    with pytest.raises(BudgetExceeded):
+        handler.on_chat_model_start({}, [[]])


### PR DESCRIPTION
Groq has no entries in the cost map yet  this adds the 4 current production models,
prices pulled from Groq's docs today (June 2026):

- `llama-3.1-8b-instant` - $0.05/$0.08 per 1M tokens
- `llama-3.3-70b-versatile` -$0.59/$0.79 per 1M tokens
- `meta-llama/llama-4-scout-17b-16e-instruct` - $0.11/$0.34 per 1M tokens
- `qwen/qwen3-32b` -$0.29/$0.59 per 1M tokens

Also includes a `ChatGroq` example and tests confirming the adapter's
`usage_metadata` fallback works with Groq's token-usage shape.

83 tests pass, ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Groq/LangChain example demonstrating strict USD spending limits and automatic request blocking when the budget is exceeded.

* **Bug Fixes**
  * Improved spend tracking for Groq Chat responses by correctly interpreting Groq-style usage metadata for token accounting.
  * Added pricing entries for additional Groq models to ensure more accurate cost calculations during budget checks.

* **Tests**
  * Added coverage for Groq LangChain adapter parsing, budget recording behavior, and budget-exceeded blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->