### PR TITLE
release: py 0.2.0 / js 0.2.1 — Groq pricing, reliable CrewAI hard-stop, gated publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install --upgrade pip
       # Install the framework extras so the adapter handler tests actually run
-      # (instead of skipping). langchain-core covers the LangChain handler tests.
-      - run: pip install -e ".[dev,langchain]"
+      # (instead of skipping). langchain-core covers the LangChain handler
+      # tests; litellm covers the callback-swallowing regression tests (the
+      # CrewAI adapter tests stub crewai itself, so the heavy extra stays out).
+      - run: pip install -e ".[dev,langchain,litellm]"
       - name: Pytest
         run: pytest -q
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,12 +1,13 @@
 name: Publish to npm
 
+# Runs after the full CI workflow succeeds on main (not on the raw push), so a
+# red lint/cost-map-sync/python job blocks an npm release too. The old js/**
+# path filter is gone; the version gate below already makes no-op runs cheap.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
-    # The npm package lives in js/; only publish when it (or this workflow) changes.
-    paths:
-      - 'js/**'
-      - '.github/workflows/publish-npm.yml'
   workflow_dispatch:
 
 concurrency:
@@ -14,11 +15,20 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write # push the release tag; npm auth stays the token secret
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
+    # workflow_run's `branches` filter matches the HEAD branch NAME of the
+    # triggering run — a fork PR from a branch named "main" would match it. The
+    # event/head_repository checks restrict publishing to push-triggered CI on
+    # this repo's own main.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -28,6 +38,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+          # workflow_run checks out the default branch by default; pin to the
+          # exact commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -69,3 +82,16 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag the release
+        # Maps the published artifact back to its exact commit ("js-" prefix:
+        # the PyPI package versions independently and tags "py-v<version>").
+        if: steps.check.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PKG_VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/js-v$PKG_VERSION" \
+            -f sha="$(git rev-parse HEAD)" \
+            || echo "::warning::tag js-v$PKG_VERSION already exists or could not be created"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,12 @@
 name: Publish to PyPI
 
+# Runs after the full CI workflow (lint, python matrix, cost-map-sync, js)
+# succeeds on main — not on the raw push. npm 0.2.0 once shipped while main CI
+# was red on cost-map-sync; gating on workflow_run closes that hole.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -10,17 +15,29 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write # push the release tag; PyPI auth stays the token secret
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
+    # workflow_run's `branches` filter matches the HEAD branch NAME of the
+    # triggering run — a fork PR from a branch named "main" would match it. The
+    # event/head_repository checks restrict publishing to push-triggered CI on
+    # this repo's own main.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+          # workflow_run checks out the default branch by default; pin to the
+          # exact commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -77,3 +94,16 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Tag the release
+        # Maps the published artifact back to its exact commit ("py-" prefix:
+        # the npm package versions independently and tags "js-v<version>").
+        if: steps.check.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PKG_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/py-v$PKG_VERSION" \
+            -f sha="$(git rev-parse HEAD)" \
+            || echo "::warning::tag py-v$PKG_VERSION already exists or could not be created"

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,66 @@
+name: Version Guard
+
+# Publishing is version-gated on main, so a source change merged without a
+# version bump silently never ships — that is exactly how PyPI fell 3.5 weeks
+# behind the repo. Fail the PR instead, unless the change is deliberately
+# unreleased (apply the skip-version-guard label).
+#
+# Lives in its own workflow (not ci.yml) so the labeled/unlabeled trigger types
+# — needed for the skip label to re-evaluate without a manual re-run — don't
+# re-run and cancel the whole CI matrix on every label change.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: version-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  version-guard:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-version-guard') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          # The checkout is refs/pull/N/merge — a synthetic merge commit whose
+          # first parent is the CURRENT base tip. Depth 2 makes HEAD^1
+          # resolvable; comparing against it (rather than the event's
+          # pull_request.base.sha snapshot, which goes stale as the base moves)
+          # means a release merged to main after the PR opened still counts.
+          fetch-depth: 2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.13'
+      - name: Require a version bump when package source changes
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only HEAD^1 HEAD)
+          fail=0
+
+          # pyproject.toml is included: dependency/extras changes alter the
+          # shipped artifact just like src changes do.
+          if echo "$changed" | grep -q '^\(src/floe_guard/\|pyproject\.toml\)'; then
+            old=$(git show "HEAD^1:pyproject.toml" | python -c "import sys,tomllib;print(tomllib.loads(sys.stdin.read())['project']['version'])")
+            new=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+            if [ "$old" = "$new" ]; then
+              echo "::error::Python package source or packaging metadata changed but pyproject.toml version is still $new — bump it (or label the PR skip-version-guard)."
+              fail=1
+            fi
+          fi
+
+          if echo "$changed" | grep -q '^js/\(src/\|package\.json\)'; then
+            old=$(git show "HEAD^1:js/package.json" | python -c "import sys,json;print(json.loads(sys.stdin.read())['version'])")
+            new=$(python -c "import json;print(json.load(open('js/package.json'))['version'])")
+            if [ "$old" = "$new" ]; then
+              echo "::error::js package source or packaging metadata changed but js/package.json version is still $new — bump it (or label the PR skip-version-guard)."
+              fail=1
+            fi
+          fi
+
+          exit "$fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,83 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-## js 0.2.0 — 2026-07-08
+## py 0.2.0 / js 0.2.1 — 2026-07-10
+
+Everything the repo grew between the 0.1.0 uploads and this release ships here —
+the earlier revision of this changelog misattributed several of these features
+to the py 0.1.0 entry; that entry now reflects what the released artifact
+actually contained.
+
+### Added (py)
+
+- **Concurrency-safe enforcement**: atomic `reserve()` / `settle()` /
+  `release()` with a lock-guarded running total, closing the
+  check-then-record race that let parallel callers blow the ceiling
+  (issue #18). `check()` / `record()` are unchanged for sequential use.
+- **Context-aware budgeting**: `BudgetGuard.advisory()` returning a
+  `BudgetAdvisory` (`near_limit`, `used_bps`, `remaining_usd`, totals), with a
+  `near_limit_bps` constructor threshold (default 8000 = 80%).
+- **Adapters**: LangChain (`budget_guard_callback_handler`), OpenAI
+  (`guarded_completion` / `guarded_acompletion`), and Anthropic (same pair,
+  with cache-token metering) — each behind an optional extra
+  (`[langchain]`, `[openai]`, `[anthropic]`).
+- **Hosted budget read**: `hosted_remaining_usd()` (GET
+  `/v1/agents/credit-remaining`, opt-in via `FLOE_API_KEY`, host override via
+  `FLOE_API_BASE_URL`), `HostedEnforcementError`, and package-root export of
+  `hosted_enforcement_available()`. This is the package's only network call
+  and never runs unless you set the key.
+
+### Added (py + js)
+
+- **Groq pricing**: curated Groq models vendored in the cost map —
+  `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`,
+  `meta-llama/llama-4-scout-17b-16e-instruct`, `qwen/qwen3-32b` (new for py;
+  these four already shipped in js 0.2.0), plus the current production lineup
+  `openai/gpt-oss-120b`, `openai/gpt-oss-20b`, `openai/gpt-oss-safeguard-20b`
+  (new for both packages). Kept as an explicit allowlist
+  (`scripts/update-cost-map.mjs`) so generic multi-provider names stay
+  fail-closed instead of under-metering.
+- **Smarter model-id resolution** (both packages, identical logic): lookup
+  candidates are tried most-specific-first — the raw id, the id with a known
+  `openai/` / `anthropic/` / `groq/` first segment stripped (so
+  `groq/qwen/qwen3-32b` and ChatGroq's `qwen/qwen3-32b` hit the same entry),
+  then the bare last segment; each also with a trailing dated-snapshot suffix
+  removed, so an unlisted snapshot like `claude-opus-4-8-<date>` prices at its
+  alias entry instead of failing closed. Unknown provider prefixes are
+  deliberately not bridged.
+- Cost-map refresh adds `claude-sonnet-5` (both packages; the py package also
+  gains `claude-fable-5`, which already shipped in js 0.2.0 —
+  `claude-opus-4-8` and `claude-sonnet-4-6` shipped in the 0.1.0 maps) and
+  warns when a curated Groq model disappears upstream instead of silently
+  dropping it.
+
+### Fixed (py)
+
+- **CrewAI / LiteLLM-callback silent footgun**: LiteLLM runs custom-logger
+  hooks inside `except Exception`, so the callback's enforcement raise
+  (pre-call `BudgetExceeded`, fail-closed `UnpriceableModelError`) could be
+  swallowed and a crew kept running unmetered with no visible signal. The
+  callback now records the violation on its `tripped` attribute and logs it at
+  ERROR level on the `floe_guard` logger, and
+  `budget_guarded_llm` returns a `crewai.LLM` subclass that re-raises
+  `tripped` and runs `check()` in the call path — outside LiteLLM — so the
+  crew hard-stops at the next call. `guard_crew` now returns the registered
+  callback (previously `None`) and reuses an existing registration for the
+  same guard.
+
+### Changed (py + js)
+
+- Price lookup order is now most-specific-first (raw id before stripped
+  forms) for both `price_overrides` and the cost map. Previously the bare name
+  was tried before the raw id.
+
+## js 0.2.0 — published 2026-07-10
 
 ### Added
 
+- Curated Groq cost-map entries: `llama-3.1-8b-instant`,
+  `llama-3.3-70b-versatile`, `meta-llama/llama-4-scout-17b-16e-instruct`,
+  `qwen/qwen3-32b`, plus `claude-fable-5`.
 - **Vercel AI SDK v5 support.** The middleware now works with both `ai@4`
   (`LanguageModelV1Middleware`, `promptTokens`/`completionTokens`) and `ai@5`
   (`LanguageModelV2Middleware`, `inputTokens`/`outputTokens`) from a single
@@ -30,18 +103,18 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## py 0.1.0 / js 0.1.0 — 2026-06
 
-Initial public release.
+Initial public releases (PyPI 2026-06-15, npm 2026-06-16).
 
-- `BudgetGuard` with `check()` / `record()`, concurrency-safe
-  `reserve()` / `settle()` / `release()`, and `advisory()` for context-aware
-  budgeting (taper before the hard-stop).
-- Offline pricing from a vendored LiteLLM cost map; unpriceable models fail
-  closed (`UnpriceableModelError`) with manual `price_overrides` as the
-  escape hatch.
-- Python adapters: CrewAI, LiteLLM, LangChain, OpenAI, Anthropic — each behind
-  an optional extra; the core stays dependency-free.
+- `BudgetGuard` with `check()` / `record()` (sequential; the atomic
+  reservation API landed in py 0.2.0).
+- Offline pricing from a vendored LiteLLM cost map covering OpenAI and
+  Anthropic; unpriceable models fail closed (`UnpriceableModelError`) with
+  manual `price_overrides` as the escape hatch.
+- Python adapters: CrewAI and LiteLLM, behind optional extras; the core stays
+  dependency-free. (The LangChain, OpenAI, and Anthropic adapters landed in
+  py 0.2.0.)
+- Hosted-Floe hook as a stub (`hosted_enforcement_available()` under
+  `floe_guard.hosted`); this release performs no network calls of any kind.
 - TypeScript package (`js/`) with Vercel AI SDK middleware
   (`budgetGuardMiddleware`), verified against `ai@4`.
-- Optional hosted-Floe budget read (`hosted_remaining_usd()`) via
-  `FLOE_API_KEY` — the only network call in the package, opt-in.
 - No runtime telemetry of any kind.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ guard = BudgetGuard(
 # or, set fail_closed=False to warn-and-skip for models you accept un-metered.
 ```
 
+### What the bundled map prices
+
+The vendored map deliberately covers **OpenAI, Anthropic, and a curated set of
+Groq models** (the allowlist lives in
+[`scripts/update-cost-map.mjs`](scripts/update-cost-map.mjs)) — not all of
+LiteLLM's upstream list. Generic open-weights names (`qwen3-32b`,
+`gpt-oss-120b`) are served by many vendors at very different prices, so
+resolving them at one vendor's rate would under-meter a spend guard; they stay
+unpriceable unless you scope them (`groq/…`) or pass a manual price.
+
+Model ids resolve flexibly: provider-prefixed forms work
+(`openai/gpt-4o`, `groq/qwen/qwen3-32b` and the ChatGroq `qwen/qwen3-32b` both
+hit the same entry), and a dated snapshot the map doesn't list yet
+(`claude-opus-4-8-<date>`) prices at its alias entry instead of failing closed.
+Everything else — Gemini, Mistral, Cohere, Ollama, Bedrock, self-hosted —
+needs `price_overrides` (or `fail_closed=False` to accept it un-metered).
+
 ## Context-aware budgeting
 
 The hard-stop is the guarantee; `advisory()` is the *upside*. Read it before a
@@ -142,17 +159,26 @@ pip install floe-guard[crewai]
 ```
 
 ```python
-from crewai import Crew
+from crewai import Agent, Crew
 from floe_guard import BudgetGuard
-from floe_guard.integrations.crewai import guard_crew
+from floe_guard.integrations.crewai import budget_guarded_llm
 
 guard = BudgetGuard(limit_usd=1.00)
-guard_crew(guard)              # one line — enforces across the whole crew
-Crew(agents=[...], tasks=[...]).kickoff()
+llm = budget_guarded_llm(guard, "gpt-4o")   # meters AND hard-stops
+Crew(agents=[Agent(..., llm=llm)], tasks=[...]).kickoff()
 ```
 
-CrewAI runs on LiteLLM, so one callback caps every agent and task under a single
-budget.
+CrewAI runs on LiteLLM, so one callback meters every agent and task under a
+single budget. Use `budget_guarded_llm` (not just `guard_crew`) to get the hard
+stop: LiteLLM can swallow exceptions raised inside its callbacks (verified on
+litellm 1.91.x), so a callback alone may keep the crew running past a
+violation. `budget_guarded_llm` also enforces in the LLM call path — where a
+raise reliably reaches CrewAI — re-raising any violation the callback recorded
+before the next call runs. `guard_crew(guard)` remains available for metering
+existing crews; check the returned callback's `tripped` attribute (and the
+`floe_guard` logger's ERROR output) if you use it alone. A recorded violation
+latches for the life of the callback — after remediating (say, adding a price
+override), call `callback.reset()` or build a fresh guard.
 
 ### LiteLLM
 
@@ -169,7 +195,12 @@ response = guarded_completion(guard, model="gpt-4o", messages=[...])
 ```
 
 Prefer the LiteLLM-native callback? Register `budget_guard_callback(guard)` on
-`litellm.callbacks`.
+`litellm.callbacks` — but know its limit: LiteLLM runs callbacks inside
+`except Exception`, so the callback's enforcement raise can be swallowed and
+your loop keeps going. The callback records any violation on its `tripped`
+attribute and logs it at ERROR level; consult `tripped` in your own loop, or
+use `guarded_completion` (which enforces at the call site) for the guaranteed
+stop. Wrapper enforcement is tested against litellm 1.91.x.
 
 ### LangChain
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "ai": "^4.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -137,6 +137,12 @@
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
+  "claude-sonnet-5": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
   "ft:gpt-3.5-turbo": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000006,
@@ -587,6 +593,30 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "gpt-5.6": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-luna": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-sol": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-terra": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
   "gpt-audio": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
@@ -638,6 +668,18 @@
   "gpt-realtime-2": {
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2.1": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2.1-mini": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
     "litellm_provider": "openai",
     "mode": "chat"
   },
@@ -729,6 +771,24 @@
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-120b": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-20b": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-safeguard-20b": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "groq",
     "mode": "chat"
   },
   "qwen/qwen3-32b": {

--- a/js/src/pricing.ts
+++ b/js/src/pricing.ts
@@ -32,11 +32,58 @@ interface CostMapEntry {
 
 const COST_MAP = costMapJson as Record<string, CostMapEntry>;
 
-/** Strip an optional `provider/` prefix (LiteLLM convention, e.g. `openai/gpt-4o`). */
-function bareModel(model: string): string {
+/**
+ * The one `<provider>/` prefix that is safe to strip: the remainder of a
+ * `groq/…` id is the ChatGroq id the map vendors (e.g. `groq/qwen/qwen3-32b` →
+ * `qwen/qwen3-32b`). `openai/` and `anthropic/` are deliberately excluded:
+ * their own model ids never contain slashes (single-segment remainders are
+ * already covered by the bare-last-segment fallback), so a multi-segment
+ * remainder under those prefixes is some OTHER vendor's model behind an
+ * OpenAI-compatible endpoint (vLLM, OpenRouter, …) — bridging it into a
+ * Groq-priced key would under-meter. Unknown prefixes fail closed the same way.
+ */
+const PROVIDER_PREFIXES = new Set(["groq"]);
+
+/**
+ * A trailing dated-snapshot suffix: Anthropic's `-20250929` or OpenAI's
+ * `-2024-08-06`. Vendors resolve alias ids to dated snapshots in responses, so a
+ * snapshot the map doesn't list yet prices at its alias entry (same model, same
+ * rate) instead of failing closed. (`\d` is ASCII-only in JS; the Python regex
+ * uses re.ASCII to match.)
+ */
+const DATE_SUFFIX = /-(?:\d{8}|\d{4}-\d{2}-\d{2})$/;
+
+/**
+ * Lookup keys for a model id in two specificity groups, deduplicated.
+ *
+ * Group 1 (exact): the raw id, the id with a known `provider/` first segment
+ * stripped, the bare last segment. Group 2 (date-stripped): the same forms
+ * with a trailing dated-snapshot suffix removed. Kept separate so a
+ * less-specific date-stripped key (in overrides OR the map) can never shadow
+ * an exact dated entry — e.g. an alias override must not absorb a snapshot
+ * the map prices differently.
+ */
+function candidateGroups(model: string): [string[], string[]] {
   const m = model.trim();
-  const slash = m.lastIndexOf("/");
-  return slash === -1 ? m : m.slice(slash + 1);
+  const base = [m];
+  const firstSlash = m.indexOf("/");
+  if (firstSlash !== -1 && PROVIDER_PREFIXES.has(m.slice(0, firstSlash))) {
+    base.push(m.slice(firstSlash + 1));
+  }
+  const lastSlash = m.lastIndexOf("/");
+  if (lastSlash !== -1) {
+    base.push(m.slice(lastSlash + 1));
+  }
+  const exact: string[] = [];
+  for (const cand of base) {
+    if (cand && !exact.includes(cand)) exact.push(cand);
+  }
+  const stripped: string[] = [];
+  for (const cand of exact) {
+    const c = cand.replace(DATE_SUFFIX, "");
+    if (c && !exact.includes(c) && !stripped.includes(c)) stripped.push(c);
+  }
+  return [exact, stripped];
 }
 
 function bothFinite(a: unknown, b: unknown): boolean {
@@ -51,41 +98,53 @@ function bothFinite(a: unknown, b: unknown): boolean {
 /**
  * Resolve a model to its per-token price, or `null` if it cannot be priced.
  *
- * Overrides win, then the bundled cost map (looked up by bare name, then the raw
- * field). Fail-closed: both prices must be finite, else `null`.
+ * Per specificity group (exact forms first, date-stripped fallbacks second):
+ * overrides win, then the bundled cost map. Fail-closed: the first matching
+ * entry must have finite prices, else `null`.
  */
 export function resolvePrice(
   model: string,
   overrides?: Record<string, ManualPrice>,
 ): PricedModel | null {
-  const bare = bareModel(model);
-
-  if (overrides) {
-    const ov = overrides[bare] ?? overrides[model.trim()];
-    if (ov !== undefined) {
-      if (bothFinite(ov.inputCostPerToken, ov.outputCostPerToken)) {
-        return {
-          inputCostPerToken: ov.inputCostPerToken,
-          outputCostPerToken: ov.outputCostPerToken,
-          source: "override",
-        };
+  for (const cands of candidateGroups(model)) {
+    if (overrides) {
+      for (const cand of cands) {
+        // Own-property check so a key like "constructor" can't pull a function
+        // off Object.prototype and be treated as a price entry.
+        const ov = Object.prototype.hasOwnProperty.call(overrides, cand)
+          ? overrides[cand]
+          : undefined;
+        if (ov !== undefined) {
+          if (bothFinite(ov.inputCostPerToken, ov.outputCostPerToken)) {
+            return {
+              inputCostPerToken: ov.inputCostPerToken,
+              outputCostPerToken: ov.outputCostPerToken,
+              source: "override",
+            };
+          }
+          return null;
+        }
       }
-      return null;
+    }
+
+    for (const cand of cands) {
+      const entry = Object.prototype.hasOwnProperty.call(COST_MAP, cand)
+        ? COST_MAP[cand]
+        : undefined;
+      if (!entry) continue;
+
+      const input = entry.input_cost_per_token;
+      const output = entry.output_cost_per_token;
+      if (!bothFinite(input, output)) return null;
+
+      return {
+        inputCostPerToken: input as number,
+        outputCostPerToken: output as number,
+        source: "cost_map",
+      };
     }
   }
-
-  const entry = COST_MAP[bare] ?? COST_MAP[model.trim()];
-  if (!entry) return null;
-
-  const input = entry.input_cost_per_token;
-  const output = entry.output_cost_per_token;
-  if (!bothFinite(input, output)) return null;
-
-  return {
-    inputCostPerToken: input as number,
-    outputCostPerToken: output as number,
-    source: "cost_map",
-  };
+  return null;
 }
 
 /** USD cost for token usage. Negative counts are clamped to zero. */

--- a/js/test/pricing.test.ts
+++ b/js/test/pricing.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Pricing-resolution tests — kept in lockstep with tests/test_pricing.py so
+ * the two packages resolve identically (the cost map itself is byte-identical
+ * by CI guard; this covers the lookup logic).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { resolvePrice } from "../src/pricing";
+
+describe("resolvePrice", () => {
+  it("resolves a known model and its provider-prefixed form", () => {
+    const bare = resolvePrice("gpt-4o");
+    const prefixed = resolvePrice("openai/gpt-4o");
+    expect(bare).not.toBeNull();
+    expect(prefixed).not.toBeNull();
+    expect(prefixed!.inputCostPerToken).toBe(bare!.inputCostPerToken);
+  });
+
+  it("returns null for an unknown model", () => {
+    expect(resolvePrice("no-such-model-anywhere")).toBeNull();
+  });
+
+  it("bridges LiteLLM 'groq/<org>/<model>' ids to the vendored ChatGroq keys", () => {
+    for (const model of [
+      "groq/qwen/qwen3-32b",
+      "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+      "groq/openai/gpt-oss-120b",
+    ]) {
+      const priced = resolvePrice(model);
+      expect(priced, model).not.toBeNull();
+      const chatGroq = resolvePrice(model.slice("groq/".length));
+      expect(chatGroq, model).not.toBeNull();
+      expect(priced!.inputCostPerToken).toBe(chatGroq!.inputCostPerToken);
+    }
+  });
+
+  it("keeps bare multi-provider names unpriceable (anti-under-metering)", () => {
+    expect(resolvePrice("qwen3-32b")).toBeNull();
+    expect(resolvePrice("gpt-oss-120b")).toBeNull();
+  });
+
+  it("does not bridge unknown provider prefixes", () => {
+    expect(resolvePrice("fireworks_ai/qwen/qwen3-32b")).toBeNull();
+  });
+
+  it("does not bridge openai/ or anthropic/ prefixes into Groq-priced keys", () => {
+    // "openai/<model>" is LiteLLM's route for ANY OpenAI-compatible endpoint;
+    // a multi-segment remainder is some other vendor's model → fail closed.
+    expect(resolvePrice("openai/qwen/qwen3-32b")).toBeNull();
+    expect(resolvePrice("anthropic/qwen/qwen3-32b")).toBeNull();
+    expect(resolvePrice("openai/meta-llama/llama-4-scout-17b-16e-instruct")).toBeNull();
+  });
+
+  it("prices an unlisted dated snapshot at its alias entry", () => {
+    const alias = resolvePrice("claude-opus-4-8");
+    const dated = resolvePrice("claude-opus-4-8-20991231");
+    expect(alias).not.toBeNull();
+    expect(dated).not.toBeNull();
+    expect(dated!.inputCostPerToken).toBe(alias!.inputCostPerToken);
+    expect(resolvePrice("gpt-5.5-2099-01-01")).not.toBeNull();
+    expect(resolvePrice("anthropic/claude-sonnet-5-20991231")).not.toBeNull();
+  });
+
+  it("prefers an exact dated key over the alias fallback", () => {
+    const exact = resolvePrice("claude-sonnet-4-5-20250929");
+    expect(exact).not.toBeNull();
+    expect(exact!.source).toBe("cost_map");
+  });
+
+  it("matches overrides against the provider-stripped candidate", () => {
+    const priced = resolvePrice("groq/my-model", {
+      "my-model": { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+    });
+    expect(priced).not.toBeNull();
+    expect(priced!.source).toBe("override");
+  });
+
+  it("fails closed on a malformed override", () => {
+    expect(
+      resolvePrice("x", { x: { inputCostPerToken: NaN, outputCostPerToken: 1e-6 } }),
+    ).toBeNull();
+  });
+
+  it("does not let an alias override shadow an exact dated map entry", () => {
+    // gpt-4o-2024-05-13 has its own map entry at 2x the alias rate; an
+    // alias-keyed override is a less-specific match and must not absorb it.
+    const exact = resolvePrice("gpt-4o-2024-05-13");
+    expect(exact).not.toBeNull();
+    const priced = resolvePrice("gpt-4o-2024-05-13", {
+      "gpt-4o": { inputCostPerToken: 2.5e-6, outputCostPerToken: 1e-5 },
+    });
+    expect(priced!.source).toBe("cost_map");
+    expect(priced!.inputCostPerToken).toBe(exact!.inputCostPerToken);
+    // The override still wins for the alias itself and for unlisted snapshots.
+    expect(resolvePrice("gpt-4o", {
+      "gpt-4o": { inputCostPerToken: 1e-9, outputCostPerToken: 2e-9 },
+    })!.source).toBe("override");
+    expect(resolvePrice("gpt-4o-2099-01-01", {
+      "gpt-4o": { inputCostPerToken: 1e-9, outputCostPerToken: 2e-9 },
+    })!.source).toBe("override");
+  });
+
+  it("only strips ASCII-digit date suffixes (parity with Python's re.ASCII)", () => {
+    expect(resolvePrice("gpt-4o-٢٠٢٥٠١٠١")).toBeNull();
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.1.0"
+version = "0.2.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -26,11 +26,16 @@ const SOURCE_URL =
 // Providers floe-guard prices (matches the proxy's ROUTABLE_PROVIDERS).
 const ROUTABLE_PROVIDERS = new Set(["openai", "anthropic"]);
 
-// Curated Groq models, vendored under their slashless ChatGroq ids (upstream
-// keys them "groq/<id>"). Kept as an explicit allowlist rather than adding
-// "groq" to ROUTABLE_PROVIDERS: fully-generic bare names (e.g. "qwen3-32b")
-// are multi-provider, and pricing them at Groq's cheap rate would under-meter
-// a spend guard — unlisted models stay unpriceable and fail closed.
+// Curated Groq models, vendored under their ChatGroq ids (upstream keys them
+// "groq/<id>"; pricing.py/pricing.ts strip the known "groq/" prefix at lookup,
+// so both id conventions resolve). Kept as an explicit allowlist rather than
+// adding "groq" to ROUTABLE_PROVIDERS: fully-generic bare names (e.g.
+// "qwen3-32b") are multi-provider, and pricing them at Groq's cheap rate would
+// under-meter a spend guard — unlisted models stay unpriceable and fail closed.
+//
+// Groq deprecation schedule (keep entries until their shutdown date passes):
+//   qwen/qwen3-32b + meta-llama/llama-4-scout-17b-16e-instruct — 2026-07-17
+//   llama-3.1-8b-instant + llama-3.3-70b-versatile             — 2026-08-16
 const GROQ_KEY_MAP = new Map([
   ["groq/llama-3.1-8b-instant", "llama-3.1-8b-instant"],
   ["groq/llama-3.3-70b-versatile", "llama-3.3-70b-versatile"],
@@ -39,6 +44,13 @@ const GROQ_KEY_MAP = new Map([
     "meta-llama/llama-4-scout-17b-16e-instruct",
   ],
   ["groq/qwen/qwen3-32b", "qwen/qwen3-32b"],
+  // Current production lineup (gpt-oss-120b/20b are Groq's recommended
+  // replacements for the deprecating llamas). The "openai/" ChatGroq prefix is
+  // safe: OpenAI's own API does not serve gpt-oss, so the key can't collide
+  // with an OpenAI-routed id.
+  ["groq/openai/gpt-oss-120b", "openai/gpt-oss-120b"],
+  ["groq/openai/gpt-oss-20b", "openai/gpt-oss-20b"],
+  ["groq/openai/gpt-oss-safeguard-20b", "openai/gpt-oss-safeguard-20b"],
 ]);
 
 /**
@@ -72,6 +84,19 @@ const entries = Object.entries(raw)
   .filter(([k, v]) => isUsable(k, v))
   .map(([k, v]) => [GROQ_KEY_MAP.get(k) ?? k, v])
   .sort(([a], [b]) => a.localeCompare(b));
+
+// A curated Groq model that upstream dropped (or stopped fully pricing) would
+// otherwise vanish from the vendored map with no signal — the refresh PR diff
+// would just show a deletion. Warn so the reviewer knows the allowlist entry
+// stopped resolving (expected once Groq's shutdown dates pass; see above).
+const vendored = new Set(entries.map(([k]) => k));
+for (const [src, dest] of GROQ_KEY_MAP) {
+  if (!vendored.has(dest)) {
+    console.warn(
+      `WARNING: curated Groq model ${src} is missing or unpriceable upstream — dropped from the vendored map.`,
+    );
+  }
+}
 
 // null-prototype: model keys come from remote JSON, so a "__proto__" (or similar)
 // key is stored as plain data instead of mutating the object's prototype.

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -137,6 +137,12 @@
     "litellm_provider": "anthropic",
     "mode": "chat"
   },
+  "claude-sonnet-5": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
   "ft:gpt-3.5-turbo": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000006,
@@ -587,6 +593,30 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "gpt-5.6": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-luna": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000006,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-sol": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-5.6-terra": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
   "gpt-audio": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
@@ -638,6 +668,18 @@
   "gpt-realtime-2": {
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2.1": {
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000024,
+    "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "gpt-realtime-2.1-mini": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
     "litellm_provider": "openai",
     "mode": "chat"
   },
@@ -729,6 +771,24 @@
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-120b": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-20b": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "groq",
+    "mode": "chat"
+  },
+  "openai/gpt-oss-safeguard-20b": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "groq",
     "mode": "chat"
   },
   "qwen/qwen3-32b": {

--- a/src/floe_guard/integrations/crewai.py
+++ b/src/floe_guard/integrations/crewai.py
@@ -7,16 +7,20 @@ and free: it meters tokens against the bundled cost map and hard-stops the crew
 before the next LLM call crosses your ceiling.
 
 CrewAI calls ``litellm.completion`` under the hood for every agent step, so a
-single LiteLLM callback enforces the budget across the **whole crew** — every
-agent, every task — with no per-agent wiring.
+single LiteLLM callback meters the budget across the **whole crew** — every
+agent, every task — with no per-agent wiring. But LiteLLM can swallow
+exceptions raised inside its callbacks (see the litellm adapter's module
+docstring), so the callback alone cannot be trusted to *stop* the crew. Use
+:func:`budget_guarded_llm`, which also enforces in the call path — where a
+raise reliably reaches CrewAI:
 
     from crewai import Agent, Crew, Task
     from floe_guard import BudgetGuard
-    from floe_guard.integrations.crewai import guard_crew
+    from floe_guard.integrations.crewai import budget_guarded_llm
 
     guard = BudgetGuard(limit_usd=1.00)
-    guard_crew(guard)          # 1 line — enforces across the whole crew
-    Crew(agents=[...], tasks=[...]).kickoff()
+    llm = budget_guarded_llm(guard, "gpt-4o")   # meters + hard-stops
+    Crew(agents=[Agent(..., llm=llm)], tasks=[...]).kickoff()
 """
 
 from __future__ import annotations
@@ -37,12 +41,19 @@ def _require_crewai() -> Any:
     return crewai
 
 
-def guard_crew(guard: BudgetGuard) -> None:
-    """Enforce ``guard`` across every LLM call any CrewAI agent makes.
+def guard_crew(guard: BudgetGuard) -> Any:
+    """Meter ``guard`` across every LLM call any CrewAI agent makes.
 
-    Registers a LiteLLM callback (CrewAI runs on LiteLLM) that checks the budget
+    Registers a LiteLLM callback (CrewAI runs on LiteLLM) that reserves budget
     before each call and accrues spend after. Call once before ``kickoff()``.
     Idempotent for the same guard — re-registering will not double-count.
+
+    Returns the registered callback. **Blocking is best-effort on this path**:
+    LiteLLM can swallow the callback's enforcement raise (see the litellm
+    adapter docstring), in which case the violation is recorded on the returned
+    callback's ``tripped`` attribute and logged at ERROR level, but the crew
+    keeps running. :func:`budget_guarded_llm` closes that gap by re-raising
+    ``tripped`` in the call path, outside LiteLLM — prefer it.
     """
     try:
         import litellm
@@ -52,26 +63,69 @@ def guard_crew(guard: BudgetGuard) -> None:
             "Install: pip install floe-guard[crewai]"
         ) from e
 
-    callback = budget_guard_callback(guard)
     existing = list(getattr(litellm, "callbacks", None) or [])
-    # Drop any previously-installed floe-guard callback bound to this same guard
-    # so repeated calls don't stack duplicate accrual.
-    existing = [cb for cb in existing if getattr(cb, "guard", None) is not guard]
+    # Reuse a previously-installed floe-guard callback bound to this same guard:
+    # it keeps its in-flight reservations and tripped state, and any LLM wrapper
+    # already holding a reference to it stays live.
+    for cb in existing:
+        if getattr(cb, "guard", None) is guard:
+            return cb
+    callback = budget_guard_callback(guard)
     existing.append(callback)
     litellm.callbacks = existing
+    return callback
 
 
 def budget_guarded_llm(guard: BudgetGuard, model: str, **kwargs: Any) -> Any:
     """Return a ``crewai.LLM`` for ``model`` with ``guard`` enforced crew-wide.
 
-    Convenience over :func:`guard_crew`: builds the LLM you pass to your agents
-    and registers the budget callback in one step.
+    Metering runs through the same LiteLLM callback as :func:`guard_crew`;
+    enforcement additionally runs in the LLM's ``call`` / ``acall`` paths,
+    where a raise reliably propagates to CrewAI even when LiteLLM swallows
+    callback exceptions: before each call the LLM re-raises any violation the
+    callback recorded (``tripped``) and runs ``guard.check()``. A crew whose
+    spend crosses the ceiling — or that hits an unpriceable model with
+    ``fail_closed=True`` — stops at the next call instead of running unmetered.
+
+    A recorded violation latches: it persists for the life of the callback
+    (which :func:`guard_crew` reuses per guard) even if you later add a price
+    override or raise ``limit_usd``. After remediating, call
+    ``callback.reset()`` (the callback is on ``llm`` via :func:`guard_crew`'s
+    return value) or build a fresh ``BudgetGuard``.
     """
     _require_crewai()
     from crewai import LLM
 
-    guard_crew(guard)
-    return LLM(model, **kwargs)
+    callback = guard_crew(guard)
+
+    def _enforce() -> None:
+        tripped = callback.tripped
+        if tripped is not None:
+            # Drop the accumulated traceback: re-raising the same latched
+            # instance on every subsequent call would grow it unboundedly.
+            raise tripped.with_traceback(None)
+        guard.check()
+
+    class BudgetGuardedLLM(LLM):  # type: ignore[misc]
+        """``crewai.LLM`` that enforces the budget outside LiteLLM's callbacks."""
+
+        def call(self, *args: Any, **call_kwargs: Any) -> Any:
+            _enforce()
+            return super().call(*args, **call_kwargs)
+
+        async def acall(self, *args: Any, **call_kwargs: Any) -> Any:
+            # CrewAI 1.x async crews await acall(); without this override they
+            # would bypass enforcement entirely. Harmless on 0.x (never invoked).
+            _enforce()
+            return await super().acall(*args, **call_kwargs)
+
+    if "__new__" in vars(LLM):
+        # CrewAI >= 1.0: LLM.__new__ is a factory that can return a native
+        # provider-SDK instance, silently discarding this subclass AND
+        # bypassing LiteLLM (so the metering callback never fires). Force the
+        # LiteLLM route, which makes __new__ honor the subclass.
+        return BudgetGuardedLLM(model=model, is_litellm=True, **kwargs)
+    return BudgetGuardedLLM(model, **kwargs)
 
 
 __all__ = ["guard_crew", "budget_guarded_llm"]

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -16,14 +16,28 @@ Both reserve before the call and settle after, so the ceiling holds even when a
 crew fans calls out in parallel (issue #18) — not just on a single sequential
 loop. Every priced response routes through the same
 :class:`~floe_guard.BudgetGuard`.
+
+**Callback caveat.** LiteLLM runs custom-logger hooks inside ``except
+Exception`` blocks (verified on litellm 1.91.x), so an enforcement error raised
+*inside* the callback — the pre-call :class:`~floe_guard.BudgetExceeded` or a
+fail-closed :class:`~floe_guard.UnpriceableModelError` — can be swallowed and
+the run keeps going. The callback therefore also records the violation on its
+``tripped`` attribute and logs it at ERROR level; a caller that owns the call
+site (the wrapper functions here, or the CrewAI adapter's
+``budget_guarded_llm``) re-raises ``tripped`` *outside* LiteLLM before the next
+call, which is what actually hard-stops the loop.
 """
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import Any
 
+from ..errors import BudgetExceeded, UnpriceableModelError
 from ..guard import BudgetGuard
+
+_logger = logging.getLogger("floe_guard")
 
 
 def _require_litellm() -> Any:
@@ -123,6 +137,13 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
     the response's actual token cost, and ``log_failure_event`` releases the
     reservation. Reservations are keyed per call, so parallel crew calls each
     hold their own slice of the ceiling instead of racing one shared total.
+
+    LiteLLM may swallow exceptions raised inside these hooks (see the module
+    docstring), so an enforcement raise is also recorded on ``tripped`` and
+    logged at ERROR level. If you register the callback yourself, consult
+    ``callback.tripped`` in your own loop and stop when it is set — or use
+    :func:`guarded_completion` / the CrewAI adapter's ``budget_guarded_llm``,
+    which do that for you.
     """
     litellm = _require_litellm()
     from litellm.integrations.custom_logger import CustomLogger
@@ -131,6 +152,12 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
+            # The first enforcement violation (BudgetExceeded or fail-closed
+            # UnpriceableModelError). Survives LiteLLM swallowing the raise, so a
+            # call-path owner can re-raise it outside the callback machinery.
+            # Latches until reset() — a config change on the guard alone does
+            # not clear it.
+            self.tripped: Exception | None = None
             self._reservations: dict[Any, float] = {}
             self._rlock = threading.Lock()
 
@@ -141,8 +168,32 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
             call_id = (kwargs or {}).get("litellm_call_id") if isinstance(kwargs, dict) else None
             return call_id if call_id is not None else id(kwargs)
 
+        def _trip(self, exc: Exception) -> None:
+            with self._rlock:
+                if self.tripped is None:
+                    self.tripped = exc
+            _logger.error(
+                "floe-guard budget enforcement tripped inside a LiteLLM callback "
+                "(%s). LiteLLM may swallow this exception and keep the run going — "
+                "the guard re-raises it before the next call on the "
+                "guarded_completion / budget_guarded_llm paths.",
+                exc,
+            )
+
+        def reset(self) -> None:
+            """Clear a recorded violation after remediation (e.g. adding a
+            price override or raising ``limit_usd``) so the same guard and
+            callback can run again. The latch is deliberate — it is NOT
+            cleared by config changes on the guard itself."""
+            with self._rlock:
+                self.tripped = None
+
         def _hold(self, kwargs: Any) -> None:
-            reserved = self.guard.reserve()  # raises BudgetExceeded -> aborts the call
+            try:
+                reserved = self.guard.reserve()  # raises BudgetExceeded -> aborts the call
+            except BudgetExceeded as exc:
+                self._trip(exc)
+                raise
             with self._rlock:
                 self._reservations[self._key(kwargs)] = reserved
 
@@ -150,13 +201,20 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
             with self._rlock:
                 return self._reservations.pop(self._key(kwargs), 0.0)
 
+        def _settle(self, kwargs: Any, response_obj: Any) -> None:
+            try:
+                _record_response(self.guard, kwargs, response_obj, reserved=self._pop(kwargs))
+            except UnpriceableModelError as exc:
+                self._trip(exc)
+                raise
+
         def log_pre_api_call(self, model: Any, messages: Any, kwargs: Any) -> None:
             self._hold(kwargs)
 
         def log_success_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
         ) -> None:
-            _record_response(self.guard, kwargs, response_obj, reserved=self._pop(kwargs))
+            self._settle(kwargs, response_obj)
 
         def log_failure_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
@@ -169,7 +227,7 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         async def async_log_success_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any
         ) -> None:
-            _record_response(self.guard, kwargs, response_obj, reserved=self._pop(kwargs))
+            self._settle(kwargs, response_obj)
 
         async def async_log_failure_event(
             self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from dataclasses import dataclass
 from importlib import resources
 from typing import Any
@@ -44,11 +45,52 @@ def _load_cost_map() -> dict[str, Any]:
 _COST_MAP: dict[str, Any] = _load_cost_map()
 
 
-def _bare_model(model: str) -> str:
-    """Strip an optional ``provider/`` prefix (LiteLLM convention, e.g. ``openai/gpt-4o``)."""
+# The one "<provider>/" prefix that is safe to strip: the remainder of a
+# "groq/…" id is the ChatGroq id the map vendors (e.g. "groq/qwen/qwen3-32b" →
+# "qwen/qwen3-32b"). "openai/" and "anthropic/" are deliberately excluded:
+# their own model ids never contain slashes (single-segment remainders are
+# already covered by the bare-last-segment fallback), so a multi-segment
+# remainder under those prefixes is some OTHER vendor's model behind an
+# OpenAI-compatible endpoint (vLLM, OpenRouter, …) — bridging it into a
+# Groq-priced key would under-meter. Unknown prefixes fail closed the same way.
+_PROVIDER_PREFIXES = frozenset({"groq"})
+
+# A trailing dated-snapshot suffix: Anthropic's "-20250929" or OpenAI's
+# "-2024-08-06". Vendors resolve alias ids to dated snapshots in responses, so a
+# snapshot the map doesn't list yet prices at its alias entry (same model, same
+# rate) instead of failing closed. re.ASCII: TS "\d" is ASCII-only — a Unicode
+# digit suffix must not strip in one package and not the other.
+_DATE_SUFFIX = re.compile(r"-(?:\d{8}|\d{4}-\d{2}-\d{2})$", re.ASCII)
+
+
+def _candidate_groups(model: str) -> tuple[list[str], list[str]]:
+    """Lookup keys for a model id in two specificity groups, deduplicated.
+
+    Group 1 (exact): the raw id, the id with a known ``provider/`` first
+    segment stripped, the bare last segment. Group 2 (date-stripped): the same
+    forms with a trailing dated-snapshot suffix removed. Kept separate so a
+    less-specific date-stripped key (in overrides OR the map) can never shadow
+    an exact dated entry — e.g. an alias override must not absorb a snapshot
+    the map prices differently.
+    """
     m = model.strip()
+    base = [m]
+    first, _, rest = m.partition("/")
+    if rest and first in _PROVIDER_PREFIXES:
+        base.append(rest)
     slash = m.rfind("/")
-    return m if slash == -1 else m[slash + 1 :]
+    if slash != -1:
+        base.append(m[slash + 1 :])
+    exact: list[str] = []
+    for cand in base:
+        if cand and cand not in exact:
+            exact.append(cand)
+    stripped: list[str] = []
+    for cand in exact:
+        c = _DATE_SUFFIX.sub("", cand)
+        if c and c not in exact and c not in stripped:
+            stripped.append(c)
+    return exact, stripped
 
 
 def resolve_price(
@@ -57,34 +99,37 @@ def resolve_price(
 ) -> PricedModel | None:
     """Resolve a model to its per-token price, or ``None`` if it cannot be priced.
 
-    Overrides win, then the bundled cost map (looked up by bare name, then the
-    raw field). Fail-closed: both prices must be finite, else ``None``.
+    Per specificity group (exact forms first, date-stripped fallbacks second):
+    overrides win, then the bundled cost map. Fail-closed: the first matching
+    entry must have finite prices, else ``None``.
     """
-    bare = _bare_model(model)
+    for candidates in _candidate_groups(model):
+        if overrides:
+            for cand in candidates:
+                ov = overrides.get(cand)
+                if ov is not None:
+                    if _both_finite(ov.input_cost_per_token, ov.output_cost_per_token):
+                        return PricedModel(
+                            input_cost_per_token=ov.input_cost_per_token,
+                            output_cost_per_token=ov.output_cost_per_token,
+                            source="override",
+                        )
+                    return None
 
-    if overrides:
-        ov = overrides.get(bare) or overrides.get(model.strip())
-        if ov is not None:
-            if _both_finite(ov.input_cost_per_token, ov.output_cost_per_token):
-                return PricedModel(
-                    input_cost_per_token=ov.input_cost_per_token,
-                    output_cost_per_token=ov.output_cost_per_token,
-                    source="override",
-                )
-            return None
-
-    entry = _COST_MAP.get(bare) or _COST_MAP.get(model.strip())
-    if not entry:
-        return None
-    input_cost = entry.get("input_cost_per_token")
-    output_cost = entry.get("output_cost_per_token")
-    if not _both_finite(input_cost, output_cost):
-        return None
-    return PricedModel(
-        input_cost_per_token=float(input_cost),
-        output_cost_per_token=float(output_cost),
-        source="cost_map",
-    )
+        for cand in candidates:
+            entry = _COST_MAP.get(cand)
+            if not entry:
+                continue
+            input_cost = entry.get("input_cost_per_token")
+            output_cost = entry.get("output_cost_per_token")
+            if not _both_finite(input_cost, output_cost):
+                return None
+            return PricedModel(
+                input_cost_per_token=float(input_cost),
+                output_cost_per_token=float(output_cost),
+                source="cost_map",
+            )
+    return None
 
 
 def _both_finite(a: Any, b: Any) -> bool:

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -1,0 +1,214 @@
+"""CrewAI adapter tests — the callback-swallowing footgun must stay closed.
+
+LiteLLM runs custom-logger hooks inside ``except Exception`` (verified on
+litellm 1.91.x), so an enforcement error raised inside the callback can be
+swallowed and a crew keeps running unmetered. These tests simulate exactly that
+swallowing and assert the ``budget_guarded_llm`` call path still hard-stops.
+
+Needs litellm (the callback is a real ``CustomLogger``); crewai itself is
+stubbed so the suite doesn't depend on the heavy extra.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+litellm = pytest.importorskip("litellm")
+
+from floe_guard import (  # noqa: E402
+    BudgetExceeded,
+    BudgetGuard,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+from floe_guard.integrations.crewai import budget_guarded_llm, guard_crew  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_litellm_callbacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with no global callbacks and leaks none."""
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+
+@pytest.fixture(autouse=True)
+def _stub_crewai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A minimal crewai module: just the LLM class the adapter subclasses.
+
+    Mirrors CrewAI 0.x (no ``__new__`` factory); the 1.x factory behavior has
+    its own stub in the factory test below.
+    """
+
+    class LLM:
+        def __init__(self, model: str, **kwargs: Any) -> None:
+            self.model = model
+            self.kwargs = kwargs
+
+        def call(self, *args: Any, **kwargs: Any) -> str:
+            return "stub-response"
+
+        async def acall(self, *args: Any, **kwargs: Any) -> str:
+            return "stub-async-response"
+
+    stub = types.ModuleType("crewai")
+    stub.LLM = LLM  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "crewai", stub)
+
+
+def _swallow(fn: Any, *args: Any) -> None:
+    """Invoke a callback hook the way litellm's handler does: eat Exceptions."""
+    try:
+        fn(*args)
+    except Exception:
+        pass
+
+
+def _response(model: str) -> dict[str, Any]:
+    return {"model": model, "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
+
+
+def test_guard_crew_registers_once_and_returns_the_callback() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    cb1 = guard_crew(guard)
+    cb2 = guard_crew(guard)
+    assert cb1 is cb2
+    assert [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard] == [cb1]
+
+
+def test_unpriceable_model_hard_stops_next_call_despite_swallowed_settle(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The released-0.1.0 footgun: an unpriceable model's fail-closed raise dies
+    # inside litellm, spend stays $0, and the crew keeps running. The wrapper
+    # must now stop the NEXT call, outside litellm's callback machinery.
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "groq/brand-new-model-2099")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+
+    kwargs = {"litellm_call_id": "c1", "model": "groq/brand-new-model-2099"}
+    with pytest.warns(UnpriceableModelWarning):
+        _swallow(cb.log_success_event, kwargs, _response("groq/brand-new-model-2099"), None, None)
+
+    assert guard.spent_usd == 0.0  # the completed call itself went unmetered
+    assert isinstance(cb.tripped, UnpriceableModelError)
+    assert any(
+        r.name == "floe_guard" and r.levelname == "ERROR" for r in caplog.records
+    ), "the swallowed violation must be loud on the logging channel"
+    with pytest.raises(UnpriceableModelError):
+        llm.call("next step")
+
+
+def test_ceiling_hard_stops_next_call_despite_swallowed_pre_call_block() -> None:
+    # litellm also swallows the pre-call BudgetExceeded, so even a PRICED model
+    # never hard-stopped through the callback alone. The wrapper's call-path
+    # check must block once accrued spend crosses the ceiling.
+    guard = BudgetGuard(limit_usd=0.001)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+
+    # One completed call accrues past the ceiling (settle never blocks; check does).
+    _swallow(cb.log_success_event, {"litellm_call_id": "c1", "model": "gpt-4o"},
+             _response("gpt-4o"), None, None)
+    assert guard.spent_usd > guard.limit_usd
+
+    # The swallowed pre-call block of the runaway's next attempt.
+    _swallow(cb.log_pre_api_call, "gpt-4o", [], {"litellm_call_id": "c2", "model": "gpt-4o"})
+    assert isinstance(cb.tripped, BudgetExceeded)
+
+    with pytest.raises(BudgetExceeded):
+        llm.call("next step")
+
+
+def test_wrapper_passes_through_while_under_budget() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    assert llm.call("hello") == "stub-response"
+    assert llm.model == "gpt-4o"
+
+
+def test_acall_enforces_like_call() -> None:
+    # CrewAI 1.x async crews await acall(); it must not bypass enforcement.
+    import asyncio
+
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    assert asyncio.run(llm.acall("hello")) == "stub-async-response"
+
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+    cb.tripped = UnpriceableModelError("gpt-4o")
+    with pytest.raises(UnpriceableModelError):
+        asyncio.run(llm.acall("next step"))
+
+
+def test_tripped_reraise_does_not_accumulate_traceback() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+    cb.tripped = UnpriceableModelError("gpt-4o")
+
+    def frames() -> int:
+        with pytest.raises(UnpriceableModelError) as excinfo:
+            llm.call("hi")
+        n, tb = 0, excinfo.value.__traceback__
+        while tb is not None:
+            n, tb = n + 1, tb.tb_next
+        return n
+
+    # Re-raising the latched instance must not grow its traceback per call.
+    assert frames() == frames()
+
+
+def test_callback_reset_clears_the_latch() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+    cb.tripped = UnpriceableModelError("gpt-4o")
+    with pytest.raises(UnpriceableModelError):
+        llm.call("hi")
+    cb.reset()
+    assert cb.tripped is None
+    assert llm.call("hi") == "stub-response"
+
+
+def test_crewai_1x_new_factory_gets_forced_litellm_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # CrewAI >= 1.0: LLM.__new__ is a factory that can return a native
+    # provider-SDK instance, discarding the subclass (and bypassing LiteLLM
+    # entirely). The adapter must construct with is_litellm=True so the
+    # subclass — and the metering callback — survive.
+    class NativeLLM:
+        def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+            self.model = model
+
+        def call(self, *args: Any, **kwargs: Any) -> str:
+            return "native-unguarded"
+
+    class LLM:
+        def __new__(cls, *args: Any, **kwargs: Any):  # the 1.x factory
+            if not kwargs.get("is_litellm"):
+                return NativeLLM(**kwargs)
+            return super().__new__(cls)
+
+        def __init__(self, model: str | None = None, **kwargs: Any) -> None:
+            self.model = model
+            self.kwargs = kwargs
+
+        def call(self, *args: Any, **kwargs: Any) -> str:
+            return "stub-response"
+
+        async def acall(self, *args: Any, **kwargs: Any) -> str:
+            return "stub-async-response"
+
+    stub = types.ModuleType("crewai")
+    stub.LLM = LLM  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "crewai", stub)
+
+    guard = BudgetGuard(limit_usd=0.0)  # $0 ceiling: first call must block
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    assert type(llm).__name__ == "BudgetGuardedLLM"  # factory did not swap it out
+    with pytest.raises(BudgetExceeded):
+        llm.call("hi")

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -90,13 +90,18 @@ def test_model_from_prefers_response_then_kwargs() -> None:
 
 def test_settle_model_falls_back_to_priceable_alias() -> None:
     guard = BudgetGuard(limit_usd=10.0)
-    # Served snapshot isn't in the bundled cost map, but the requested alias is:
-    # settle on the alias so a stale map doesn't fail-closed an otherwise-priced call.
-    unpriced_served = _Response("gpt-4o-2099-01-01", _Usage(1, 1))
+    # Served id isn't priceable in any form (no dated suffix to strip, not in
+    # the map), but the requested alias is: settle on the alias so a stale map
+    # doesn't fail-closed an otherwise-priced call.
+    unpriced_served = _Response("gpt-4o-nonexistent-variant", _Usage(1, 1))
     assert _settle_model(guard, {"model": "gpt-4o"}, unpriced_served) == "gpt-4o"
     # Served id IS priceable → it wins (source of truth).
     priced_served = _Response("gpt-4o-2024-08-06", _Usage(1, 1))
     assert _settle_model(guard, {"model": "gpt-4o"}, priced_served) == "gpt-4o-2024-08-06"
+    # A dated snapshot the map doesn't list prices via its alias entry now, so
+    # the served id itself stays the settle model (same rate, truer id).
+    dated_served = _Response("gpt-4o-2099-01-01", _Usage(1, 1))
+    assert _settle_model(guard, {"model": "gpt-4o"}, dated_served) == "gpt-4o-2099-01-01"
 
 
 def test_record_response_accrues() -> None:

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -31,6 +31,96 @@ def test_unknown_model_is_unpriceable() -> None:
     assert resolve_price("no-such-model-anywhere") is None
 
 
+def test_groq_prefixed_multi_segment_ids_resolve() -> None:
+    # LiteLLM/CrewAI pass "groq/<org>/<model>"; the map vendors the ChatGroq id
+    # ("<org>/<model>"). Stripping the known "groq/" first segment must bridge
+    # the two conventions (previously only the exact ChatGroq form resolved).
+    for model in (
+        "groq/qwen/qwen3-32b",
+        "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+        "groq/openai/gpt-oss-120b",
+    ):
+        priced = resolve_price(model)
+        assert priced is not None, model
+        assert priced.source == "cost_map"
+        chatgroq_form = resolve_price(model.removeprefix("groq/"))
+        assert chatgroq_form is not None, model
+        assert priced.input_cost_per_token == chatgroq_form.input_cost_per_token
+
+
+def test_bare_multi_provider_names_stay_unpriceable() -> None:
+    # Deliberate: a fully-bare name like "qwen3-32b" is served by many providers
+    # at different prices; resolving it at Groq's cheap rate would under-meter.
+    assert resolve_price("qwen3-32b") is None
+    assert resolve_price("gpt-oss-120b") is None
+
+
+def test_unknown_provider_prefix_is_not_bridged() -> None:
+    # Only the groq/ prefix is stripped — another vendor serving the same
+    # open-weights model must not inherit Groq's price.
+    assert resolve_price("fireworks_ai/qwen/qwen3-32b") is None
+
+
+def test_openai_and_anthropic_prefixes_do_not_bridge_to_groq_keys() -> None:
+    # "openai/<model>" is LiteLLM's route for ANY OpenAI-compatible endpoint
+    # (vLLM, OpenRouter, …), so a multi-segment remainder under openai/ or
+    # anthropic/ is some other vendor's model and must fail closed — not price
+    # at the Groq rate of the vendored "qwen/qwen3-32b"-style keys.
+    assert resolve_price("openai/qwen/qwen3-32b") is None
+    assert resolve_price("anthropic/qwen/qwen3-32b") is None
+    assert resolve_price("openai/meta-llama/llama-4-scout-17b-16e-instruct") is None
+
+
+def test_dated_snapshot_falls_back_to_alias_price() -> None:
+    # Anthropic responses carry dated snapshot ids; a snapshot the map doesn't
+    # list yet must price at its alias entry instead of failing closed.
+    alias = resolve_price("claude-opus-4-8")
+    dated = resolve_price("claude-opus-4-8-20991231")
+    assert alias is not None and dated is not None
+    assert dated.input_cost_per_token == alias.input_cost_per_token
+    # OpenAI-style dashed dates, with and without a provider prefix.
+    assert resolve_price("gpt-5.5-2099-01-01") is not None
+    assert resolve_price("anthropic/claude-sonnet-5-20991231") is not None
+
+
+def test_exact_dated_key_wins_over_alias_fallback() -> None:
+    # A snapshot the map DOES list resolves via its own entry (raw id is the
+    # most-specific candidate), not the alias fallback.
+    exact = resolve_price("claude-sonnet-4-5-20250929")
+    assert exact is not None
+    assert exact.source == "cost_map"
+
+
+def test_override_matches_provider_stripped_candidate() -> None:
+    priced = resolve_price("groq/my-model", {"my-model": ManualPrice(1e-6, 2e-6)})
+    assert priced is not None
+    assert priced.source == "override"
+
+
+def test_alias_override_does_not_shadow_exact_dated_map_entry() -> None:
+    # gpt-4o-2024-05-13 has its OWN map entry at 2x the gpt-4o alias rate. An
+    # alias-keyed override (a less-specific, date-stripped match) must not
+    # absorb the snapshot — that would meter it at half its true cost.
+    exact = resolve_price("gpt-4o-2024-05-13")
+    assert exact is not None
+    priced = resolve_price("gpt-4o-2024-05-13", {"gpt-4o": ManualPrice(2.5e-6, 1e-5)})
+    assert priced is not None
+    assert priced.source == "cost_map"
+    assert priced.input_cost_per_token == exact.input_cost_per_token
+    # The override still wins for the alias itself and for unlisted snapshots.
+    assert resolve_price("gpt-4o", {"gpt-4o": ManualPrice(1e-9, 2e-9)}).source == "override"
+    assert (
+        resolve_price("gpt-4o-2099-01-01", {"gpt-4o": ManualPrice(1e-9, 2e-9)}).source
+        == "override"
+    )
+
+
+def test_date_suffix_stripping_is_ascii_only() -> None:
+    # TS "\d" is ASCII-only; the Python regex uses re.ASCII to match. A
+    # Unicode-digit suffix must not strip to the alias in either package.
+    assert resolve_price("gpt-4o-٢٠٢٥٠١٠١") is None
+
+
 def test_override_wins_over_cost_map() -> None:
     priced = resolve_price("gpt-4o", {"gpt-4o": ManualPrice(1e-9, 2e-9)})
     assert priced is not None


### PR DESCRIPTION
## Summary
Ships py 0.2.0 / js 0.2.1: adds Groq pricing (with correct model-id resolution), syncs PyPI with the documented API, and makes the CrewAI hard-stop reliable.

## Changes
- Cost map: vendor curated Groq models (incl. `gpt-oss-120b`/`20b`) and `claude-sonnet-5`; refresh script warns when a curated model vanishes upstream
- Pricing: resolve `groq/<org>/<model>` ids and unlisted dated snapshots (`claude-opus-4-8-<date>`) via alias; multi-provider bare names still fail closed (identical logic in py and ts)
- CrewAI/LiteLLM: LiteLLM swallows callback exceptions — the callback now  latches violations (`tripped`/`reset()`, ERROR log) and `budget_guarded_llm` enforces in `call`/`acall`, incl. the crewai ≥ 1.0 `LLM.__new__` factory route
- Release: py → 0.2.0 (ships `advisory()`, `reserve()`/`settle()`, the LangChain/OpenAI/Anthropic adapters previously documented but unreleased), js → 0.2.1; CHANGELOG corrected to match released artifacts
- CI: publish workflows gate on full CI success with fork-origin checks and tag releases; new version-guard requires a bump when package source changes

## Testing
123 pytest (new regression tests for id resolution, override precedence, and the callback-swallowing hard-stop) and 36 vitest.

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)
