### PR TITLE
feat: add LangGraph adapter with atomic fan-out reserve/settle and typed budget advisory (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,9 @@ jobs:
       # Install the framework extras so the adapter handler tests actually run
       # (instead of skipping). langchain-core covers the LangChain handler
       # tests; litellm covers the callback-swallowing regression tests (the
-      # CrewAI adapter tests stub crewai itself, so the heavy extra stays out).
-      - run: pip install -e ".[dev,langchain,litellm]"
+      # CrewAI adapter tests stub crewai itself, so the heavy extra stays out);
+      # langgraph covers the fan-out reserve/settle and advisory-channel tests.
+      - run: pip install -e ".[dev,langchain,litellm,langgraph]"
       - name: Pytest
         run: pytest -q
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added (py)
+
+- **LangGraph adapter** (`floe-guard[langgraph]`, issue #33): `guarded_node`
+  wraps graph nodes with the reserve-before / settle-after contract, so a
+  `StateGraph` fan-out of parallel sub-agents holds one shared ceiling
+  atomically; `AdvisoryChannel` / `latest_advisory` expose the typed
+  `BudgetAdvisory` in graph state after each metered node, so a router can
+  downshift models on `near_limit` before the hard-stop. Ships with a
+  no-API-key example (`examples/langgraph_budget_aware.py`).
+
 ## py 0.2.0 / js 0.2.1 — 2026-07-10
 
 Everything the repo grew between the 0.1.0 uploads and this release ships here —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.6.0 — 2026-07-18
+
 ### Added (py)
 
 - **LangGraph adapter** (`floe-guard[langgraph]`, issue #33): `guarded_node`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ The optional adapters need their extras to run/import:
 pip install -e ".[crewai]"      # CrewAI adapter
 pip install -e ".[litellm]"     # LiteLLM adapter
 pip install -e ".[langchain]"   # LangChain adapter
+pip install -e ".[langgraph]"   # LangGraph adapter
 pip install -e ".[openai]"      # OpenAI adapter
 pip install -e ".[anthropic]"   # Anthropic adapter
 ```

--- a/README.md
+++ b/README.md
@@ -254,9 +254,10 @@ def worker(state: State) -> dict:
 `guarded_node` gives every branch of a `StateGraph` fan-out its own atomic
 slice of the ceiling (reserve-before / settle-after, the same contract the
 OpenAI and Anthropic adapters use), so N parallel sub-agents can't race one
-shared total. Pass `estimated_cost` so the very first branches hold a
-realistic slice (a fresh guard has no last call to estimate from); afterwards
-each reservation re-estimates from the last settled cost automatically. After each settled call it writes the guard's `BudgetAdvisory`
+shared total. Pass `estimated_cost` to hold a conservative fixed slice on
+every call of that node (the `0.01` above); a node that omits it estimates
+from the guard's last settled cost instead, which is `0` on a fresh guard, so
+seed a cold-start fan-out explicitly. After each settled call it writes the guard's `BudgetAdvisory`
 into `state["budget"]`, so a router node can downshift to a cheaper model on
 `near_limit` *before* the hard-stop — see
 [`examples/langgraph_budget_aware.py`](examples/langgraph_budget_aware.py) for

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ class State(TypedDict):
 
 guard = BudgetGuard(limit_usd=0.10)
 
-@guarded_node(guard)                 # reserve() before, settle()/release() after
+@guarded_node(guard, estimated_cost=0.01)   # reserve() before, settle()/release() after
 def worker(state: State) -> dict:
     response = my_llm_call(state)
     return {"results": [response["text"]], "usage": {
@@ -254,7 +254,9 @@ def worker(state: State) -> dict:
 `guarded_node` gives every branch of a `StateGraph` fan-out its own atomic
 slice of the ceiling (reserve-before / settle-after, the same contract the
 OpenAI and Anthropic adapters use), so N parallel sub-agents can't race one
-shared total. After each settled call it writes the guard's `BudgetAdvisory`
+shared total. Pass `estimated_cost` so the very first branches hold a
+realistic slice (a fresh guard has no last call to estimate from); afterwards
+each reservation re-estimates from the last settled cost automatically. After each settled call it writes the guard's `BudgetAdvisory`
 into `state["budget"]`, so a router node can downshift to a cheaper model on
 `near_limit` *before* the hard-stop — see
 [`examples/langgraph_budget_aware.py`](examples/langgraph_budget_aware.py) for

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $0.10 instead of $4,000. No account, no signup, no network, **no telemetry**.
 Runs in your process.
 
 Works with [CrewAI](#crewai) · [LiteLLM](#litellm) · [LangChain](#langchain) ·
-[OpenAI](#openai) · [Anthropic](#anthropic) ·
+[LangGraph](#langgraph) · [OpenAI](#openai) · [Anthropic](#anthropic) ·
 [Vercel AI SDK](#vercel-ai-sdk) — or any stack, via plain `check()` / `record()`.
 
 ```bash
@@ -220,6 +220,45 @@ llm.invoke("hello")            # checks budget before the call, records spend af
 
 The handler checks the budget on LLM start (raising `BudgetExceeded` aborts the
 call before it runs) and records token usage on LLM end.
+
+### LangGraph
+
+```bash
+pip install floe-guard[langgraph]
+```
+
+```python
+import operator
+from typing import Annotated
+from typing_extensions import TypedDict
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.langgraph import AdvisoryChannel, guarded_node
+
+class State(TypedDict):
+    results: Annotated[list, operator.add]
+    budget: AdvisoryChannel          # typed BudgetAdvisory, refreshed per call
+
+guard = BudgetGuard(limit_usd=0.10)
+
+@guarded_node(guard)                 # reserve() before, settle()/release() after
+def worker(state: State) -> dict:
+    response = my_llm_call(state)
+    return {"results": [response["text"]], "usage": {
+        "model": response["model"],
+        "prompt_tokens": response["prompt_tokens"],
+        "completion_tokens": response["completion_tokens"],
+    }}
+```
+
+`guarded_node` gives every branch of a `StateGraph` fan-out its own atomic
+slice of the ceiling (reserve-before / settle-after, the same contract the
+OpenAI and Anthropic adapters use), so N parallel sub-agents can't race one
+shared total. After each settled call it writes the guard's `BudgetAdvisory`
+into `state["budget"]`, so a router node can downshift to a cheaper model on
+`near_limit` *before* the hard-stop — see
+[`examples/langgraph_budget_aware.py`](examples/langgraph_budget_aware.py) for
+the full budget-aware router (no API key needed).
 
 ### OpenAI
 

--- a/examples/langgraph_budget_aware.py
+++ b/examples/langgraph_budget_aware.py
@@ -1,0 +1,100 @@
+"""Context-aware budgeting in a LangGraph graph — the router tapers near the cap.
+
+No API key, no account, no network — a stub LLM returns fixed token usage. The
+LangGraph port of ``examples/budget_aware.py``: every worker node is wrapped
+with ``guarded_node`` (atomic reserve/settle, so this pattern survives a
+parallel fan-out unchanged), and each settled call refreshes a typed
+``BudgetAdvisory`` in the graph state. The router node reads
+``state["budget"].near_limit`` and downshifts to the cheap model, so the run
+finishes on budget instead of slamming into the hard-stop mid-task.
+
+The advisory is a *soft* signal you choose to act on; ``reserve()`` is still
+the hard guarantee on every guarded node.
+
+Run:  pip install floe-guard[langgraph]
+      python examples/langgraph_budget_aware.py
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Annotated
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.langgraph import AdvisoryChannel, guarded_node
+
+FULL = ("gpt-4o", 1000, 1000)  # ~$0.0125 / call
+CHEAP = ("gpt-4o-mini", 1000, 1000)  # ~$0.0008 / call
+
+
+class State(TypedDict):
+    steps: Annotated[int, operator.add]
+    log: Annotated[list, operator.add]
+    budget: AdvisoryChannel
+
+
+def stub_llm(model: tuple[str, int, int]) -> dict[str, object]:
+    """A fake LLM call — no network, no key."""
+    name, prompt_tokens, completion_tokens = model
+    return {"model": name, "prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens}
+
+
+def make_worker(model: tuple[str, int, int]):
+    def worker(state: State) -> dict:
+        response = stub_llm(model)
+        return {
+            "steps": 1,
+            "log": [f"{response['model']}"],
+            # Report the call's usage; guarded_node settles it and refreshes
+            # state["budget"] with the guard's advisory.
+            "usage": response,
+        }
+
+    return worker
+
+
+def route(state: State) -> str:
+    """Downshift on the advisory; stop when not even a cheap call fits."""
+    adv = state.get("budget")
+    if adv is None:
+        return "full_step"  # first call — no signal yet
+    if adv.remaining_usd < 0.0008:
+        return END
+    if adv.near_limit:
+        return "cheap_step"
+    return "full_step"
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to downshift before the ceiling.
+    guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+
+    graph = StateGraph(State)
+    graph.add_node("full_step", guarded_node(guard, make_worker(FULL), estimated_cost=0.0125))
+    graph.add_node("cheap_step", guarded_node(guard, make_worker(CHEAP), estimated_cost=0.0008))
+    graph.add_conditional_edges(START, route)
+    graph.add_conditional_edges("full_step", route)
+    graph.add_conditional_edges("cheap_step", route)
+
+    tapered = False
+    final = graph.compile().invoke({"steps": 0, "log": []}, {"recursion_limit": 200})
+
+    for step, model in enumerate(final["log"], start=1):
+        if model == CHEAP[0] and not tapered:
+            tapered = True
+            print("  [advisory] near_limit tripped → tapering to", model, "\n")
+        print(f"  step {step:>2}: {model}")
+
+    print(
+        f"\nFinished at step {final['steps']}. "
+        f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f}), "
+        f"advisory read {final['budget'].used_bps / 100:.0f}% used."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Floe Labs" }]
-keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "cost", "openai", "anthropic"]
+keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -27,6 +27,7 @@ dependencies = []
 litellm = ["litellm>=1.0"]
 crewai = ["crewai>=0.30", "litellm>=1.0"]
 langchain = ["langchain-core>=0.3"]
+langgraph = ["langgraph>=1.0"]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.40"]
 dev = ["pytest>=7.0", "ruff>=0.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.5.0"
+version = "0.6.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -27,7 +27,7 @@ from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.5.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.6.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/integrations/__init__.py
+++ b/src/floe_guard/integrations/__init__.py
@@ -5,4 +5,5 @@ Each adapter lives behind an optional extra so the core stays dependency-free:
     pip install floe-guard[litellm]
     pip install floe-guard[crewai]
     pip install floe-guard[langchain]
+    pip install floe-guard[langgraph]
 """

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -29,7 +29,9 @@ read ``state["budget"].near_limit`` and downshift to a cheaper model *before*
 
     guard = BudgetGuard(limit_usd=0.10)
 
-    @guarded_node(guard)
+    # estimated_cost seeds the very first hold (a fresh guard has no last
+    # cost to estimate from); later calls re-estimate from the last settled cost.
+    @guarded_node(guard, estimated_cost=0.01)
     def worker(state: State) -> dict:
         response = my_llm_call(state)  # however the node does its work
         return {
@@ -111,7 +113,15 @@ def _usage_from_update(update: Any, usage_key: str) -> tuple[str, int, int] | No
 
 
 def _settle_update(guard: BudgetGuard, update: Any, usage_key: str, *, reserved: float) -> None:
-    usage = _usage_from_update(update, usage_key)
+    try:
+        usage = _usage_from_update(update, usage_key)
+    except (TypeError, ValueError):
+        # A malformed usage payload (e.g. prompt_tokens="abc") cannot be priced.
+        # Release the in-flight hold before propagating so the reservation
+        # doesn't leak and shrink remaining_usd permanently — the same
+        # fail-safe as settle()'s pricing-error path.
+        guard.release(reserved)
+        raise
     if usage is None:
         # No usage reported — the node metered elsewhere (another adapter) or
         # spent nothing. Free the hold; do NOT settle, or the spend would be

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -1,0 +1,214 @@
+"""LangGraph adapter (optional extra: ``pip install floe-guard[langgraph]``).
+
+Two pieces (issue #33):
+
+:func:`guarded_node` wraps a graph node with the reserve-before / settle-after
+contract the OpenAI and Anthropic adapters use: ``reserve()`` before the node
+runs, ``settle(..., reserved=...)`` from the usage it reports, ``release()`` on
+error. LangGraph executes the parallel branches of a ``StateGraph`` fan-out on
+a thread pool, which is exactly the check-then-record race that atomic
+reservations close (issue #18) — N sub-agents each hold their own slice of the
+ceiling instead of racing one shared total.
+
+:func:`latest_advisory` (used via :data:`AdvisoryChannel`) is the reducer for a
+typed budget channel in the graph state. Every guarded node refreshes it with
+:meth:`~floe_guard.BudgetGuard.advisory` after settling, so a router node can
+read ``state["budget"].near_limit`` and downshift to a cheaper model *before*
+``reserve()`` hard-blocks::
+
+    import operator
+    from typing import Annotated
+    from typing_extensions import TypedDict
+
+    from floe_guard import BudgetGuard
+    from floe_guard.integrations.langgraph import AdvisoryChannel, guarded_node
+
+    class State(TypedDict):
+        results: Annotated[list, operator.add]
+        budget: AdvisoryChannel
+
+    guard = BudgetGuard(limit_usd=0.10)
+
+    @guarded_node(guard)
+    def worker(state: State) -> dict:
+        response = my_llm_call(state)  # however the node does its work
+        return {
+            "results": [response["text"]],
+            # Report what the call consumed; the wrapper settles it.
+            "usage": {
+                "model": response["model"],
+                "prompt_tokens": response["prompt_tokens"],
+                "completion_tokens": response["completion_tokens"],
+            },
+        }
+
+The wrapped node reports its spend by returning a ``"usage"`` entry (the shape
+above — the same one ``examples/budget_aware.py`` uses). If a node meters its
+LLM call through another floe-guard adapter instead (e.g. the OpenAI or
+Anthropic wrappers), omit ``"usage"``: the reservation still holds the branch's
+slice of the ceiling while the call is in flight, and the wrapper releases the
+hold afterwards instead of settling it twice.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from functools import wraps
+from typing import Annotated, Any
+
+from ..guard import BudgetAdvisory, BudgetGuard
+
+
+def _require_langgraph() -> None:
+    try:
+        import langgraph  # noqa: F401
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "The LangGraph adapter requires langgraph. "
+            "Install with: pip install floe-guard[langgraph]"
+        ) from e
+
+
+def latest_advisory(
+    current: BudgetAdvisory | None, update: BudgetAdvisory | None
+) -> BudgetAdvisory | None:
+    """Reducer for the budget channel: keep the advisory reflecting the most spend.
+
+    Parallel branches finish in nondeterministic order, so "last write wins"
+    does not mean "latest spend wins". ``used_bps`` is monotone in the guard's
+    running total, so the higher reading is always the fresher truth.
+    """
+    if update is None:
+        return current
+    if current is None:
+        return update
+    return update if update.used_bps >= current.used_bps else current
+
+
+# Declare this on your graph state to receive the advisory after each guarded
+# node:  ``budget: AdvisoryChannel``
+AdvisoryChannel = Annotated[BudgetAdvisory | None, latest_advisory]
+
+
+def _usage_from_update(update: Any, usage_key: str) -> tuple[str, int, int] | None:
+    """Pull (model, prompt_tokens, completion_tokens) from a node's state update.
+
+    Returns ``None`` when the update carries no usage entry at all — distinct
+    from an entry reporting zero tokens, which still routes through the guard's
+    accounting below.
+    """
+    if not isinstance(update, dict):
+        return None
+    usage = update.get(usage_key)
+    if usage is None:
+        return None
+    get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
+    model = str(get("model", "") or "")
+    prompt_tokens = int(get("prompt_tokens", 0) or 0)
+    completion_tokens = int(get("completion_tokens", 0) or 0)
+    return model, prompt_tokens, completion_tokens
+
+
+def _settle_update(guard: BudgetGuard, update: Any, usage_key: str, *, reserved: float) -> None:
+    usage = _usage_from_update(update, usage_key)
+    if usage is None:
+        # No usage reported — the node metered elsewhere (another adapter) or
+        # spent nothing. Free the hold; do NOT settle, or the spend would be
+        # counted twice.
+        guard.release(reserved)
+        return
+    model, prompt_tokens, completion_tokens = usage
+    if prompt_tokens <= 0 and completion_tokens <= 0:
+        # A usage entry with no tokens — nothing to meter. Free the hold.
+        guard.release(reserved)
+        return
+    # There IS spend to account for. Route it through settle() even when the
+    # model id is missing, so the guard's policy applies (fail-closed → warn +
+    # raise; fail-open → warn + skip) rather than letting a completed call go
+    # unmetered and skew the next reservation's estimate.
+    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
+
+
+def _inject_advisory(guard: BudgetGuard, update: Any, advisory_key: str | None) -> Any:
+    if advisory_key is None:
+        return update
+    if update is None:
+        return {advisory_key: guard.advisory()}
+    if isinstance(update, dict):
+        # Refresh AFTER settling so the branch's own spend is included. The
+        # channel's reducer (latest_advisory) resolves concurrent writes.
+        return {**update, advisory_key: guard.advisory()}
+    # Command/other update objects pass through untouched — nothing to annotate.
+    return update
+
+
+def guarded_node(
+    guard: BudgetGuard,
+    node: Callable[..., Any] | None = None,
+    *,
+    usage_key: str = "usage",
+    advisory_key: str | None = "budget",
+    estimated_cost: float | None = None,
+) -> Callable[..., Any]:
+    """Wrap a LangGraph node with a budget reservation, accrual, and advisory.
+
+    Works as a decorator (``@guarded_node(guard)``) or a plain wrapper
+    (``guarded_node(guard, fn)``); sync and async nodes are both supported.
+
+    Raises :class:`~floe_guard.BudgetExceeded` before the node runs if the
+    reservation would cross the ceiling — the branch never executes. On
+    success, the node's ``usage_key`` entry is settled against the reservation
+    and the guard's :class:`~floe_guard.BudgetAdvisory` is written to
+    ``advisory_key`` in the returned update (declare that key on the graph
+    state with :data:`AdvisoryChannel`, or pass ``advisory_key=None`` to skip
+    the injection). On error the reservation is released and the exception
+    propagates, so a failed branch never leaks its hold.
+
+    ``estimated_cost`` sizes the reservation; it defaults to the guard's last
+    recorded call cost (see :meth:`~floe_guard.BudgetGuard.reserve`). On a cold
+    guard no call has been recorded yet, so that default is ``0`` — when the
+    very first graph step is already a parallel fan-out, pass an explicit
+    ``estimated_cost`` per node so each branch holds a realistic slice.
+    """
+    _require_langgraph()
+
+    def wrap(fn: Callable[..., Any]) -> Callable[..., Any]:
+        if inspect.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                reserved = guard.reserve(estimated_cost)
+                try:
+                    update = await fn(*args, **kwargs)
+                except BaseException:
+                    guard.release(reserved)
+                    raise
+                _settle_update(guard, update, usage_key, reserved=reserved)
+                return _inject_advisory(guard, update, advisory_key)
+
+            return async_wrapper
+
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            reserved = guard.reserve(estimated_cost)
+            try:
+                update = fn(*args, **kwargs)
+            except BaseException:
+                guard.release(reserved)
+                raise
+            _settle_update(guard, update, usage_key, reserved=reserved)
+            return _inject_advisory(guard, update, advisory_key)
+
+        return wrapper
+
+    if node is None:
+        return wrap
+    return wrap(node)
+
+
+__all__ = [
+    "AdvisoryChannel",
+    "guarded_node",
+    "latest_advisory",
+]

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -29,8 +29,9 @@ read ``state["budget"].near_limit`` and downshift to a cheaper model *before*
 
     guard = BudgetGuard(limit_usd=0.10)
 
-    # estimated_cost seeds the very first hold (a fresh guard has no last
-    # cost to estimate from); later calls re-estimate from the last settled cost.
+    # estimated_cost holds a fixed, conservative slice on every call of this
+    # node; omit it to estimate from the guard's last settled cost instead
+    # (0 on a fresh guard, so seed a cold-start fan-out explicitly).
     @guarded_node(guard, estimated_cost=0.01)
     def worker(state: State) -> dict:
         response = my_llm_call(state)  # however the node does its work
@@ -115,8 +116,9 @@ def _usage_from_update(update: Any, usage_key: str) -> tuple[str, int, int] | No
 def _settle_update(guard: BudgetGuard, update: Any, usage_key: str, *, reserved: float) -> None:
     try:
         usage = _usage_from_update(update, usage_key)
-    except (TypeError, ValueError):
-        # A malformed usage payload (e.g. prompt_tokens="abc") cannot be priced.
+    except (TypeError, ValueError, OverflowError):
+        # A malformed usage payload (e.g. prompt_tokens="abc" or float("inf"))
+        # cannot be priced.
         # Release the in-flight hold before propagating so the reservation
         # doesn't leak and shrink remaining_usd permanently — the same
         # fail-safe as settle()'s pricing-error path.

--- a/tests/test_langgraph_adapter.py
+++ b/tests/test_langgraph_adapter.py
@@ -171,6 +171,23 @@ def test_node_error_releases_reservation() -> None:
     assert guard.spent_usd == pytest.approx(0.0125)  # only the warm call
 
 
+def test_malformed_usage_releases_hold_and_raises() -> None:
+    # A malformed usage payload must not leak the reservation: the hold is
+    # released before the error propagates, the same fail-safe as settle()'s
+    # pricing-error path.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+
+    @guarded_node(guard)
+    def broken_usage(state: dict) -> dict:
+        return {"usage": {"model": MODEL, "prompt_tokens": "abc", "completion_tokens": 50}}
+
+    with pytest.raises(ValueError):
+        broken_usage({})
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+    assert guard.spent_usd == pytest.approx(0.0125)  # only the warm call
+
+
 def test_node_without_usage_releases_hold_and_still_reports_advisory() -> None:
     # A node that meters through another floe-guard adapter (or spends nothing)
     # must not be double-counted: the hold is released, not settled.

--- a/tests/test_langgraph_adapter.py
+++ b/tests/test_langgraph_adapter.py
@@ -1,0 +1,240 @@
+"""LangGraph adapter: the ceiling must hold across a real StateGraph fan-out.
+
+Issue #33's acceptance criteria, as tests:
+
+1. A fan-out with N parallel sub-agents never crosses ``limit_usd`` —
+   ``reserve()``/``settle()`` hold under branch concurrency (LangGraph runs the
+   branches of a superstep on a thread pool, the exact race of issue #18).
+2. Graph state exposes a typed ``BudgetAdvisory``; a router downshifts model
+   choice on ``near_limit`` before any ``BudgetExceeded``.
+"""
+
+from __future__ import annotations
+
+import operator
+import time
+from typing import Annotated
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+from langgraph.graph import END, START, StateGraph  # noqa: E402
+from typing_extensions import TypedDict  # noqa: E402
+
+from floe_guard import BudgetAdvisory, BudgetExceeded, BudgetGuard  # noqa: E402
+from floe_guard.integrations.langgraph import (  # noqa: E402
+    AdvisoryChannel,
+    guarded_node,
+    latest_advisory,
+)
+
+MODEL = "gpt-4o"  # 1k in + 1k out = $0.0125 / call
+CHEAP = "gpt-4o-mini"  # 1k in + 1k out = ~$0.0008 / call
+
+
+def _usage(model: str = MODEL) -> dict:
+    return {"model": model, "prompt_tokens": 1_000, "completion_tokens": 1_000}
+
+
+class FanOutState(TypedDict):
+    results: Annotated[list, operator.add]
+    budget: AdvisoryChannel
+
+
+class LoopState(TypedDict):
+    # Module-level (not defined inside its test): langgraph resolves node/route
+    # type hints through the function's module globals, where a test-local
+    # class would not exist.
+    models_used: Annotated[list, operator.add]
+    steps: Annotated[int, operator.add]
+    budget: AdvisoryChannel
+
+
+def _wait_for_settles(guard: BudgetGuard, timeout: float = 2.0) -> None:
+    """Wait for in-flight branches to settle/release their holds.
+
+    When a branch raises BudgetExceeded, invoke() re-raises while sibling
+    threads may still be inside their simulated API latency; their settle()
+    lands moments later. Bounded wait, then the assertions run.
+    """
+    deadline = time.monotonic() + timeout
+    while guard._reserved > 1e-9 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
+def test_fan_out_within_budget_settles_exactly() -> None:
+    # 6 parallel branches at $0.0125 fit under a $0.10 ceiling: every branch
+    # must run, settle its own slice, and leak nothing.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)  # warm the next-call estimate
+
+    def make_branch(i: int):
+        def branch(state: FanOutState) -> dict:
+            time.sleep(0.02)  # API latency — the window the old race exploited
+            return {"results": [i], "usage": _usage()}
+
+        return branch
+
+    g = StateGraph(FanOutState)
+    for i in range(6):
+        g.add_node(f"agent_{i}", guarded_node(guard, make_branch(i)))
+        g.add_edge(START, f"agent_{i}")
+        g.add_edge(f"agent_{i}", END)
+    out = g.compile().invoke({"results": []})
+
+    assert sorted(out["results"]) == list(range(6))
+    assert guard.spent_usd == pytest.approx(7 * 0.0125)  # warm call + 6 branches
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+    # The advisory channel carries the fan-out's final utilization.
+    assert isinstance(out["budget"], BudgetAdvisory)
+    assert out["budget"].used_bps == 8750
+
+
+def test_fan_out_over_budget_never_crosses_ceiling() -> None:
+    # 16 parallel branches want ~$0.21 against a $0.10 ceiling. Some branches
+    # must be refused at reserve() time, and the total must hold — the graph
+    # port of test_concurrency's 16-agents guarantee.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+
+    def make_branch(i: int):
+        def branch(state: FanOutState) -> dict:
+            time.sleep(0.02)
+            return {"results": [i], "usage": _usage()}
+
+        return branch
+
+    g = StateGraph(FanOutState)
+    for i in range(16):
+        g.add_node(f"agent_{i}", guarded_node(guard, make_branch(i)))
+        g.add_edge(START, f"agent_{i}")
+        g.add_edge(f"agent_{i}", END)
+    app = g.compile()
+
+    with pytest.raises(BudgetExceeded):
+        app.invoke({"results": []})
+    _wait_for_settles(guard)
+
+    # The guarantee: parallel branches never push spend past the ceiling...
+    assert guard.spent_usd <= guard.limit_usd + 1e-9
+    # ...and no reservation leaked from the raced and the refused branches.
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+
+
+def test_router_downshifts_on_near_limit_before_hard_stop() -> None:
+    # Acceptance (b): a router reads state["budget"].near_limit and switches to
+    # the cheap model, so the run finishes on budget with zero BudgetExceeded.
+    guard = BudgetGuard(limit_usd=0.05, near_limit_bps=7000, on_block=lambda *_: None)
+
+    def route(state: LoopState) -> str:
+        adv = state.get("budget")
+        if state["steps"] >= 12:  # safety valve; the budget should not need it
+            return END
+        if adv is not None and adv.near_limit and adv.remaining_usd < 0.0008:
+            return END  # not even a cheap call left
+        return "cheap_step" if adv is not None and adv.near_limit else "full_step"
+
+    def full_step(state: LoopState) -> dict:
+        return {"models_used": [MODEL], "steps": 1, "usage": _usage(MODEL)}
+
+    def cheap_step(state: LoopState) -> dict:
+        return {"models_used": [CHEAP], "steps": 1, "usage": _usage(CHEAP)}
+
+    g = StateGraph(LoopState)
+    g.add_node("full_step", guarded_node(guard, full_step, estimated_cost=0.0125))
+    g.add_node("cheap_step", guarded_node(guard, cheap_step, estimated_cost=0.0008))
+    g.add_conditional_edges(START, route)
+    g.add_conditional_edges("full_step", route)
+    g.add_conditional_edges("cheap_step", route)
+    out = g.compile().invoke({"models_used": [], "steps": 0}, {"recursion_limit": 100})
+
+    # $0.05 at $0.0125/call trips the 70% advisory after the 3rd full call...
+    assert out["models_used"][:3] == [MODEL, MODEL, MODEL]
+    # ...then every later call ran on the cheap model, and the ceiling held
+    # without a single hard block.
+    assert set(out["models_used"][3:]) == {CHEAP}
+    assert guard.spent_usd <= guard.limit_usd + 1e-9
+
+
+def test_node_error_releases_reservation() -> None:
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+
+    @guarded_node(guard)
+    def broken(state: dict) -> dict:
+        raise RuntimeError("upstream API fell over")
+
+    with pytest.raises(RuntimeError):
+        broken({})
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+    assert guard.spent_usd == pytest.approx(0.0125)  # only the warm call
+
+
+def test_node_without_usage_releases_hold_and_still_reports_advisory() -> None:
+    # A node that meters through another floe-guard adapter (or spends nothing)
+    # must not be double-counted: the hold is released, not settled.
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+    guard.record(MODEL, 1_000, 1_000)
+
+    @guarded_node(guard)
+    def tool_only(state: dict) -> dict:
+        return {"results": ["no llm call here"]}
+
+    update = tool_only({})
+    assert guard.spent_usd == pytest.approx(0.0125)
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+    assert isinstance(update["budget"], BudgetAdvisory)
+
+
+def test_async_node_is_guarded_too() -> None:
+    # asyncio.run keeps this self-contained — the dev extra carries no async
+    # pytest plugin, and the suite must stay green bare.
+    import asyncio
+
+    guard = BudgetGuard(limit_usd=0.10, on_block=lambda *_: None)
+
+    @guarded_node(guard)
+    async def async_worker(state: dict) -> dict:
+        return {"usage": _usage()}
+
+    update = asyncio.run(async_worker({}))
+    assert guard.spent_usd == pytest.approx(0.0125)
+    assert isinstance(update["budget"], BudgetAdvisory)
+
+
+def test_langgraph_example_finishes_on_budget(capsys: pytest.CaptureFixture[str]) -> None:
+    # Acceptance (c): the prebuilt budget-aware router example runs end to end
+    # with no API key and finishes under its ceiling (same contract as the
+    # runaway_loop example test).
+    import sys
+    from pathlib import Path
+
+    examples = Path(__file__).resolve().parent.parent / "examples"
+    sys.path.insert(0, str(examples))
+    try:
+        import langgraph_budget_aware
+
+        langgraph_budget_aware.main()
+    finally:
+        sys.path.remove(str(examples))
+
+    out = capsys.readouterr().out
+    assert "tapering" in out
+    assert "Finished at step" in out
+    assert "held under $0.10" in out
+
+
+def test_latest_advisory_prefers_higher_utilization() -> None:
+    early = BudgetAdvisory(
+        near_limit=False, used_bps=2500, remaining_usd=0.075, limit_usd=0.10, spent_usd=0.025
+    )
+    late = BudgetAdvisory(
+        near_limit=True, used_bps=8750, remaining_usd=0.0125, limit_usd=0.10, spent_usd=0.0875
+    )
+    # Branch completion order is nondeterministic — the reducer must keep the
+    # fresher (higher-utilization) reading regardless of write order.
+    assert latest_advisory(early, late) is late
+    assert latest_advisory(late, early) is late
+    assert latest_advisory(None, early) is early
+    assert latest_advisory(late, None) is late

--- a/tests/test_langgraph_adapter.py
+++ b/tests/test_langgraph_adapter.py
@@ -187,6 +187,15 @@ def test_malformed_usage_releases_hold_and_raises() -> None:
     assert guard._reserved == pytest.approx(0.0, abs=1e-9)
     assert guard.spent_usd == pytest.approx(0.0125)  # only the warm call
 
+    @guarded_node(guard)
+    def infinite_usage(state: dict) -> dict:
+        return {"usage": {"model": MODEL, "prompt_tokens": float("inf"), "completion_tokens": 50}}
+
+    with pytest.raises(OverflowError):
+        infinite_usage({})
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+    assert guard.spent_usd == pytest.approx(0.0125)
+
 
 def test_node_without_usage_releases_hold_and_still_reports_advisory() -> None:
     # A node that meters through another floe-guard adapter (or spends nothing)


### PR DESCRIPTION
## Summary
LangGraph adapter for floe-guard (issue #33): every branch of a StateGraph fan-out gets its own atomic slice of the ceiling (reserve-before / settle-after, the same contract the OpenAI and Anthropic adapters use), and a typed BudgetAdvisory channel in graph state lets a router downshift models before the hard-stop.

## Changes
- `src/floe_guard/integrations/langgraph.py`: `guarded_node` (sync + async, decorator or plain wrapper): `reserve()` before the node runs, `settle(reserved=...)` from the usage it reports, `release()` on error or when the node metered its call elsewhere (no double-counting). `latest_advisory` reducer + `AdvisoryChannel`, so `state["budget"]` always carries the freshest utilization under parallel writes.
- `tests/test_langgraph_adapter.py`: 8 tests mapping the acceptance criteria. A real 16-branch over-budget StateGraph fan-out never crosses `limit_usd` (the graph port of the 16-concurrent-agents test), a within-budget fan-out settles exactly with zero leaked holds, the router downshifts on `near_limit` with zero `BudgetExceeded`, error and no-usage paths release the hold, async nodes are guarded, reducer ordering is write-order independent, and the example runs end to end on budget.
- `examples/langgraph_budget_aware.py`: LangGraph port of `examples/budget_aware.py` (no API key, no network). Full model until the 70% advisory trips, tapers to the cheap model, finishes at $0.0998 under a $0.10 ceiling.
- `pyproject.toml`: `langgraph = ["langgraph>=1.0"]` extra + keyword. `.github/workflows/ci.yml`: install the extra in the test matrix so the adapter tests run instead of skipping (mirrors the langchain/litellm rationale). README section, CHANGELOG (Unreleased), CONTRIBUTING extras list, integrations docstring.

## Testing
- [x] `pytest` passes: 123 passed, 1 skipped (baseline 115 passed, 1 skipped)
- [x] `ruff check .` and `ruff format .` are clean
- [x] Cost-map copies untouched (no JS changes)
- [x] CHANGELOG.md updated

Acceptance criteria from #33:
- [x] A LangGraph fan-out with N parallel sub-agents never crosses `limit_usd` (`test_fan_out_over_budget_never_crosses_ceiling`, 16 branches on the superstep thread pool)
- [x] Graph State exposes a typed `BudgetAdvisory`; a router downshifts on `near_limit` before any `BudgetExceeded` (`test_router_downshifts_on_near_limit_before_hard_stop`)
- [x] Ships as the optional extra `floe-guard[langgraph]`, mirroring the crewai/langchain extras

## Related issues
Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LangGraph adapter enabling budget-aware node wrapping with automatic reserve/settle.
  * Nodes provide budget advisories for routing and near-limit downshifting, including concurrent fan-out handling.
  * Added a no-API-key budget-aware LangGraph example.
* **Documentation**
  * Updated README and CHANGELOG with LangGraph usage, plus guidance for the LangGraph optional setup.
* **Tests**
  * Added LangGraph acceptance tests for ceiling enforcement, async/error handling, malformed/missing usage, and advisory aggregation/order.
* **Chores**
  * Updated CI to install LangGraph extras for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->