### PR TITLE
feat: add per call native spend logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.3.0 / js 0.3.0 — 2026-07-14
+
 ### Added (py + js)
 
 - **Per-call spend ledger**: every priced `record()` / `settle()` appends a
@@ -27,6 +29,11 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   together.
 - `record()` / `settle()` accept an optional `label` to tag events with an
   agent/task name.
+
+### Fixed (py)
+
+- `floe_guard.__version__` now reports the real package version (it had been
+  stuck at `0.1.0` since the 0.2.0 release).
 
 ## py 0.2.0 / js 0.2.1 — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added (py + js)
+
+- **Per-call spend ledger**: every priced `record()` / `settle()` appends a
+  typed `SpendEvent` (`timestamp`, `kind: llm|tool`, `model_or_tool`,
+  `prompt_tokens`, `completion_tokens`, `cost_usd`, optional `label` and
+  `reserved`) to `guard.spend_log` (py) / `guard.spendLog` (js), so the ledger
+  sums to the running total (unless the ring-buffer cap below has evicted old
+  events) — no more rebuilding per-call breakdowns outside the guard. `export_log()` / `exportLog()` serialises it as JSONL with
+  an identical snake_case schema in both languages, so heterogeneous agents
+  emit one concatenable stream. An optional `max_log_events` / `maxLogEvents`
+  ring-buffer cap bounds memory for long-running agents.
+- **`record_tool()` / `recordTool()`**: accrue a non-LLM cost (paid tool/API
+  call) against the same ceiling and log it as a `kind: "tool"` event, so
+  `check()` / `reserve()` enforce the budget across LLM and tool spend
+  together.
+- `record()` / `settle()` accept an optional `label` to tag events with an
+  agent/task name.
+
 ## py 0.2.0 / js 0.2.1 — 2026-07-10
 
 Everything the repo grew between the 0.1.0 uploads and this release ships here —

--- a/README.md
+++ b/README.md
@@ -150,6 +150,31 @@ unchanged — hosted just answers across *every* vendor and cap with server-trut
 balances and rolling-window reset timing, which a single local budget can't know.
 The TS package exposes the identical `guard.advisory()`.
 
+## Per-call spend log
+
+The guard keeps a typed, in-memory ledger of everything it priced: each
+`record()` / `settle()` appends one `SpendEvent`, and `record_tool()` lets paid
+non-LLM calls (search APIs, scrapers) spend the same budget and land in the same
+log. The events sum to `spent_usd` (unless a `max_log_events` ring buffer has
+evicted old ones) — no more rebuilding per-call breakdowns around the guard.
+
+```python
+guard = BudgetGuard(limit_usd=1.00)                      # max_log_events=N caps memory
+guard.record("gpt-4o", 1_200, 350, label="researcher")   # label is optional
+guard.record_tool("serpapi.search", 0.01, label="researcher")
+
+guard.spend_log      # [SpendEvent(timestamp=…, kind="llm", model_or_tool="gpt-4o",
+                     #             prompt_tokens=1200, completion_tokens=350,
+                     #             cost_usd=0.0065, label="researcher"), …]
+print(guard.export_log(), end="")   # JSONL, one event per line
+```
+
+`export_log()` emits a stable snake_case schema —
+`{timestamp, kind: llm|tool, model_or_tool, prompt_tokens, completion_tokens,
+cost_usd, label?, reserved?}` — identical to the TS package's `exportLog()`, so
+every agent produces the same shape regardless of stack and the streams can be
+concatenated and analysed together.
+
 ## Framework adapters (optional extras)
 
 ### CrewAI

--- a/js/README.md
+++ b/js/README.md
@@ -63,6 +63,27 @@ const adv = guard.advisory();
 const model = adv.nearLimit ? openai("gpt-4o-mini") : openai("gpt-4o");
 ```
 
+## Per-call spend log
+
+The guard keeps a typed, in-memory ledger of everything it priced: each
+`record()` / `settle()` appends one `SpendEvent`, and `recordTool()` lets paid
+non-LLM calls spend the same budget and land in the same log. The events sum to
+`spentUsd` (unless a `maxLogEvents` ring buffer has evicted old ones).
+
+```ts
+const guard = new BudgetGuard(1.0); // { maxLogEvents: N } caps memory
+guard.record("gpt-4o", 1_200, 350, { label: "researcher" });
+guard.recordTool("serpapi.search", 0.01, { label: "researcher" });
+
+guard.spendLog; // [{ timestamp, kind: "llm", modelOrTool: "gpt-4o", … }, …]
+process.stdout.write(guard.exportLog()); // JSONL, one event per line
+```
+
+`exportLog()` emits a stable snake_case schema —
+`{timestamp, kind: llm|tool, model_or_tool, prompt_tokens, completion_tokens,
+cost_usd, label?, reserved?}` — identical to the Python package's
+`export_log()`, so every agent produces the same shape regardless of stack.
+
 ## Compatibility
 
 `ai` is declared as a peer dependency with the range `>=4.0.0 <6.0.0`:

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "ai": "^4.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -33,6 +33,33 @@ import {
 /** Tolerance for float rounding in the running spend total (well below $0.000001). */
 const EPS = 1e-12;
 
+/**
+ * One priced spend event in the guard's per-call ledger.
+ *
+ * Every {@link BudgetGuard.record} / {@link BudgetGuard.settle} /
+ * {@link BudgetGuard.recordTool} that accrues spend appends exactly one event, so
+ * the ledger's costs sum to `spentUsd` (unless a `maxLogEvents` ring buffer has
+ * evicted old events). The schema is identical in the Python
+ * package (`SpendEvent` in `src/floe_guard/guard.py`) and
+ * {@link BudgetGuard.exportLog} serialises it with the same snake_case keys in
+ * both languages, so every agent emits the same shape regardless of stack.
+ */
+export interface SpendEvent {
+  /** Unix epoch seconds (UTC). */
+  readonly timestamp: number;
+  readonly kind: "llm" | "tool";
+  readonly modelOrTool: string;
+  /** `null` for tool events. */
+  readonly promptTokens: number | null;
+  /** `null` for tool events. */
+  readonly completionTokens: number | null;
+  readonly costUsd: number;
+  /** Caller-supplied tag (agent/task name). */
+  readonly label?: string;
+  /** The reservation settled by this call, if any. */
+  readonly reserved?: number;
+}
+
 export interface BudgetGuardOptions {
   /** Per-model manual prices for models the bundled cost map cannot price. */
   priceOverrides?: Record<string, ManualPrice>;
@@ -53,6 +80,13 @@ export interface BudgetGuardOptions {
    * flags `nearLimit` so an agent can taper before the hard-stop. Default 8000.
    */
   nearLimitBps?: number;
+  /**
+   * Optional cap on the per-call spend ledger ({@link BudgetGuard.spendLog}).
+   * When set, the ledger is a ring buffer keeping the most recent N events so a
+   * long-running agent's memory stays bounded; the running totals are
+   * unaffected. Default: keep every event.
+   */
+  maxLogEvents?: number;
 }
 
 /**
@@ -92,6 +126,9 @@ export class BudgetGuard {
   private lastCost = 0;
   /** USD held for in-flight calls (reserved, not yet settled). Counts toward the ceiling. */
   private reserved = 0;
+  /** Per-call ledger, oldest first; a ring buffer when maxLogEvents is set. */
+  private readonly spendEvents: SpendEvent[] = [];
+  private readonly maxLogEvents?: number;
 
   /**
    * @param limitUsd the spend ceiling, in USD. `0` blocks the very first call.
@@ -112,7 +149,16 @@ export class BudgetGuard {
         `nearLimitBps must be an integer in 0..10000, got ${nearLimitBps}`,
       );
     }
+    if (
+      options.maxLogEvents !== undefined &&
+      (!Number.isInteger(options.maxLogEvents) || options.maxLogEvents < 0)
+    ) {
+      throw new RangeError(
+        `maxLogEvents must be a non-negative integer, got ${options.maxLogEvents}`,
+      );
+    }
     this.limitUsd = limitUsd;
+    this.maxLogEvents = options.maxLogEvents;
     this.priceOverrides = options.priceOverrides;
     this.failClosed = options.failClosed ?? true;
     this.onBlock = options.onBlock ?? defaultOnBlock;
@@ -181,13 +227,16 @@ export class BudgetGuard {
    * Release a reservation and record the actual cost. `record` is `settle` with
    * no reservation. Returns the USD cost of this call; unpriceable-model handling
    * matches {@link BudgetGuard.record}, and any held reservation is released even
-   * on the warn-and-skip path.
+   * on the warn-and-skip path. A priced call appends one {@link SpendEvent} to
+   * {@link BudgetGuard.spendLog} (`label` tags it, e.g. with an agent/task name);
+   * the warn-and-skip path accrues nothing and logs nothing, so the ledger stays
+   * in lockstep with `spentUsd`.
    */
   settle(
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { reserved?: number; price?: ManualPrice } = {},
+    options: { reserved?: number; price?: ManualPrice; label?: string } = {},
   ): number {
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt this.reserved and break the ceiling for
@@ -237,6 +286,18 @@ export class BudgetGuard {
       this.spentUsd = this.limitUsd;
     }
     this.lastCost = cost;
+    this.appendEvent({
+      timestamp: Date.now() / 1000,
+      kind: "llm",
+      modelOrTool: model,
+      promptTokens,
+      completionTokens,
+      costUsd: cost,
+      ...(options.label !== undefined ? { label: options.label } : {}),
+      // 0 means "no reservation" (the plain record() path) — omit rather than
+      // log a meaningless zero.
+      ...(reserved ? { reserved } : {}),
+    });
     return cost;
   }
 
@@ -251,12 +312,46 @@ export class BudgetGuard {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { price?: ManualPrice } = {},
+    options: { price?: ManualPrice; label?: string } = {},
   ): number {
     return this.settle(model, promptTokens, completionTokens, {
       reserved: 0,
       price: options.price,
+      label: options.label,
     });
+  }
+
+  /**
+   * Accrue a non-LLM cost (a paid tool/API call) against the same ceiling.
+   *
+   * Tools with direct dollar costs — search APIs, scrapers, sandboxes — spend the
+   * same budget the LLM calls do; `recordTool` folds them into `spentUsd` (so
+   * `check()` / `reserve()` see them) and appends a `kind: "tool"`
+   * {@link SpendEvent} to {@link BudgetGuard.spendLog}. The caller supplies the
+   * cost: tools have no token usage to price. Deliberately does NOT update the
+   * next-call estimate — that predicts the next *LLM* call, and a tool's price
+   * would skew it. Returns `costUsd`.
+   */
+  recordTool(tool: string, costUsd: number, options: { label?: string } = {}): number {
+    if (!Number.isFinite(costUsd) || costUsd < 0) {
+      throw new RangeError(`costUsd must be a finite, non-negative number, got ${costUsd}`);
+    }
+    this.spentUsd += costUsd;
+    // Same sub-epsilon clamp as settle(): never report a rounding-artifact
+    // crossing of the ceiling.
+    if (this.spentUsd - this.limitUsd > 0 && this.spentUsd - this.limitUsd < EPS) {
+      this.spentUsd = this.limitUsd;
+    }
+    this.appendEvent({
+      timestamp: Date.now() / 1000,
+      kind: "tool",
+      modelOrTool: tool,
+      promptTokens: null,
+      completionTokens: null,
+      costUsd,
+      ...(options.label !== undefined ? { label: options.label } : {}),
+    });
+    return costUsd;
   }
 
   /**
@@ -276,6 +371,55 @@ export class BudgetGuard {
   /** USD left before the ceiling, net of in-flight reservations (never negative). */
   get remainingUsd(): number {
     return Math.max(0, this.limitUsd - this.spentUsd - this.reserved);
+  }
+
+  /**
+   * The per-call spend ledger, oldest first — one {@link SpendEvent} per priced
+   * `record()` / `settle()` / `recordTool()`. Returns a snapshot copy: mutating
+   * it cannot corrupt the ledger.
+   */
+  get spendLog(): SpendEvent[] {
+    return [...this.spendEvents];
+  }
+
+  /**
+   * The spend ledger as JSONL — one event per line, newline-terminated.
+   *
+   * The schema is stable and language-independent (snake_case keys, fixed order;
+   * optional fields omitted when absent), identical to the Python package's
+   * `export_log()`, so heterogeneous agents produce logs you can concatenate and
+   * analyse as one stream. (The *schema* is the contract, not the bytes: the two
+   * runtimes may render the same float differently, e.g. JS `0.0000025` vs
+   * Python `2.5e-06`.) Empty ledger yields `""`.
+   */
+  exportLog(): string {
+    return this.spendEvents
+      .map((e) => {
+        // snake_case wire shape, fixed key order — the cross-language schema.
+        const row: Record<string, unknown> = {
+          timestamp: e.timestamp,
+          kind: e.kind,
+          model_or_tool: e.modelOrTool,
+          prompt_tokens: e.promptTokens,
+          completion_tokens: e.completionTokens,
+          cost_usd: e.costUsd,
+        };
+        if (e.label !== undefined) row.label = e.label;
+        if (e.reserved !== undefined) row.reserved = e.reserved;
+        return `${JSON.stringify(row)}\n`;
+      })
+      .join("");
+  }
+
+  private appendEvent(event: SpendEvent): void {
+    // Frozen for parity with Python's frozen dataclass: spendLog copies the
+    // array but shares the event objects, so an unfrozen event would let a
+    // consumer silently rewrite logged history.
+    this.spendEvents.push(Object.freeze(event));
+    if (this.maxLogEvents !== undefined && this.spendEvents.length > this.maxLogEvents) {
+      // Ring buffer: drop the oldest overflow (at most one per append).
+      this.spendEvents.splice(0, this.spendEvents.length - this.maxLogEvents);
+    }
   }
 
   /**

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -10,6 +10,7 @@ export {
   BudgetGuard,
   type BudgetGuardOptions,
   type BudgetAdvisory,
+  type SpendEvent,
 } from "./guard.js";
 export {
   FloeGuardError,

--- a/js/test/spend-log.test.ts
+++ b/js/test/spend-log.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BudgetExceeded, BudgetGuard } from "../src/index.js";
+
+const MODEL = "gpt-4o"; // 1k in + 1k out = $0.0025 + $0.01 = $0.0125/call
+
+describe("BudgetGuard.spendLog", () => {
+  it("every priced call appends one event and the ledger sums to spentUsd", () => {
+    const guard = new BudgetGuard(1.0);
+    const n = 7;
+    for (let i = 0; i < n; i++) {
+      guard.record(MODEL, 1_000, 1_000);
+    }
+    const log = guard.spendLog;
+    expect(log).toHaveLength(n);
+    const total = log.reduce((sum, e) => sum + e.costUsd, 0);
+    expect(total).toBeCloseTo(guard.spentUsd, 12);
+  });
+
+  it("llm event schema", () => {
+    const guard = new BudgetGuard(1.0);
+    const cost = guard.record(MODEL, 1_200, 350, { label: "researcher" });
+    const [event] = guard.spendLog;
+    expect(event.kind).toBe("llm");
+    expect(event.modelOrTool).toBe(MODEL);
+    expect(event.promptTokens).toBe(1_200);
+    expect(event.completionTokens).toBe(350);
+    expect(event.costUsd).toBeCloseTo(cost, 12);
+    expect(event.label).toBe("researcher");
+    expect(event.reserved).toBeUndefined(); // plain record(): no reservation to log
+    expect(event.timestamp).toBeGreaterThan(0);
+  });
+
+  it("settle logs the reservation it settled", () => {
+    const guard = new BudgetGuard(1.0);
+    const handle = guard.reserve(0.05);
+    guard.settle(MODEL, 1_000, 1_000, { reserved: handle });
+    const [event] = guard.spendLog;
+    expect(event.reserved).toBeCloseTo(0.05, 12);
+  });
+
+  it("recordTool accrues and logs a tool event", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.record(MODEL, 1_000, 1_000);
+    const returned = guard.recordTool("serpapi.search", 0.01, { label: "researcher" });
+    expect(returned).toBeCloseTo(0.01, 12);
+    expect(guard.spentUsd).toBeCloseTo(0.0125 + 0.01, 12);
+    const toolEvent = guard.spendLog.at(-1)!;
+    expect(toolEvent.kind).toBe("tool");
+    expect(toolEvent.modelOrTool).toBe("serpapi.search");
+    expect(toolEvent.promptTokens).toBeNull();
+    expect(toolEvent.completionTokens).toBeNull();
+    expect(toolEvent.costUsd).toBeCloseTo(0.01, 12);
+    expect(toolEvent.label).toBe("researcher");
+    const total = guard.spendLog.reduce((sum, e) => sum + e.costUsd, 0);
+    expect(total).toBeCloseTo(guard.spentUsd, 12);
+  });
+
+  it("recordTool spend counts toward the ceiling", () => {
+    const guard = new BudgetGuard(0.05, { onBlock: () => {} });
+    guard.recordTool("scraper", 0.05);
+    expect(() => guard.check()).toThrow(BudgetExceeded);
+  });
+
+  it("recordTool rejects bad costs", () => {
+    const guard = new BudgetGuard(1.0);
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -0.01]) {
+      expect(() => guard.recordTool("tool", bad)).toThrow(RangeError);
+    }
+    expect(guard.spendLog).toHaveLength(0);
+  });
+
+  it("the unpriceable skip path logs nothing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const guard = new BudgetGuard(1.0, { failClosed: false });
+      guard.record("model-that-does-not-exist", 1_000, 1_000);
+      expect(guard.spendLog).toHaveLength(0);
+      expect(guard.spentUsd).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("maxLogEvents is a ring buffer keeping the newest", () => {
+    const guard = new BudgetGuard(10.0, { maxLogEvents: 3 });
+    for (let i = 0; i < 5; i++) {
+      guard.record(MODEL, 1_000, 1_000, { label: `call-${i}` });
+    }
+    expect(guard.spendLog.map((e) => e.label)).toEqual(["call-2", "call-3", "call-4"]);
+    // The cap bounds the ledger only — totals still cover all 5 calls.
+    expect(guard.spentUsd).toBeCloseTo(5 * 0.0125, 12);
+  });
+
+  it("maxLogEvents: 0 disables the ledger but not the totals", () => {
+    const guard = new BudgetGuard(1.0, { maxLogEvents: 0 });
+    guard.record(MODEL, 1_000, 1_000);
+    expect(guard.spendLog).toHaveLength(0);
+    expect(guard.exportLog()).toBe("");
+    expect(guard.spentUsd).toBeCloseTo(0.0125, 12);
+  });
+
+  it("maxLogEvents validation", () => {
+    for (const bad of [-1, 1.5, Number.NaN]) {
+      expect(() => new BudgetGuard(1.0, { maxLogEvents: bad })).toThrow(RangeError);
+    }
+  });
+
+  it("spendLog returns a snapshot copy", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.record(MODEL, 1_000, 1_000);
+    const snapshot = guard.spendLog;
+    snapshot.length = 0;
+    expect(guard.spendLog).toHaveLength(1);
+  });
+});
+
+describe("BudgetGuard.exportLog", () => {
+  it("emits stable, Python-compatible JSONL", () => {
+    const guard = new BudgetGuard(1.0);
+    const handle = guard.reserve(0.02);
+    guard.settle(MODEL, 1_000, 1_000, { reserved: handle, label: "writer" });
+    guard.record(MODEL, 500, 100);
+    guard.recordTool("browser", 0.001);
+
+    const out = guard.exportLog();
+    expect(out.endsWith("\n")).toBe(true);
+    const lines = out.trimEnd().split("\n");
+    expect(lines).toHaveLength(3);
+
+    const [settled, recorded, tool] = lines.map((l) => JSON.parse(l));
+    // Fixed snake_case key order, optional fields present only when set — the
+    // schema the Python package's export_log() emits field-for-field.
+    expect(Object.keys(settled)).toEqual([
+      "timestamp",
+      "kind",
+      "model_or_tool",
+      "prompt_tokens",
+      "completion_tokens",
+      "cost_usd",
+      "label",
+      "reserved",
+    ]);
+    expect(Object.keys(recorded)).toEqual([
+      "timestamp",
+      "kind",
+      "model_or_tool",
+      "prompt_tokens",
+      "completion_tokens",
+      "cost_usd",
+    ]);
+    expect(tool.kind).toBe("tool");
+    expect(tool.prompt_tokens).toBeNull();
+    expect(tool.completion_tokens).toBeNull();
+    const total = [settled, recorded, tool].reduce((sum, row) => sum + row.cost_usd, 0);
+    expect(total).toBeCloseTo(guard.spentUsd, 12);
+  });
+
+  it("keeps unicode raw, matching Python's ensure_ascii=False", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.record(MODEL, 10, 10, { label: "café-agent" });
+    expect(guard.exportLog()).toContain("café-agent");
+  });
+
+  it("an empty ledger exports as the empty string", () => {
+    expect(new BudgetGuard(1.0).exportLog()).toBe("");
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.2.0"
+version = "0.3.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -20,15 +20,16 @@ from .errors import (
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
-from .guard import BudgetAdvisory, BudgetGuard
+from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
+    "SpendEvent",
     "BudgetExceeded",
     "FloeGuardError",
     "HostedEnforcementError",

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -24,7 +24,7 @@ from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 
-__version__ = "0.2.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.3.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -27,12 +27,16 @@ upgrade (see the README).
 
 from __future__ import annotations
 
+import json
 import math
 import sys
 import threading
+import time
 import warnings
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 from .errors import (
     BudgetExceeded,
@@ -69,6 +73,52 @@ class BudgetAdvisory:
     scope: str = "local"  # hosted reports the tightest cap across all scopes
 
 
+@dataclass(frozen=True)
+class SpendEvent:
+    """One priced spend event in the guard's per-call ledger.
+
+    Every :meth:`BudgetGuard.record` / :meth:`BudgetGuard.settle` /
+    :meth:`BudgetGuard.record_tool` that accrues spend appends exactly one event,
+    so ``sum(e.cost_usd for e in guard.spend_log)`` equals ``guard.spent_usd``
+    (unless a ``max_log_events`` ring buffer has evicted old events).
+    The schema is identical in the TS package (``SpendEvent`` in ``js/src/guard.ts``)
+    and :meth:`BudgetGuard.export_log` serialises it with the same snake_case keys
+    in both languages, so every agent emits the same shape regardless of stack.
+    """
+
+    timestamp: float  # Unix epoch seconds (UTC)
+    kind: Literal["llm", "tool"]
+    model_or_tool: str
+    prompt_tokens: int | None  # None for tool events
+    completion_tokens: int | None  # None for tool events
+    cost_usd: float
+    label: str | None = None  # caller-supplied tag (agent/task name)
+    reserved: float | None = None  # the reservation settled by this call, if any
+
+    def to_dict(self) -> dict[str, object]:
+        """The stable wire shape used by :meth:`BudgetGuard.export_log`.
+
+        Key order is fixed and the optional fields (``label``, ``reserved``) are
+        omitted when absent — not emitted as null — matching the TS package's
+        ``exportLog()`` field-for-field. (The *schema* is the contract, not the
+        bytes: the two runtimes may render the same float differently, e.g.
+        Python ``2.5e-06`` vs JS ``0.0000025``.)
+        """
+        out: dict[str, object] = {
+            "timestamp": self.timestamp,
+            "kind": self.kind,
+            "model_or_tool": self.model_or_tool,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "cost_usd": self.cost_usd,
+        }
+        if self.label is not None:
+            out["label"] = self.label
+        if self.reserved is not None:
+            out["reserved"] = self.reserved
+        return out
+
+
 class BudgetGuard:
     """Hard-stop an agent before its next LLM call crosses a USD ceiling.
 
@@ -87,6 +137,10 @@ class BudgetGuard:
         near_limit_bps: utilization (basis points, 0..10000) at which
             :meth:`advisory` flags ``near_limit`` so an agent can taper before the
             hard-stop. Defaults to ``8000`` (80%).
+        max_log_events: optional cap on the per-call spend ledger
+            (:attr:`spend_log`). When set, the ledger is a ring buffer keeping the
+            most recent N events so a long-running agent's memory stays bounded;
+            the running totals are unaffected. ``None`` (default) keeps every event.
 
     Thread-safe: the running total and in-flight reservations are guarded by a
     lock, so the guard can back a parallel crew (use :meth:`reserve` /
@@ -101,6 +155,7 @@ class BudgetGuard:
         fail_closed: bool = True,
         on_block: Callable[[float, float], None] | None = None,
         near_limit_bps: int = 8000,
+        max_log_events: int | None = None,
     ) -> None:
         if not math.isfinite(limit_usd) or limit_usd < 0:
             # NaN/inf would make every check() comparison evaluate False and
@@ -127,6 +182,17 @@ class BudgetGuard:
         # USD held for calls that are in flight (reserved but not yet settled).
         # Counted against the ceiling so concurrent callers can't overshoot.
         self._reserved = 0.0
+        # Same int-not-bool contract as near_limit_bps (parity with TS Number.isInteger).
+        if max_log_events is not None and (
+            isinstance(max_log_events, bool)
+            or not isinstance(max_log_events, int)
+            or max_log_events < 0
+        ):
+            raise ValueError(
+                f"max_log_events must be None or a non-negative int, got {max_log_events!r}"
+            )
+        # Per-call ledger; deque(maxlen=None) is unbounded, otherwise a ring buffer.
+        self._spend_log: deque[SpendEvent] = deque(maxlen=max_log_events)
         self._lock = threading.Lock()
 
     # ── enforcement ───────────────────────────────────────────────────────────
@@ -181,13 +247,17 @@ class BudgetGuard:
         *,
         reserved: float = 0.0,
         price: ManualPrice | None = None,
+        label: str | None = None,
     ) -> float:
         """Release a reservation and record the actual cost. Concurrency-safe.
 
         ``record`` is ``settle`` with no reservation. Returns the USD cost of
         this call. Unpriceable-model handling matches :meth:`record` (warn +
         raise when ``fail_closed``, else warn + skip), and any held reservation
-        is released even on the skip path.
+        is released even on the skip path. A priced call appends one
+        :class:`SpendEvent` to :attr:`spend_log` (``label`` tags it, e.g. with an
+        agent or task name); the warn-and-skip path accrues nothing and logs
+        nothing, so the ledger stays in lockstep with ``spent_usd``.
         """
         # A bad reserved handle would corrupt _reserved and break the ceiling for
         # OTHER in-flight calls (negative → phantom hold; inf → clears all holds).
@@ -229,6 +299,20 @@ class BudgetGuard:
             if 0.0 < self.spent_usd - self.limit_usd < _EPS:
                 self.spent_usd = self.limit_usd
             self._last_cost = cost
+            self._spend_log.append(
+                SpendEvent(
+                    timestamp=time.time(),
+                    kind="llm",
+                    model_or_tool=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    cost_usd=cost,
+                    label=label,
+                    # 0.0 means "no reservation" (the plain record() path) — omit
+                    # rather than log a meaningless zero.
+                    reserved=reserved if reserved else None,
+                )
+            )
         return cost
 
     def record(
@@ -238,6 +322,7 @@ class BudgetGuard:
         completion_tokens: int,
         *,
         price: ManualPrice | None = None,
+        label: str | None = None,
     ) -> float:
         """Price one response's tokens offline and add the cost to the total.
 
@@ -245,7 +330,44 @@ class BudgetGuard:
         ``price`` is given, behaviour depends on ``fail_closed`` (see the class
         docstring): warn + raise (default), or warn + skip accrual.
         """
-        return self.settle(model, prompt_tokens, completion_tokens, reserved=0.0, price=price)
+        return self.settle(
+            model, prompt_tokens, completion_tokens, reserved=0.0, price=price, label=label
+        )
+
+    def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
+        """Accrue a non-LLM cost (a paid tool/API call) against the same ceiling.
+
+        Tools with direct dollar costs — search APIs, scrapers, sandboxes — spend
+        the same budget the LLM calls do; ``record_tool`` folds them into
+        ``spent_usd`` (so :meth:`check` / :meth:`reserve` see them) and appends a
+        ``kind="tool"`` :class:`SpendEvent` to :attr:`spend_log`. The caller
+        supplies the cost: tools have no token usage to price. Deliberately does
+        NOT update the next-call estimate — that predicts the next *LLM* call, and
+        a tool's price would skew it. Returns ``cost_usd``.
+        """
+        if not math.isfinite(cost_usd) or cost_usd < 0:
+            raise ValueError(f"cost_usd must be a finite, non-negative number, got {cost_usd!r}")
+        # int (and bool) are valid inputs; coerce so the logged event and the
+        # return value are always float, like every other cost in the guard.
+        cost_usd = float(cost_usd)
+        with self._lock:
+            self.spent_usd += cost_usd
+            # Same sub-epsilon clamp as settle(): never report a rounding-artifact
+            # crossing of the ceiling.
+            if 0.0 < self.spent_usd - self.limit_usd < _EPS:
+                self.spent_usd = self.limit_usd
+            self._spend_log.append(
+                SpendEvent(
+                    timestamp=time.time(),
+                    kind="tool",
+                    model_or_tool=tool,
+                    prompt_tokens=None,
+                    completion_tokens=None,
+                    cost_usd=cost_usd,
+                    label=label,
+                )
+            )
+        return cost_usd
 
     def release(self, reserved: float) -> None:
         """Drop an in-flight reservation without recording spend (e.g. the call
@@ -265,6 +387,34 @@ class BudgetGuard:
         """USD left before the ceiling, net of in-flight reservations (never negative)."""
         with self._lock:
             return max(0.0, self.limit_usd - self.spent_usd - self._reserved)
+
+    @property
+    def spend_log(self) -> list[SpendEvent]:
+        """The per-call spend ledger, oldest first — one :class:`SpendEvent` per
+        priced :meth:`record` / :meth:`settle` / :meth:`record_tool`.
+
+        Returns a snapshot copy: safe to iterate while other threads keep
+        recording, and mutating it cannot corrupt the ledger.
+        """
+        with self._lock:
+            return list(self._spend_log)
+
+    def export_log(self) -> str:
+        """The spend ledger as JSONL — one event per line, newline-terminated.
+
+        The schema is stable and language-independent (snake_case keys, fixed
+        order; optional fields omitted when absent), identical to the TS
+        package's ``exportLog()``, so heterogeneous agents produce logs you can
+        concatenate and analyse as one stream. Empty ledger yields ``""``.
+        """
+        # Compact separators and raw (non-escaped) unicode match JS
+        # JSON.stringify's layout; float rendering may still differ between the
+        # runtimes (2.5e-06 vs 0.0000025) — the schema, not the bytes, is the
+        # cross-language contract.
+        return "".join(
+            f"{json.dumps(event.to_dict(), separators=(',', ':'), ensure_ascii=False)}\n"
+            for event in self.spend_log
+        )
 
     def advisory(self) -> BudgetAdvisory:
         """Context-aware spend advisory for this budget — see :class:`BudgetAdvisory`.

--- a/tests/test_spend_log.py
+++ b/tests/test_spend_log.py
@@ -1,0 +1,168 @@
+"""Tests for the per-call spend ledger (guard.spend_log / export_log / record_tool)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from floe_guard import BudgetExceeded, BudgetGuard, SpendEvent, UnpriceableModelWarning
+
+MODEL = "gpt-4o"  # 1k in + 1k out = $0.0025 + $0.01 = $0.0125/call
+
+
+def test_every_priced_call_appends_one_event_and_ledger_sums_to_spent() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    n = 7
+    for _ in range(n):
+        guard.record(MODEL, 1_000, 1_000)
+    log = guard.spend_log
+    assert len(log) == n
+    assert all(isinstance(e, SpendEvent) for e in log)
+    assert sum(e.cost_usd for e in log) == pytest.approx(guard.spent_usd)
+
+
+def test_llm_event_schema() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    cost = guard.record(MODEL, 1_200, 350, label="researcher")
+    (event,) = guard.spend_log
+    assert event.kind == "llm"
+    assert event.model_or_tool == MODEL
+    assert event.prompt_tokens == 1_200
+    assert event.completion_tokens == 350
+    assert event.cost_usd == pytest.approx(cost)
+    assert event.label == "researcher"
+    assert event.reserved is None  # plain record(): no reservation to log
+    assert event.timestamp > 0
+
+
+def test_settle_logs_the_reservation_it_settled() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.05)
+    guard.settle(MODEL, 1_000, 1_000, reserved=handle)
+    (event,) = guard.spend_log
+    assert event.reserved == pytest.approx(0.05)
+
+
+def test_record_tool_accrues_and_logs_a_tool_event() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard.record(MODEL, 1_000, 1_000)
+    returned = guard.record_tool("serpapi.search", 0.01, label="researcher")
+    assert returned == pytest.approx(0.01)
+    assert guard.spent_usd == pytest.approx(0.0125 + 0.01)
+    tool_event = guard.spend_log[-1]
+    assert tool_event.kind == "tool"
+    assert tool_event.model_or_tool == "serpapi.search"
+    assert tool_event.prompt_tokens is None
+    assert tool_event.completion_tokens is None
+    assert tool_event.cost_usd == pytest.approx(0.01)
+    assert tool_event.label == "researcher"
+    # The ledger invariant holds across mixed llm + tool events.
+    assert sum(e.cost_usd for e in guard.spend_log) == pytest.approx(guard.spent_usd)
+
+
+def test_record_tool_spend_counts_toward_the_ceiling() -> None:
+    guard = BudgetGuard(limit_usd=0.05)
+    guard.record_tool("scraper", 0.05)
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+
+
+def test_record_tool_rejects_bad_costs() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    for bad in (float("nan"), float("inf"), -0.01):
+        with pytest.raises(ValueError):
+            guard.record_tool("tool", bad)
+    assert guard.spend_log == []
+
+
+def test_unpriceable_skip_path_logs_nothing() -> None:
+    guard = BudgetGuard(limit_usd=1.00, fail_closed=False)
+    with pytest.warns(UnpriceableModelWarning):
+        guard.record("model-that-does-not-exist", 1_000, 1_000)
+    assert guard.spend_log == []
+    assert guard.spent_usd == 0.0
+
+
+def test_max_log_events_is_a_ring_buffer_keeping_the_newest() -> None:
+    guard = BudgetGuard(limit_usd=10.00, max_log_events=3)
+    for i in range(5):
+        guard.record(MODEL, 1_000, 1_000, label=f"call-{i}")
+    log = guard.spend_log
+    assert [e.label for e in log] == ["call-2", "call-3", "call-4"]
+    # The cap bounds the ledger only — totals still cover all 5 calls.
+    assert guard.spent_usd == pytest.approx(5 * 0.0125)
+
+
+def test_max_log_events_zero_disables_the_ledger_but_not_the_totals() -> None:
+    guard = BudgetGuard(limit_usd=1.00, max_log_events=0)
+    guard.record(MODEL, 1_000, 1_000)
+    assert guard.spend_log == []
+    assert guard.export_log() == ""
+    assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_max_log_events_validation() -> None:
+    for bad in (-1, 1.5, True):
+        with pytest.raises(ValueError):
+            BudgetGuard(limit_usd=1.00, max_log_events=bad)  # type: ignore[arg-type]
+
+
+def test_spend_log_returns_a_snapshot_copy() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard.record(MODEL, 1_000, 1_000)
+    snapshot = guard.spend_log
+    snapshot.clear()
+    assert len(guard.spend_log) == 1
+
+
+def test_export_log_is_stable_jsonl() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.02)
+    guard.settle(MODEL, 1_000, 1_000, reserved=handle, label="writer")
+    guard.record(MODEL, 500, 100)
+    guard.record_tool("browser", 0.001)
+
+    out = guard.export_log()
+    assert out.endswith("\n")
+    lines = out.splitlines()
+    assert len(lines) == 3
+
+    settled, recorded, tool = (json.loads(line) for line in lines)
+    # Fixed key order, optional fields present only when set — the schema the TS
+    # package's exportLog() emits field-for-field.
+    assert list(settled) == [
+        "timestamp",
+        "kind",
+        "model_or_tool",
+        "prompt_tokens",
+        "completion_tokens",
+        "cost_usd",
+        "label",
+        "reserved",
+    ]
+    assert list(recorded) == [
+        "timestamp",
+        "kind",
+        "model_or_tool",
+        "prompt_tokens",
+        "completion_tokens",
+        "cost_usd",
+    ]
+    assert tool["kind"] == "tool"
+    assert tool["prompt_tokens"] is None and tool["completion_tokens"] is None
+    assert sum(row["cost_usd"] for row in (settled, recorded, tool)) == pytest.approx(
+        guard.spent_usd
+    )
+
+
+def test_export_log_keeps_unicode_raw_like_json_stringify() -> None:
+    # JS JSON.stringify never \u-escapes non-ASCII; the Python export must not
+    # either, or the same label would serialise differently per language.
+    guard = BudgetGuard(limit_usd=1.00)
+    guard.record(MODEL, 10, 10, label="café-agent")
+    assert "café-agent" in guard.export_log()
+
+
+def test_export_log_empty_ledger_is_empty_string() -> None:
+    assert BudgetGuard(limit_usd=1.00).export_log() == ""


### PR DESCRIPTION
## Summary
* **New Features**
  * Added a per-call spend ledger for LLM and tool/API costs.
  * Added labels for spend events and support for reservation tracking.
  * Added JSONL export with a stable, cross-language format.
  * Added optional log size limits while preserving total spend accounting.
  * Added tool cost recording that respects budget limits.
* **Documentation**
  * Documented spend logging, event fields, limits, and JSONL export.
* **Tests**
  * Added comprehensive coverage for ledger behavior, validation, exports, and budget enforcement.

## Testing
How was this tested?

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)