### PR TITLE
feat:request-sized pre-call estimates and mid-stream budget enforceme…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.4.0 — 2026-07-14
+
+### Added (py)
+
+- **Request-sized pre-call estimates**: `BudgetGuard.estimate_call(model,
+  prompt_tokens, max_completion_tokens)` prices the actual incoming request
+  from the cost map, so `reserve(est)` / `check(est)` block an oversized call
+  — including the very first one, which the last-cost prediction is blind to.
+  The LiteLLM adapter reserves request-sized automatically (prompt via
+  `litellm.token_counter`, cap from `max_tokens`); the LangChain handler sizes
+  its pre-call `check()` from the serialized model config and a ~4 chars/token
+  prompt heuristic. Anything unpriceable/unsized falls back to the previous
+  last-cost behaviour.
+- **Mid-stream enforcement**: `StreamGuard` / `guard_stream()` re-price a
+  streaming response chunk-by-chunk and raise `BudgetExceeded`
+  mid-generation when the running call would cross the ceiling — the partial
+  spend is settled (and lands in `spend_log`) instead of the whole overshoot
+  being discovered post-mortem. `finish(prompt_tokens=…, completion_tokens=…)`
+  reconciles the chunk heuristic to provider-reported usage; unpriceable
+  models fail closed before the stream starts. Demo:
+  `examples/streaming_guard.py` (no API key).
+
 ## py 0.3.0 / js 0.3.0 — 2026-07-14
 
 ### Added (py + js)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
-## py 0.4.0 — 2026-07-14
+## py 0.4.0 — 2026-07-15
 
 ### Added (py)
 
@@ -29,8 +29,10 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   spend is settled (and lands in `spend_log`) instead of the whole overshoot
   being discovered post-mortem. `finish(prompt_tokens=…, completion_tokens=…)`
   reconciles the chunk heuristic to provider-reported usage; unpriceable
-  models fail closed before the stream starts. Demo:
-  `examples/streaming_guard.py` (no API key).
+  models fail closed before the stream starts; parallel streams count each
+  other's in-flight accrual, so unreserved streams share the ceiling instead
+  of each spending it in full. Demo: `examples/streaming_guard.py` (no API
+  key).
 
 ## py 0.3.0 / js 0.3.0 — 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,45 @@ cost_usd, label?, reserved?}` — identical to the TS package's `exportLog()`, s
 every agent produces the same shape regardless of stack and the streams can be
 concatenated and analysed together.
 
+## Request-sized estimates and mid-stream enforcement
+
+Two gaps in last-cost prediction, closed in 0.4.0 (Python):
+
+**The oversized first call.** `check()`/`reserve()` predict from the *last*
+call — blind on call #1, wrong for a call much bigger than the previous one.
+`estimate_call()` prices the **actual incoming request** so even a first call
+that alone would cross the cap blocks pre-flight:
+
+```python
+est = guard.estimate_call("gpt-4o", prompt_tokens=12_000, max_completion_tokens=4_096)
+handle = guard.reserve(est)   # raises BudgetExceeded NOW if this call can't fit
+```
+
+The LiteLLM adapter does this automatically (prompt tokens via
+`litellm.token_counter`, output cap from `max_tokens`), and the LangChain
+handler sizes its pre-call `check()` the same way. Unpriceable or unsized
+requests fall back to the old last-cost prediction — the wiring only ever
+tightens enforcement.
+
+**The stream that runs long.** `record()` meters a *completed* response — too
+late for a generation that starts cheap and keeps going. `guard_stream()` (or
+the underlying `StreamGuard`) re-prices the call on every chunk and cuts the
+stream off **mid-generation**, settling the tokens actually consumed instead of
+recording a big overshoot after the fact:
+
+```python
+from floe_guard import guard_stream
+
+for chunk in guard_stream(guard, "gpt-4o", stream, prompt_tokens=1_000):
+    print(chunk, end="")   # raises BudgetExceeded mid-stream at the ceiling
+```
+
+Chunk sizes are estimated at ~4 chars/token (pass `count_tokens=` for a real
+tokenizer); the final accrual reconciles to provider-reported usage via
+`StreamGuard.finish(...)`. See
+[`examples/streaming_guard.py`](examples/streaming_guard.py) for a runnable
+demo (no API key).
+
 ## Framework adapters (optional extras)
 
 ### CrewAI
@@ -320,10 +359,13 @@ vendored cost map *inside your process*:
 - It only sees the vendors you instrument.
 - A determined agent or a bug could route around an in-process check.
 - Under heavy or cold-start concurrency it bounds steady-state spend, not the
-  first parallel wave. Reservations size from the last call's cost (`0` until the
-  first `record()`), so the opening fan-out has nothing to estimate from. Pass a
-  known per-call max to `reserve()` to bound it, or use hosted Floe for a hard cap
+  first parallel wave. Reservations default to the last call's cost (`0` until
+  the first `record()`) — size them to the real request with `estimate_call()`
+  (the LiteLLM adapter does this for you), or use hosted Floe for a hard cap
   under arbitrary concurrency.
+- Mid-stream enforcement (`guard_stream`) prices chunks by a ~4 chars/token
+  heuristic unless you supply a tokenizer, so the cut-off point is approximate;
+  the final accrual reconciles to provider-reported usage.
 
 It's genuinely useful on its own, and it's honest about its limits. No inflated
 metrics, no "zero defaults" claims — it's a free local stop, not a vault.

--- a/examples/streaming_guard.py
+++ b/examples/streaming_guard.py
@@ -1,0 +1,67 @@
+"""Mid-stream kill-switch demo — runs with NO API key and NO account.
+
+Two enforcement gaps this demo closes (both new in 0.4.0):
+
+1. **The oversized first call.** ``check()``/``reserve()`` predict the next
+   call from the LAST one — on call #1 there is no baseline, so a huge request
+   sails through and the overshoot is only discovered after the money is spent.
+   ``estimate_call()`` prices the ACTUAL request (real prompt size + output
+   cap) so the very first call blocks pre-flight if it alone would cross.
+
+2. **The stream that runs long.** ``record()`` meters a COMPLETED response —
+   too late to stop a generation that starts cheap and keeps going.
+   ``guard_stream()`` re-prices the call on every chunk and cuts the stream
+   off mid-generation, settling only the tokens actually consumed.
+
+Run it::
+
+    python examples/streaming_guard.py
+
+The "LLM" is a stub generator — no network, no key. Costs are computed offline
+from the bundled cost map, exactly as for a real ``gpt-4o`` call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from floe_guard import BudgetExceeded, BudgetGuard, guard_stream
+
+MODEL = "gpt-4o"
+
+
+def stub_llm_stream() -> Iterator[str]:
+    """A fake streaming LLM that never stops talking."""
+    while True:
+        yield "and another thing... "  # ~5 tokens per chunk by the heuristic
+
+
+def main() -> None:
+    guard = BudgetGuard(limit_usd=0.01)  # ≙ 1_000 gpt-4o output tokens
+
+    # ── 1. the oversized FIRST call is blocked pre-flight ──────────────────────
+    print(f"Budget: ${guard.limit_usd:.2f}\n")
+    print("1) First call asks for 100k output tokens (≈ $1.00):")
+    estimate = guard.estimate_call(MODEL, prompt_tokens=1_000, max_completion_tokens=100_000)
+    try:
+        guard.reserve(estimate)  # request-sized, so call #1 has no free pass
+    except BudgetExceeded:
+        print("   blocked BEFORE the request was sent — $0.00 spent.\n")
+
+    # ── 2. a stream that starts cheap but runs long is cut off mid-flight ──────
+    print("2) Streaming a response that never wants to stop:")
+    chunks = 0
+    try:
+        for _ in guard_stream(guard, MODEL, stub_llm_stream()):
+            chunks += 1
+    except BudgetExceeded:
+        print(f"   stream cut off mid-generation after {chunks} chunks.")
+        print(f"   spent ${guard.spent_usd:.4f} of the ${guard.limit_usd:.2f} ceiling — "
+              "the partial spend is settled, not lost:")
+        for event in guard.spend_log:
+            print(f"     ledger: {event.kind} {event.model_or_tool} "
+                  f"{event.completion_tokens} tokens → ${event.cost_usd:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -23,13 +23,16 @@ from .errors import (
 from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
+from .stream import StreamGuard, guard_stream
 
-__version__ = "0.3.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.4.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
     "SpendEvent",
+    "StreamGuard",
+    "guard_stream",
     "BudgetExceeded",
     "FloeGuardError",
     "HostedEnforcementError",

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -193,6 +193,10 @@ class BudgetGuard:
             )
         # Per-call ledger; deque(maxlen=None) is unbounded, otherwise a ring buffer.
         self._spend_log: deque[SpendEvent] = deque(maxlen=max_log_events)
+        # Active streams' (accrued_usd, reserved_usd), keyed by registry token —
+        # see _stream_register(). Lets parallel streams count each other's
+        # in-flight accrual against the ceiling before anything settles.
+        self._stream_costs: dict[object, tuple[float, float]] = {}
         self._lock = threading.Lock()
 
     # ── enforcement ───────────────────────────────────────────────────────────
@@ -484,14 +488,39 @@ class BudgetGuard:
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
 
-    def _stream_would_cross(self, cumulative_call_cost: float, own_reserved: float) -> bool:
-        """Would an in-flight streaming call, at its cumulative cost so far,
-        cross the ceiling? Other calls' reservations still count against the
-        limit; this call's own hold is excluded because its real accrued cost
-        replaces the estimate. Used by :class:`~floe_guard.stream.StreamGuard`.
+    def _stream_register(self, reserved: float) -> object:
+        """Register an active stream (see :class:`~floe_guard.stream.StreamGuard`)
+        and return its registry key. Active streams' accrued-but-unsettled costs
+        count against the ceiling for each OTHER stream, so parallel unreserved
+        streams share the budget instead of each spending the full ceiling."""
+        key = object()
+        with self._lock:
+            self._stream_costs[key] = (0.0, max(0.0, reserved))
+        return key
+
+    def _stream_unregister(self, key: object) -> None:
+        """Drop a stream's registry entry once its cost is settled (settle()
+        moves the accrual into ``spent_usd``, so keeping it would double-count)."""
+        with self._lock:
+            self._stream_costs.pop(key, None)
+
+    def _stream_would_cross(self, key: object, cumulative_call_cost: float) -> bool:
+        """Atomically record stream ``key``'s cumulative cost so far and answer:
+        would it cross the ceiling? Counted against the limit: settled spend,
+        other calls' reservations (this stream's own hold is excluded — its real
+        accrued cost replaces the estimate), and each OTHER active stream's
+        accrual beyond its own reservation (the reservation part is already
+        inside ``_reserved``). Used by :class:`~floe_guard.stream.StreamGuard`.
         """
         with self._lock:
-            others = self.spent_usd + max(0.0, self._reserved - max(0.0, own_reserved))
+            own_reserved = self._stream_costs.get(key, (0.0, 0.0))[1]
+            self._stream_costs[key] = (cumulative_call_cost, own_reserved)
+            other_overage = sum(
+                max(0.0, accrued - held)
+                for k, (accrued, held) in self._stream_costs.items()
+                if k is not key
+            )
+            others = self.spent_usd + max(0.0, self._reserved - own_reserved) + other_overage
             return others + cumulative_call_cost > self.limit_usd + _EPS
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -214,6 +214,36 @@ class BudgetGuard:
         if self._would_cross(estimated_next_cost):
             self._block()
 
+    def estimate_call(
+        self,
+        model: str,
+        prompt_tokens: int,
+        max_completion_tokens: int = 0,
+        *,
+        price: ManualPrice | None = None,
+    ) -> float | None:
+        """Price the ACTUAL incoming request, for a request-sized reserve()/check().
+
+        :meth:`check` and :meth:`reserve` default to predicting the next call
+        from the LAST call's cost — which is blind on the first call and wrong
+        for a call much larger than the previous one. Feed this the request you
+        are about to send (its real prompt size and output cap) and pass the
+        result straight through::
+
+            est = guard.estimate_call("gpt-4o", prompt_tokens, max_completion_tokens=1024)
+            handle = guard.reserve(est)   # blocks NOW if this call alone would cross
+
+        The estimate is worst-case on output (the model may stop well short of
+        ``max_completion_tokens``); the hold is corrected to actual cost at
+        :meth:`settle`. Returns ``None`` when the model is unpriceable — and
+        ``reserve(None)`` / ``check(None)`` fall back to the last-cost
+        prediction, so the wiring degrades gracefully instead of failing.
+        """
+        priced = self._resolve(model, price)
+        if priced is None:
+            return None
+        return price_tokens(priced, prompt_tokens, max_completion_tokens)
+
     def reserve(self, estimated_cost: float | None = None) -> float:
         """Atomically check the ceiling AND hold the estimated cost in-flight.
 
@@ -453,6 +483,16 @@ class BudgetGuard:
         # matching the constructor's math.isfinite guard and the TS Number.isFinite.
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
+
+    def _stream_would_cross(self, cumulative_call_cost: float, own_reserved: float) -> bool:
+        """Would an in-flight streaming call, at its cumulative cost so far,
+        cross the ceiling? Other calls' reservations still count against the
+        limit; this call's own hold is excluded because its real accrued cost
+        replaces the estimate. Used by :class:`~floe_guard.stream.StreamGuard`.
+        """
+        with self._lock:
+            others = self.spent_usd + max(0.0, self._reserved - max(0.0, own_reserved))
+            return others + cumulative_call_cost > self.limit_usd + _EPS
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:
         with self._lock:

--- a/src/floe_guard/integrations/langchain.py
+++ b/src/floe_guard/integrations/langchain.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..guard import BudgetGuard
+from ..stream import approx_tokens
 
 
 def _require_langchain() -> Any:
@@ -34,6 +35,43 @@ def _require_langchain() -> Any:
             "Install with: pip install floe-guard[langchain]"
         ) from e
     return langchain_core
+
+
+def _estimate_start(guard: BudgetGuard, serialized: Any, texts: list[str]) -> float | None:
+    """Request-sized cost estimate for the pre-call check.
+
+    ``check()`` defaults to predicting from the LAST call's cost — blind on the
+    first call and wrong for a much larger one. Size the prediction to the
+    request instead: model id and ``max_tokens`` from the serialized model
+    config, prompt tokens via the ~4 chars/token heuristic (langchain-core has
+    no tokenizer; a rough request-sized figure still beats a stale or zero
+    baseline). Returns ``None`` when the model is unknown/unpriceable —
+    ``check(None)`` keeps the old behaviour.
+    """
+    model_kwargs = serialized.get("kwargs") if isinstance(serialized, dict) else None
+    if not isinstance(model_kwargs, dict):
+        return None
+    model = model_kwargs.get("model_name") or model_kwargs.get("model")
+    if not model:
+        return None
+    prompt_tokens = sum(approx_tokens(t) for t in texts if isinstance(t, str))
+    max_out = model_kwargs.get("max_tokens") or model_kwargs.get("max_completion_tokens") or 0
+    try:
+        max_out = max(0, int(max_out))
+    except (TypeError, ValueError):
+        max_out = 0
+    return guard.estimate_call(str(model), prompt_tokens, max_out)
+
+
+def _chat_texts(messages: Any) -> list[str]:
+    """Flatten LangChain's batched chat messages to their text contents."""
+    texts: list[str] = []
+    for batch in messages or []:
+        for message in batch or []:
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                texts.append(content)
+    return texts
 
 
 def _model_from_result(response: Any) -> str:
@@ -112,10 +150,13 @@ def budget_guard_callback_handler(guard: BudgetGuard) -> Any:
             self.guard = guard
 
         def on_llm_start(self, serialized: Any, prompts: Any, **kwargs: Any) -> None:
-            self.guard.check()
+            # Request-sized when derivable (see _estimate_start); check(None)
+            # falls back to the last-cost prediction.
+            texts = [p for p in (prompts or []) if isinstance(p, str)]
+            self.guard.check(_estimate_start(self.guard, serialized, texts))
 
         def on_chat_model_start(self, serialized: Any, messages: Any, **kwargs: Any) -> None:
-            self.guard.check()
+            self.guard.check(_estimate_start(self.guard, serialized, _chat_texts(messages)))
 
         def on_llm_end(self, response: Any, **kwargs: Any) -> None:
             _record_result(self.guard, response)

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -73,6 +73,41 @@ def _usage_from(response: Any) -> tuple[int, int]:
     return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
 
 
+def _estimate_request(litellm: Any, guard: BudgetGuard, kwargs: Any) -> float | None:
+    """Request-sized cost estimate for the pre-call reservation.
+
+    Prices the ACTUAL incoming request — prompt tokens via litellm's offline
+    ``token_counter`` plus the ``max_tokens`` output cap — so a first call, or
+    one much larger than the last, reserves its true worst-case size instead of
+    the last call's cost (which is 0 on call one). Returns ``None`` when
+    anything needed is unavailable (no model, counter failure, unpriceable
+    model); ``reserve(None)`` falls back to the last-cost prediction, so this
+    only ever tightens enforcement, never breaks a call path.
+
+    Without ``max_tokens`` on the request the output side is unpredictable and
+    estimates prompt-only — set a cap for full pre-call sizing.
+    """
+    if not isinstance(kwargs, dict):
+        return None
+    model = kwargs.get("model")
+    if not model:
+        return None
+    try:
+        prompt_tokens = int(
+            litellm.token_counter(model=model, messages=kwargs.get("messages") or [])
+        )
+    except Exception:
+        # token_counter can fail on unknown models/shapes — degrade to the
+        # guard's default prediction rather than blocking the call path.
+        return None
+    max_out = kwargs.get("max_completion_tokens") or kwargs.get("max_tokens") or 0
+    try:
+        max_out = max(0, int(max_out))
+    except (TypeError, ValueError):
+        max_out = 0
+    return guard.estimate_call(str(model), prompt_tokens, max_out)
+
+
 def _record_response(
     guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
 ) -> None:
@@ -98,10 +133,12 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
     """``litellm.completion`` with a pre-call budget reservation and post-call accrual.
 
     Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
-    would be crossed — the request never reaches LiteLLM.
+    would be crossed — the request never reaches LiteLLM. The reservation is
+    sized to the actual request (prompt tokens + ``max_tokens`` cap) when it
+    can be, so even a FIRST call that alone would cross the cap is blocked.
     """
     litellm = _require_litellm()
-    reserved = guard.reserve()
+    reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
     try:
         response = litellm.completion(**kwargs)
     except BaseException:
@@ -114,7 +151,7 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
 async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`."""
     litellm = _require_litellm()
-    reserved = guard.reserve()
+    reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
     try:
         response = await litellm.acompletion(**kwargs)
     except BaseException:
@@ -190,7 +227,9 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
 
         def _hold(self, kwargs: Any) -> None:
             try:
-                reserved = self.guard.reserve()  # raises BudgetExceeded -> aborts the call
+                # Request-sized when possible (see _estimate_request); raises
+                # BudgetExceeded -> aborts the call.
+                reserved = self.guard.reserve(_estimate_request(litellm, self.guard, kwargs))
             except BudgetExceeded as exc:
                 self._trip(exc)
                 raise
@@ -234,7 +273,6 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         ) -> None:
             self.guard.release(self._pop(kwargs))
 
-    _ = litellm  # adapter import already validated litellm is present
     return BudgetGuardCallback()
 
 

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -89,6 +89,9 @@ class StreamGuard:
         self._count = count_tokens or approx_tokens
         self._completion_tokens = 0
         self._closed = False
+        # Intra-package seam: StreamGuard is the streaming face of BudgetGuard,
+        # so it shares the guard's private resolution/ceiling internals rather
+        # than duplicating that logic (or widening the public API).
         self._priced = guard._resolve(model, price)
         if self._priced is None and guard.fail_closed:
             # Same policy as settle(), applied BEFORE any money moves: refuse to
@@ -104,6 +107,10 @@ class StreamGuard:
             self._closed = True
             guard.release(reserved)
             raise UnpriceableModelError(model)
+        # Registered AFTER the fail-closed raise so a refused stream leaves no
+        # entry; _settle() unregisters, so entries live exactly as long as the
+        # stream. Parallel streams see each other's accrual through this.
+        self._key = guard._stream_register(self._reserved)
 
     def feed_text(self, delta: str) -> None:
         """Meter one text delta (token count via the heuristic/``count_tokens``).
@@ -122,7 +129,7 @@ class StreamGuard:
         if self._priced is None:
             return  # fail-open + unpriceable: nothing to price chunks with
         cumulative = price_tokens(self._priced, self._prompt_tokens, self._completion_tokens)
-        if self._guard._stream_would_cross(cumulative, self._reserved):
+        if self._guard._stream_would_cross(self._key, cumulative):
             # The tokens in this chunk were already generated (and billed) —
             # settle them before raising so spent_usd reflects reality. The
             # overshoot is at most this one chunk, not the rest of the stream.
@@ -154,14 +161,20 @@ class StreamGuard:
 
     def _settle(self) -> float:
         self._closed = True
-        return self._guard.settle(
-            self._model,
-            self._prompt_tokens,
-            self._completion_tokens,
-            reserved=self._reserved,
-            price=self._price,
-            label=self._label,
-        )
+        try:
+            return self._guard.settle(
+                self._model,
+                self._prompt_tokens,
+                self._completion_tokens,
+                reserved=self._reserved,
+                price=self._price,
+                label=self._label,
+            )
+        finally:
+            # Settle moved the accrual into spent_usd (or skipped it, fail-open)
+            # — either way the registry entry must go, even if settle raised,
+            # or a phantom accrual would throttle every other stream forever.
+            self._guard._stream_unregister(self._key)
 
     def __enter__(self) -> StreamGuard:
         return self
@@ -192,9 +205,17 @@ def guard_stream(
     Yields each chunk after metering it, so the consumer sees everything that
     was within budget; raises :class:`~floe_guard.BudgetExceeded` mid-stream
     (after settling the partial spend) when the call would cross the ceiling.
-    ``get_text`` extracts the text delta from a chunk — defaults to treating
-    chunks as strings. The stream settles on ANY exit, including the consumer
-    breaking out early.
+    The stream settles on ANY exit, including the consumer breaking out early.
+
+    ``get_text`` extracts the text delta from a chunk. The default handles
+    plain-string chunks only and REFUSES (``TypeError``) anything else — a
+    silent zero-token fallback would let a whole stream through unmetered,
+    which is exactly the failure mode this guard exists to prevent.
+
+    Validation and the fail-closed unpriceable check run eagerly, at call
+    time. Once you start iterating, the wrapper owns ``reserved`` and settles
+    or releases it on every exit path; a returned-but-never-iterated stream
+    leaves the handle with you (release it yourself).
     """
     sg = StreamGuard(
         guard,
@@ -205,11 +226,25 @@ def guard_stream(
         label=label,
         count_tokens=count_tokens,
     )
-    extract = get_text or (lambda chunk: chunk if isinstance(chunk, str) else "")
-    with sg:
-        for chunk in chunks:
-            sg.feed_text(extract(chunk))
-            yield chunk
+
+    def _default_get_text(chunk: Any) -> str:
+        if isinstance(chunk, str):
+            return chunk
+        raise TypeError(
+            f"guard_stream got a non-string chunk ({type(chunk).__name__}) and no "
+            f"get_text= — pass get_text= to extract each chunk's text delta, or the "
+            f"stream cannot be metered."
+        )
+
+    extract = get_text or _default_get_text
+
+    def _run() -> Iterator[Any]:
+        with sg:
+            for chunk in chunks:
+                sg.feed_text(extract(chunk))
+                yield chunk
+
+    return _run()
 
 
 __all__ = ["StreamGuard", "guard_stream", "approx_tokens"]

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -1,0 +1,215 @@
+"""Mid-stream budget enforcement for token streams.
+
+``record()`` / ``settle()`` meter a COMPLETED response — by the time they run,
+the money is spent. For a streaming response that starts under budget but runs
+long, that is one call too late: the guard would only report the overshoot
+after the fact. :class:`StreamGuard` closes that gap: feed it the stream's
+deltas as they arrive and it re-prices the cumulative call chunk-by-chunk,
+raising :class:`~floe_guard.BudgetExceeded` the moment the running call would
+cross the ceiling — mid-generation, not post-mortem.
+
+Aborting still settles the tokens consumed so far: the provider bills whatever
+was generated before the cancel, so the guard records that partial spend
+(fail-closed accounting, and it lands in ``guard.spend_log`` like any other
+call), THEN raises. The worst case overshoot shrinks from "the rest of the
+stream" to a single chunk.
+
+**Token counts per chunk.** Providers stream text deltas, not token counts, so
+:meth:`StreamGuard.feed_text` estimates ~4 characters/token (the usual rule of
+thumb) unless you supply ``count_tokens=`` with a real tokenizer. The estimate
+only steers the mid-stream cut-off; the final accrual reconciles to the
+provider-reported usage when you pass it to :meth:`StreamGuard.finish`.
+
+See ``examples/streaming_guard.py`` for a runnable demo (no API key).
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
+
+from .errors import UnpriceableModelError, UnpriceableModelWarning
+from .guard import BudgetGuard
+from .pricing import ManualPrice, price_tokens
+
+
+def approx_tokens(text: str) -> int:
+    """~4 characters/token heuristic; a non-empty delta is at least one token."""
+    return max(1, len(text) // 4) if text else 0
+
+
+class StreamGuard:
+    """Meter one streaming response chunk-by-chunk and hard-stop mid-generation.
+
+    Usage (the context manager guarantees the reservation is settled or
+    released no matter how the stream ends)::
+
+        handle = guard.reserve(guard.estimate_call(model, prompt_tokens, max_tokens))
+        with StreamGuard(guard, model, prompt_tokens=prompt_tokens, reserved=handle) as sg:
+            for chunk in stream:
+                sg.feed_text(chunk_text(chunk))   # raises BudgetExceeded mid-stream
+                consume(chunk)
+            sg.finish(completion_tokens=reported_usage)  # reconcile to real usage
+
+    Fail-closed: an unpriceable model raises :class:`UnpriceableModelError` at
+    construction (after releasing ``reserved``) when the guard is fail-closed —
+    a stream whose spend cannot be measured never starts. When the guard is
+    fail-open, feeding is a no-op (nothing to price chunks with) and
+    :meth:`finish` routes through ``guard.settle`` so the warn-and-skip policy
+    still applies.
+
+    Not thread-safe itself (a stream is consumed sequentially); the underlying
+    guard accounting stays lock-protected, so parallel streams each wrap their
+    own ``StreamGuard`` against the same guard.
+    """
+
+    def __init__(
+        self,
+        guard: BudgetGuard,
+        model: str,
+        *,
+        prompt_tokens: int = 0,
+        reserved: float = 0.0,
+        price: ManualPrice | None = None,
+        label: str | None = None,
+        count_tokens: Callable[[str], int] | None = None,
+    ) -> None:
+        # Same contract as settle(): a bad handle would corrupt the guard's
+        # in-flight tally. Reject it before the stream starts, not at settle time.
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        self._guard = guard
+        self._model = model
+        self._prompt_tokens = max(0, int(prompt_tokens))
+        self._reserved = float(reserved)
+        self._price = price
+        self._label = label
+        self._count = count_tokens or approx_tokens
+        self._completion_tokens = 0
+        self._closed = False
+        self._priced = guard._resolve(model, price)
+        if self._priced is None and guard.fail_closed:
+            # Same policy as settle(), applied BEFORE any money moves: refuse to
+            # stream spend the guard cannot measure.
+            warnings.warn(
+                f"Cannot price model {model!r}: not in the bundled cost map and no "
+                f"manual price given. A stream whose spend cannot be measured "
+                f"cannot be mid-stream enforced — pass price=ManualPrice(...) or "
+                f"set it in price_overrides.",
+                UnpriceableModelWarning,
+                stacklevel=2,
+            )
+            self._closed = True
+            guard.release(reserved)
+            raise UnpriceableModelError(model)
+
+    def feed_text(self, delta: str) -> None:
+        """Meter one text delta (token count via the heuristic/``count_tokens``).
+
+        Raises :class:`~floe_guard.BudgetExceeded` when the cumulative call
+        would cross the ceiling — after settling the partial spend already
+        incurred, so the running total stays honest.
+        """
+        self.feed_tokens(self._count(delta))
+
+    def feed_tokens(self, tokens: int) -> None:
+        """Meter ``tokens`` more completion tokens. See :meth:`feed_text`."""
+        if self._closed:
+            raise RuntimeError("stream already settled — create a new StreamGuard per stream")
+        self._completion_tokens += max(0, int(tokens))
+        if self._priced is None:
+            return  # fail-open + unpriceable: nothing to price chunks with
+        cumulative = price_tokens(self._priced, self._prompt_tokens, self._completion_tokens)
+        if self._guard._stream_would_cross(cumulative, self._reserved):
+            # The tokens in this chunk were already generated (and billed) —
+            # settle them before raising so spent_usd reflects reality. The
+            # overshoot is at most this one chunk, not the rest of the stream.
+            self._settle()
+            self._guard._block()
+
+    def finish(
+        self,
+        *,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+    ) -> float:
+        """Settle the stream. Pass the provider-reported usage (many APIs attach
+        it to the final chunk) to reconcile the chunk-count heuristic to truth;
+        omitted counts keep the accumulated values. Returns the USD cost.
+        """
+        if self._closed:
+            raise RuntimeError("stream already settled")
+        if prompt_tokens is not None:
+            self._prompt_tokens = max(0, int(prompt_tokens))
+        if completion_tokens is not None:
+            self._completion_tokens = max(0, int(completion_tokens))
+        return self._settle()
+
+    @property
+    def completion_tokens(self) -> int:
+        """Completion tokens metered so far (estimate until :meth:`finish`)."""
+        return self._completion_tokens
+
+    def _settle(self) -> float:
+        self._closed = True
+        return self._guard.settle(
+            self._model,
+            self._prompt_tokens,
+            self._completion_tokens,
+            reserved=self._reserved,
+            price=self._price,
+            label=self._label,
+        )
+
+    def __enter__(self) -> StreamGuard:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        # Whatever ended the stream — clean exhaustion without an explicit
+        # finish(), a mid-stream error, or the consumer abandoning it — the
+        # tokens generated so far were billed: settle them and free the
+        # reservation. Already-settled streams (finish() or a feed abort) skip.
+        if not self._closed:
+            self._settle()
+
+
+def guard_stream(
+    guard: BudgetGuard,
+    model: str,
+    chunks: Iterable[Any],
+    *,
+    get_text: Callable[[Any], str] | None = None,
+    prompt_tokens: int = 0,
+    reserved: float = 0.0,
+    price: ManualPrice | None = None,
+    label: str | None = None,
+    count_tokens: Callable[[str], int] | None = None,
+) -> Iterator[Any]:
+    """Wrap a stream of chunks with mid-stream budget enforcement.
+
+    Yields each chunk after metering it, so the consumer sees everything that
+    was within budget; raises :class:`~floe_guard.BudgetExceeded` mid-stream
+    (after settling the partial spend) when the call would cross the ceiling.
+    ``get_text`` extracts the text delta from a chunk — defaults to treating
+    chunks as strings. The stream settles on ANY exit, including the consumer
+    breaking out early.
+    """
+    sg = StreamGuard(
+        guard,
+        model,
+        prompt_tokens=prompt_tokens,
+        reserved=reserved,
+        price=price,
+        label=label,
+        count_tokens=count_tokens,
+    )
+    extract = get_text or (lambda chunk: chunk if isinstance(chunk, str) else "")
+    with sg:
+        for chunk in chunks:
+            sg.feed_text(extract(chunk))
+            yield chunk
+
+
+__all__ = ["StreamGuard", "guard_stream", "approx_tokens"]

--- a/tests/test_stream_guard.py
+++ b/tests/test_stream_guard.py
@@ -52,7 +52,7 @@ def test_estimate_call_honors_manual_price() -> None:
 def test_oversized_first_call_is_blocked_at_its_true_size() -> None:
     # THE acceptance case: a FIRST call (no last-cost baseline) that alone would
     # cross the cap must block pre-call once the reservation is request-sized.
-    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda *_: None)
     est = guard.estimate_call(MODEL, 1_000, 100_000)  # ≈ $1.0025 ≫ $0.01
     assert est is not None and est > guard.limit_usd
     with pytest.raises(BudgetExceeded):
@@ -135,7 +135,7 @@ def test_approx_tokens_heuristic() -> None:
 def test_runaway_stream_is_cut_off_mid_generation() -> None:
     # $0.01 ceiling ≙ 1_000 gpt-4o output tokens. An endless stream must be
     # aborted mid-flight, not recorded as a big overshoot after the fact.
-    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda *_: None)
     sg = StreamGuard(guard, MODEL)
     chunks_fed = 0
     with pytest.raises(BudgetExceeded):
@@ -154,8 +154,37 @@ def test_runaway_stream_is_cut_off_mid_generation() -> None:
         guard.check()
 
 
+def test_parallel_unreserved_streams_share_the_ceiling() -> None:
+    # Regression: two zero-reservation streams on one $0.01 guard must JOINTLY
+    # stop near the ceiling. Before streams registered their accrual with the
+    # guard, each was blind to the other and both ran to the full ceiling —
+    # a 2x overshoot.
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda *_: None)
+    a, b = StreamGuard(guard, MODEL), StreamGuard(guard, MODEL)
+    feeds = 0
+    aborted = a
+    with pytest.raises(BudgetExceeded):
+        while True:
+            for sg in (a, b):
+                aborted = sg
+                sg.feed_text(CHUNK)
+                feeds += 1
+    # Joint cut-off at ~100 total chunks ($1e-4 each against $0.01), not ~200.
+    assert feeds == pytest.approx(100, abs=2)
+    # The surviving stream is boxed in by what the aborted one settled plus its
+    # own accrual — it must stop almost immediately, not run to a fresh ceiling.
+    survivor = b if aborted is a else a
+    with pytest.raises(BudgetExceeded):
+        for _ in range(50):
+            survivor.feed_text(CHUNK)
+    assert len(guard.spend_log) == 2  # both partials settled honestly
+    assert guard.spent_usd <= guard.limit_usd + 3e-4 + 1e-9  # ≤ ceiling + a few chunks
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+
+
 def test_stream_abort_settles_its_own_reservation() -> None:
-    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda *_: None)
     handle = guard.reserve(0.005)
     sg = StreamGuard(guard, MODEL, reserved=handle)
     with pytest.raises(BudgetExceeded):
@@ -227,7 +256,7 @@ def test_unpriceable_stream_fail_open_passes_through() -> None:
 
 
 def test_guard_stream_yields_until_the_ceiling_then_raises() -> None:
-    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda *_: None)
 
     def endless() -> Any:
         while True:
@@ -252,6 +281,28 @@ def test_guard_stream_settles_when_the_consumer_breaks_early() -> None:
     assert event.completion_tokens == 10  # only the consumed chunk was metered
     assert event.label == "writer"
     assert guard.spent_usd == pytest.approx(10 * 1e-5)
+
+
+def test_guard_stream_fails_closed_eagerly_for_unpriceable_models() -> None:
+    # The fail-closed check runs at CALL time, not first iteration — a stream
+    # whose spend can't be measured never starts, and the hold is released.
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.01)
+    with pytest.warns(UnpriceableModelWarning), pytest.raises(UnpriceableModelError):
+        guard_stream(guard, "model-that-does-not-exist", iter([CHUNK]), reserved=handle)
+    assert guard.remaining_usd == pytest.approx(1.00)
+
+
+def test_guard_stream_refuses_chunks_it_cannot_meter() -> None:
+    # A non-string chunk with no get_text= must fail LOUDLY: metering it as
+    # zero tokens would let the whole stream through unmetered.
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.01)
+    stream = guard_stream(guard, MODEL, iter([{"delta": "hi"}]), reserved=handle)
+    with pytest.raises(TypeError, match="get_text"):
+        next(stream)
+    # The refusal still settled the stream — no reservation leak.
+    assert guard.remaining_usd == pytest.approx(1.00)
 
 
 def test_guard_stream_exhaustion_settles_the_accumulated_usage() -> None:

--- a/tests/test_stream_guard.py
+++ b/tests/test_stream_guard.py
@@ -1,0 +1,263 @@
+"""Tests for request-sized estimates (estimate_call) and mid-stream enforcement
+(StreamGuard / guard_stream)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    ManualPrice,
+    StreamGuard,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+    guard_stream,
+)
+from floe_guard.integrations.langchain import _estimate_start
+from floe_guard.integrations.litellm import _estimate_request
+from floe_guard.stream import approx_tokens
+
+MODEL = "gpt-4o"  # $2.5e-6/input token, $1e-5/output token
+
+
+# ── estimate_call ───────────────────────────────────────────────────────────────
+
+
+def test_estimate_call_prices_the_actual_request() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    est = guard.estimate_call(MODEL, 1_000, 2_000)
+    assert est == pytest.approx(1_000 * 2.5e-6 + 2_000 * 1e-5)  # 0.0025 + 0.02
+
+
+def test_estimate_call_prompt_only_when_no_output_cap() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    assert guard.estimate_call(MODEL, 1_000) == pytest.approx(0.0025)
+
+
+def test_estimate_call_unpriceable_returns_none() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    assert guard.estimate_call("model-that-does-not-exist", 1_000, 1_000) is None
+
+
+def test_estimate_call_honors_manual_price() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    price = ManualPrice(input_cost_per_token=1e-6, output_cost_per_token=2e-6)
+    est = guard.estimate_call("my-local-model", 1_000, 500, price=price)
+    assert est == pytest.approx(1_000 * 1e-6 + 500 * 2e-6)
+
+
+def test_oversized_first_call_is_blocked_at_its_true_size() -> None:
+    # THE acceptance case: a FIRST call (no last-cost baseline) that alone would
+    # cross the cap must block pre-call once the reservation is request-sized.
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    est = guard.estimate_call(MODEL, 1_000, 100_000)  # ≈ $1.0025 ≫ $0.01
+    assert est is not None and est > guard.limit_usd
+    with pytest.raises(BudgetExceeded):
+        guard.reserve(est)
+    # Nothing was held: the budget is untouched for calls that DO fit.
+    assert guard.remaining_usd == pytest.approx(guard.limit_usd)
+    # The unsized default would have let the same first call through.
+    assert guard.reserve() == 0.0
+
+
+def test_fitting_call_reserves_its_estimated_size() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    est = guard.estimate_call(MODEL, 1_000, 1_000)
+    handle = guard.reserve(est)
+    assert handle == pytest.approx(0.0125)
+    assert guard.remaining_usd == pytest.approx(1.00 - 0.0125)
+    guard.release(handle)
+
+
+# ── adapter estimate wiring ─────────────────────────────────────────────────────
+
+
+class _FakeLiteLLM:
+    """token_counter stub — the only litellm surface _estimate_request touches."""
+
+    def __init__(self, tokens: int = 1_000, raise_on_count: bool = False) -> None:
+        self._tokens = tokens
+        self._raise = raise_on_count
+
+    def token_counter(self, model: str, messages: Any) -> int:
+        if self._raise:
+            raise RuntimeError("unknown model")
+        return self._tokens
+
+
+def test_litellm_estimate_prices_model_prompt_and_cap() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    kwargs = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}], "max_tokens": 2_000}
+    est = _estimate_request(_FakeLiteLLM(tokens=1_000), guard, kwargs)
+    assert est == pytest.approx(0.0025 + 0.02)
+
+
+def test_litellm_estimate_degrades_to_none() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    assert _estimate_request(_FakeLiteLLM(), guard, {"messages": []}) is None  # no model
+    assert _estimate_request(_FakeLiteLLM(), guard, None) is None  # non-dict kwargs
+    assert (  # token_counter failure
+        _estimate_request(_FakeLiteLLM(raise_on_count=True), guard, {"model": MODEL}) is None
+    )
+    assert (  # unpriceable model
+        _estimate_request(_FakeLiteLLM(), guard, {"model": "model-that-does-not-exist"}) is None
+    )
+
+
+def test_langchain_estimate_uses_serialized_config_and_text_heuristic() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    serialized = {"kwargs": {"model_name": MODEL, "max_tokens": 1_000}}
+    est = _estimate_start(guard, serialized, ["x" * 4_000])  # ≈ 1_000 prompt tokens
+    assert est == pytest.approx(1_000 * 2.5e-6 + 1_000 * 1e-5)
+
+
+def test_langchain_estimate_degrades_to_none() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    assert _estimate_start(guard, {}, ["hello"]) is None
+    assert _estimate_start(guard, {"kwargs": {}}, ["hello"]) is None
+    assert _estimate_start(guard, None, ["hello"]) is None
+
+
+# ── StreamGuard: mid-stream enforcement ─────────────────────────────────────────
+
+CHUNK = "x" * 40  # 10 tokens by the heuristic → $1e-4 of gpt-4o output
+
+
+def test_approx_tokens_heuristic() -> None:
+    assert approx_tokens("") == 0
+    assert approx_tokens("abc") == 1  # non-empty is at least one token
+    assert approx_tokens(CHUNK) == 10
+
+
+def test_runaway_stream_is_cut_off_mid_generation() -> None:
+    # $0.01 ceiling ≙ 1_000 gpt-4o output tokens. An endless stream must be
+    # aborted mid-flight, not recorded as a big overshoot after the fact.
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    sg = StreamGuard(guard, MODEL)
+    chunks_fed = 0
+    with pytest.raises(BudgetExceeded):
+        while True:
+            sg.feed_text(CHUNK)
+            chunks_fed += 1
+    # Cut off at the ceiling (±1 chunk — those tokens had already arrived),
+    # instead of running to infinity.
+    assert chunks_fed == pytest.approx(100, abs=1)
+    assert guard.spent_usd <= guard.limit_usd + 1e-4 + 1e-9
+    # The partial spend was settled honestly and hit the ledger.
+    (event,) = guard.spend_log
+    assert event.completion_tokens == pytest.approx(chunks_fed * 10, abs=10)
+    # The guard now blocks everything else, as after any ceiling hit.
+    with pytest.raises(BudgetExceeded):
+        guard.check()
+
+
+def test_stream_abort_settles_its_own_reservation() -> None:
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+    handle = guard.reserve(0.005)
+    sg = StreamGuard(guard, MODEL, reserved=handle)
+    with pytest.raises(BudgetExceeded):
+        while True:
+            sg.feed_text(CHUNK)
+    # The hold was released by the abort-settle: no phantom reservation left.
+    assert guard.remaining_usd == pytest.approx(max(0.0, guard.limit_usd - guard.spent_usd))
+
+
+def test_finish_reconciles_to_reported_usage() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    sg = StreamGuard(guard, MODEL, prompt_tokens=100)
+    sg.feed_text(CHUNK)  # heuristic: 10 tokens
+    cost = sg.finish(prompt_tokens=120, completion_tokens=37)  # provider truth
+    assert cost == pytest.approx(120 * 2.5e-6 + 37 * 1e-5)
+    (event,) = guard.spend_log
+    assert (event.prompt_tokens, event.completion_tokens) == (120, 37)
+
+
+def test_context_manager_settles_partial_spend_on_error() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.01)
+    with pytest.raises(RuntimeError, match="network died"):
+        with StreamGuard(guard, MODEL, reserved=handle) as sg:
+            sg.feed_text(CHUNK)
+            raise RuntimeError("network died")
+    # The 10 generated tokens were billed by the provider — they are recorded,
+    # and the reservation is gone.
+    assert guard.spent_usd == pytest.approx(10 * 1e-5)
+    assert guard.remaining_usd == pytest.approx(1.00 - guard.spent_usd)
+
+
+def test_feed_after_settle_is_an_error() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    sg = StreamGuard(guard, MODEL)
+    sg.finish(completion_tokens=1)
+    with pytest.raises(RuntimeError):
+        sg.feed_text(CHUNK)
+    with pytest.raises(RuntimeError):
+        sg.finish()
+
+
+def test_stream_guard_rejects_bad_reservation_handles() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    for bad in (float("nan"), float("inf"), -0.01):
+        with pytest.raises(ValueError):
+            StreamGuard(guard, MODEL, reserved=bad)
+
+
+def test_unpriceable_stream_fails_closed_before_any_spend() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    handle = guard.reserve(0.01)
+    with pytest.warns(UnpriceableModelWarning), pytest.raises(UnpriceableModelError):
+        StreamGuard(guard, "model-that-does-not-exist", reserved=handle)
+    # The reservation was released — fail-closed must not leak the hold.
+    assert guard.remaining_usd == pytest.approx(1.00)
+
+
+def test_unpriceable_stream_fail_open_passes_through() -> None:
+    guard = BudgetGuard(limit_usd=1.00, fail_closed=False)
+    sg = StreamGuard(guard, "model-that-does-not-exist")
+    sg.feed_text(CHUNK)  # no price to check against — must not raise
+    with pytest.warns(UnpriceableModelWarning):
+        assert sg.finish() == 0.0
+    assert guard.spent_usd == 0.0
+
+
+# ── guard_stream wrapper ────────────────────────────────────────────────────────
+
+
+def test_guard_stream_yields_until_the_ceiling_then_raises() -> None:
+    guard = BudgetGuard(limit_usd=0.01, on_block=lambda s, l: None)
+
+    def endless() -> Any:
+        while True:
+            yield CHUNK
+
+    consumed = 0
+    with pytest.raises(BudgetExceeded):
+        for _ in guard_stream(guard, MODEL, endless()):
+            consumed += 1
+    # ~100 chunks fit under the $0.01 / 1e-4-per-chunk ceiling; the crossing
+    # chunk is metered (its tokens arrived) but never yielded to the consumer.
+    assert consumed == pytest.approx(100, abs=1)
+    assert len(guard.spend_log) == 1
+
+
+def test_guard_stream_settles_when_the_consumer_breaks_early() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    stream = guard_stream(guard, MODEL, iter([CHUNK, CHUNK, CHUNK]), label="writer")
+    next(stream)
+    stream.close()  # consumer abandons the stream mid-way
+    (event,) = guard.spend_log
+    assert event.completion_tokens == 10  # only the consumed chunk was metered
+    assert event.label == "writer"
+    assert guard.spent_usd == pytest.approx(10 * 1e-5)
+
+
+def test_guard_stream_exhaustion_settles_the_accumulated_usage() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    chunks = list(guard_stream(guard, MODEL, iter([CHUNK, CHUNK]), prompt_tokens=50))
+    assert chunks == [CHUNK, CHUNK]
+    (event,) = guard.spend_log
+    assert (event.prompt_tokens, event.completion_tokens) == (50, 20)
+    assert guard.spent_usd == pytest.approx(50 * 2.5e-6 + 20 * 1e-5)


### PR DESCRIPTION
…nt (py 0.4.0).

## Summary

* **New Features**
  * Added request-sized budget estimates to block oversized calls before processing, including first requests.
  * Added mid-stream budget enforcement that stops generation when spending exceeds the limit.
  * Added streaming helpers with partial-spend tracking and provider-usage reconciliation.
  * Added automatic request estimation for LiteLLM and LangChain integrations.
  * Added fail-closed handling for unpriceable streaming models.
  * Added a runnable streaming enforcement example.

* **Documentation**
  * Updated the README and changelog with request estimation and streaming enforcement guidance.

## Testing
How was this tested?

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)