### PR TITLE
feat: LatencyBudget — cumulative tool-chain deadline sibling to Budge…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.5.0 / js 0.4.0 — 2026-07-16
+
+### Added (py + js)
+
+- **`LatencyBudget`** — BudgetGuard's sibling for time: tracks cumulative
+  elapsed time across an agentic tool chain against an end-user SLA.
+  `check(expected_ms)` raises the new `DeadlineExceeded` before a call whose
+  projected duration would blow the SLA; `remaining_ms` is the readable
+  mid-chain signal for router fallback/truncation; `advisory()` returns
+  `near_deadline` / `used_bps` / `remaining_ms`, symmetric to the budget
+  advisory's `near_limit`. Monotonic clock (`time.monotonic` /
+  `performance.now`); cooperative by design — the guard supplies the deadline
+  signal, killing a stalled in-flight call remains the framework's job.
+
 ## py 0.4.0 — 2026-07-15
 
 ### Added (py)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ deadline = LatencyBudget(sla_ms=5000)          # the user is promised 5s
 
 for step in plan:
     deadline.check(expected_ms=step.est_ms)    # raises DeadlineExceeded when projected over
+    model = DEFAULT_MODEL
     if deadline.advisory().near_deadline:      # 80% consumed by default —
         model = FAST_FALLBACK                  # downshift BEFORE the wall
     run(step, model, timeout_ms=deadline.remaining_ms)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,40 @@ cost_usd, label?, reserved?}` — identical to the TS package's `exportLog()`, s
 every agent produces the same shape regardless of stack and the streams can be
 concatenated and analysed together.
 
+## LatencyBudget — deadlines, the same way
+
+Money isn't the only budget an agent burns. `LatencyBudget` is `BudgetGuard`'s
+sibling for **time**: it tracks cumulative elapsed time across a tool chain
+against an end-user SLA and stops the *next* call before it would blow it.
+
+```python
+from floe_guard import LatencyBudget, DeadlineExceeded
+
+deadline = LatencyBudget(sla_ms=5000)          # the user is promised 5s
+
+for step in plan:
+    deadline.check(expected_ms=step.est_ms)    # raises DeadlineExceeded when projected over
+    if deadline.advisory().near_deadline:      # 80% consumed by default —
+        model = FAST_FALLBACK                  # downshift BEFORE the wall
+    run(step, model, timeout_ms=deadline.remaining_ms)
+```
+
+Same shape in TypeScript: `new LatencyBudget(5000)`, `check(expectedMs)`,
+`remainingMs`, `advisory().nearDeadline`.
+
+Honest scope, mirroring the rest of this package:
+
+- **Monotonic clock** (`time.monotonic()` / `performance.now()`) — NTP steps
+  and DST can't corrupt the budget.
+- **Cooperative, not preemptive.** The guard supplies the deadline *signal*;
+  killing an already-running stalled call is your framework's job (asyncio
+  cancellation, `AbortSignal`). `check()` prevents the next call from starting.
+- **Advisory symmetry.** `near_deadline` / `used_bps` / `remaining_ms` are the
+  latency twin of the budget advisory's `near_limit` / `used_bps` /
+  `remaining_usd` — taper logic written against one ports to the other.
+- **In-process.** One instance per request/run; distributed/server-side latency
+  tracking is out of scope.
+
 ## Request-sized estimates and mid-stream enforcement
 
 Two gaps in last-cost prediction, closed in 0.4.0 (Python):

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -70,13 +70,21 @@ export class UnpriceableModelError extends FloeGuardError {
  * Mirrors `DeadlineExceeded` in `src/floe_guard/errors.py` — message format is
  * kept byte-for-byte identical so both adapters read the same.
  */
+/** Shared millisecond rounding for cross-language message parity: `toFixed(0)`
+ *  rounds half-up while Python's `:.0f` rounds half-to-even, so tie values
+ *  would break the byte-for-byte contract. Both packages use floor(x + 0.5)
+ *  (see `_round_half_up` in `src/floe_guard/errors.py`). */
+function roundHalfUp(ms: number): number {
+  return Math.floor(ms + 0.5);
+}
+
 export class DeadlineExceeded extends FloeGuardError {
   readonly elapsedMs: number;
   readonly slaMs: number;
 
   constructor(elapsedMs: number, slaMs: number) {
     super(
-      `DEADLINE EXCEEDED — call blocked (elapsed ${elapsedMs.toFixed(0)}ms of ${slaMs.toFixed(0)}ms SLA)`,
+      `DEADLINE EXCEEDED — call blocked (elapsed ${roundHalfUp(elapsedMs)}ms of ${roundHalfUp(slaMs)}ms SLA)`,
     );
     this.name = "DeadlineExceeded";
     this.elapsedMs = elapsedMs;

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -57,3 +57,29 @@ export class UnpriceableModelError extends FloeGuardError {
     this.model = model;
   }
 }
+
+/**
+ * Thrown before a call whose projected duration would blow the SLA.
+ *
+ * The latency twin of {@link BudgetExceeded}: `LatencyBudget.check()` throws this
+ * *instead of* letting the next tool/model call start, so the chain sheds work or
+ * falls back to a faster path rather than violating the end-user SLA. Cooperative —
+ * killing an already-running stalled call is the framework's job (AbortSignal),
+ * not the guard's.
+ *
+ * Mirrors `DeadlineExceeded` in `src/floe_guard/errors.py` — message format is
+ * kept byte-for-byte identical so both adapters read the same.
+ */
+export class DeadlineExceeded extends FloeGuardError {
+  readonly elapsedMs: number;
+  readonly slaMs: number;
+
+  constructor(elapsedMs: number, slaMs: number) {
+    super(
+      `DEADLINE EXCEEDED — call blocked (elapsed ${elapsedMs.toFixed(0)}ms of ${slaMs.toFixed(0)}ms SLA)`,
+    );
+    this.name = "DeadlineExceeded";
+    this.elapsedMs = elapsedMs;
+    this.slaMs = slaMs;
+  }
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -13,8 +13,14 @@ export {
   type SpendEvent,
 } from "./guard.js";
 export {
+  LatencyBudget,
+  type LatencyBudgetOptions,
+  type LatencyAdvisory,
+} from "./latency.js";
+export {
   FloeGuardError,
   BudgetExceeded,
+  DeadlineExceeded,
   UnpriceableModelError,
 } from "./errors.js";
 export {

--- a/js/src/latency.ts
+++ b/js/src/latency.ts
@@ -1,0 +1,118 @@
+/**
+ * LatencyBudget — a cumulative tool-chain deadline, sibling to BudgetGuard.
+ *
+ * BudgetGuard stops an agent before its next call crosses a USD ceiling;
+ * LatencyBudget stops it before the next call would blow an end-user SLA:
+ *
+ * ```ts
+ * const deadline = new LatencyBudget(5000);
+ * ...
+ * deadline.check(800);                       // throws DeadlineExceeded when projected over
+ * if (deadline.advisory().nearDeadline) useFasterModel();
+ * router.pick({ maxLatencyMs: deadline.remainingMs });
+ * ```
+ *
+ * Design notes (mirroring `src/floe_guard/latency.py`):
+ * - **Monotonic clock** — `performance.now()`, never wall time.
+ * - **Cooperative, not preemptive** — the guard provides the deadline signal;
+ *   aborting a stalled in-flight call is the framework's job (AbortSignal).
+ *   `check()` prevents the NEXT call from starting.
+ * - **Advisory symmetry** — `nearDeadline` / `usedBps` / `remainingMs` are the
+ *   latency twin of BudgetGuard's `nearLimit` / `usedBps` / `remainingUsd`.
+ * - **In-process scope** — one instance per request/run; distributed latency
+ *   tracking is out of scope.
+ */
+
+import { DeadlineExceeded } from "./errors.js";
+
+/** A context-aware deadline signal — the latency twin of {@link BudgetAdvisory}.
+ *  Soft by design; the hard-stop is {@link LatencyBudget.check}. */
+export interface LatencyAdvisory {
+  nearDeadline: boolean;
+  /** SLA consumed, basis points 0..10000 (8500 = 85%). */
+  usedBps: number;
+  remainingMs: number;
+  slaMs: number;
+  elapsedMs: number;
+}
+
+export interface LatencyBudgetOptions {
+  /**
+   * Utilization (basis points, 0..10000) at which {@link LatencyBudget.advisory}
+   * flags `nearDeadline` so an agent can downshift to a faster path before the
+   * wall. Default 8000 (80%), matching BudgetGuard's `nearLimitBps`.
+   */
+  nearDeadlineBps?: number;
+  /** Invoked with `(elapsedMs, slaMs)` right before {@link DeadlineExceeded} is thrown. */
+  onBlock?: (elapsedMs: number, slaMs: number) => void;
+  /** Milliseconds-returning monotonic clock, injectable for tests. Defaults to `performance.now`. */
+  clock?: () => number;
+}
+
+export class LatencyBudget {
+  readonly slaMs: number;
+  readonly nearDeadlineBps: number;
+  private readonly onBlock?: (elapsedMs: number, slaMs: number) => void;
+  private readonly clock: () => number;
+  private readonly startedAt: number;
+
+  /** The budget starts counting at construction — build it when the request
+   *  (and its SLA) starts. */
+  constructor(slaMs: number, options: LatencyBudgetOptions = {}) {
+    if (!(Number.isFinite(slaMs) && slaMs > 0)) {
+      throw new RangeError("slaMs must be > 0");
+    }
+    const nearDeadlineBps = options.nearDeadlineBps ?? 8000;
+    if (!Number.isInteger(nearDeadlineBps) || nearDeadlineBps < 0 || nearDeadlineBps > 10000) {
+      throw new RangeError("nearDeadlineBps must be an integer 0..10000");
+    }
+    this.slaMs = slaMs;
+    this.nearDeadlineBps = nearDeadlineBps;
+    this.onBlock = options.onBlock;
+    this.clock = options.clock ?? (() => performance.now());
+    this.startedAt = this.clock();
+  }
+
+  /** Milliseconds since construction (monotonic). */
+  get elapsedMs(): number {
+    return this.clock() - this.startedAt;
+  }
+
+  /** Milliseconds left before the SLA, floored at 0 — the readable signal a
+   *  router uses to pick a faster fallback or truncate work mid-chain. */
+  get remainingMs(): number {
+    return Math.max(0, this.slaMs - this.elapsedMs);
+  }
+
+  /**
+   * Throw {@link DeadlineExceeded} when the projected elapsed time (now +
+   * `expectedMs` for the upcoming call) would blow the SLA. Call it
+   * immediately before each tool/model call; pass 0 to only gate on time
+   * already spent.
+   */
+  check(expectedMs = 0): void {
+    if (!(Number.isFinite(expectedMs) && expectedMs >= 0)) {
+      throw new RangeError("expectedMs must be >= 0");
+    }
+    const elapsed = this.elapsedMs;
+    if (elapsed + expectedMs > this.slaMs) {
+      this.onBlock?.(elapsed, this.slaMs);
+      throw new DeadlineExceeded(elapsed, this.slaMs);
+    }
+  }
+
+  /** The soft near-deadline signal — symmetric to `BudgetGuard.advisory()`. */
+  advisory(): LatencyAdvisory {
+    const elapsed = this.elapsedMs;
+    // round (not floor) — matches the Python twin; float clock arithmetic can
+    // land a hair under an exact boundary.
+    const usedBps = elapsed > 0 ? Math.min(10000, Math.round((elapsed * 10000) / this.slaMs)) : 0;
+    return {
+      nearDeadline: usedBps >= this.nearDeadlineBps,
+      usedBps,
+      remainingMs: Math.max(0, this.slaMs - elapsed),
+      slaMs: this.slaMs,
+      elapsedMs: elapsed,
+    };
+  }
+}

--- a/js/test/latency.test.ts
+++ b/js/test/latency.test.ts
@@ -81,4 +81,21 @@ describe("LatencyBudget", () => {
     const { budget } = make();
     expect(() => budget.check(-1)).toThrow(RangeError);
   });
+
+  it("rejects non-finite inputs (inf would disable the deadline; NaN slips comparisons)", () => {
+    expect(() => new LatencyBudget(Infinity)).toThrow(RangeError);
+    expect(() => new LatencyBudget(NaN)).toThrow(RangeError);
+    const { budget } = make();
+    expect(() => budget.check(NaN)).toThrow(RangeError);
+    expect(() => budget.check(Infinity)).toThrow(RangeError);
+  });
+
+  it("deadline message uses the shared half-up rounding (byte-parity with Python)", () => {
+    expect(new DeadlineExceeded(0.5, 5000.5).message).toBe(
+      "DEADLINE EXCEEDED — call blocked (elapsed 1ms of 5001ms SLA)",
+    );
+    expect(new DeadlineExceeded(-0.5, 1000).message).toBe(
+      "DEADLINE EXCEEDED — call blocked (elapsed 0ms of 1000ms SLA)",
+    );
+  });
 });

--- a/js/test/latency.test.ts
+++ b/js/test/latency.test.ts
@@ -1,0 +1,84 @@
+/**
+ * LatencyBudget — cumulative tool-chain deadline (FLO-624).
+ *
+ * Mirrors tests/test_latency.py; an injectable fake clock keeps every test
+ * sleep-free.
+ */
+
+import { describe, it, expect } from "vitest";
+import { LatencyBudget, DeadlineExceeded } from "../src/index.js";
+
+function make(slaMs = 5000, options: Record<string, unknown> = {}) {
+  let now = 100_000; // arbitrary origin — only deltas matter
+  const clock = () => now;
+  const advanceMs = (ms: number) => {
+    now += ms;
+  };
+  const budget = new LatencyBudget(slaMs, { clock, ...options });
+  return { budget, advanceMs };
+}
+
+describe("LatencyBudget", () => {
+  it("check passes with headroom and blocks when projected over", () => {
+    const { budget, advanceMs } = make(5000);
+    advanceMs(3000);
+    expect(() => budget.check(1000)).not.toThrow(); // 3000 + 1000 <= 5000
+
+    expect(() => budget.check(2500)).toThrow(DeadlineExceeded); // projected over
+    try {
+      budget.check(2500);
+    } catch (e) {
+      expect((e as DeadlineExceeded).slaMs).toBe(5000);
+      expect((e as DeadlineExceeded).elapsedMs).toBeCloseTo(3000);
+    }
+  });
+
+  it("check without an estimate gates on elapsed only", () => {
+    const { budget, advanceMs } = make(1000);
+    advanceMs(999);
+    expect(() => budget.check()).not.toThrow();
+    advanceMs(2);
+    expect(() => budget.check()).toThrow(DeadlineExceeded);
+  });
+
+  it("remainingMs is readable mid-chain and floors at zero", () => {
+    const { budget, advanceMs } = make(5000);
+    advanceMs(1500);
+    expect(budget.remainingMs).toBeCloseTo(3500);
+    advanceMs(9000);
+    expect(budget.remainingMs).toBe(0);
+  });
+
+  it("advisory is symmetric to BudgetGuard's (nearDeadline at the 80% default)", () => {
+    const { budget, advanceMs } = make(5000);
+    advanceMs(2500);
+    const mid = budget.advisory();
+    expect(mid.usedBps).toBe(5000);
+    expect(mid.nearDeadline).toBe(false);
+    expect(mid.remainingMs).toBeCloseTo(2500);
+
+    advanceMs(1600); // 4100/5000 = 82%
+    const late = budget.advisory();
+    expect(late.usedBps).toBe(8200);
+    expect(late.nearDeadline).toBe(true);
+
+    advanceMs(9000);
+    expect(budget.advisory().usedBps).toBe(10000); // capped
+  });
+
+  it("onBlock fires before the throw", () => {
+    const calls: Array<[number, number]> = [];
+    const { budget, advanceMs } = make(1000, { onBlock: (e: number, s: number) => calls.push([e, s]) });
+    advanceMs(1500);
+    expect(() => budget.check()).toThrow(DeadlineExceeded);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![1]).toBe(1000);
+  });
+
+  it("validates constructor and check inputs", () => {
+    expect(() => new LatencyBudget(0)).toThrow(RangeError);
+    expect(() => new LatencyBudget(5000, { nearDeadlineBps: 20000 })).toThrow(RangeError);
+    const { budget } = make();
+    expect(() => budget.check(-1)).toThrow(RangeError);
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.4.0"
+version = "0.5.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from .errors import (
     BudgetExceeded,
+    DeadlineExceeded,
     FloeGuardError,
     HostedEnforcementError,
     UnpriceableModelError,
@@ -22,18 +23,22 @@ from .errors import (
 )
 from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
+from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.4.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.5.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
     "SpendEvent",
+    "LatencyBudget",
+    "LatencyAdvisory",
     "StreamGuard",
     "guard_stream",
     "BudgetExceeded",
+    "DeadlineExceeded",
     "FloeGuardError",
     "HostedEnforcementError",
     "UnpriceableModelError",

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -6,6 +6,20 @@ can catch the whole family with a single ``except FloeGuardError``.
 
 from __future__ import annotations
 
+import math
+
+
+def _round_half_up(ms: float) -> int:
+    """Shared millisecond rounding for cross-language message parity.
+
+    Python's ``:.0f`` rounds half-to-even while JS ``toFixed(0)`` rounds
+    half-up, so tie values would break the byte-for-byte message contract.
+    Both packages format deadline messages through floor(x + 0.5) instead —
+    identical semantics in both runtimes (see ``roundHalfUp`` in
+    ``js/src/errors.ts``).
+    """
+    return math.floor(ms + 0.5)
+
 
 class FloeGuardError(Exception):
     """Base class for every error raised by floe-guard."""
@@ -77,5 +91,6 @@ class DeadlineExceeded(FloeGuardError):
         self.elapsed_ms = elapsed_ms
         self.sla_ms = sla_ms
         super().__init__(
-            f"DEADLINE EXCEEDED — call blocked (elapsed {elapsed_ms:.0f}ms of {sla_ms:.0f}ms SLA)"
+            f"DEADLINE EXCEEDED — call blocked (elapsed {_round_half_up(elapsed_ms)}ms "
+            f"of {_round_half_up(sla_ms)}ms SLA)"
         )

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -60,3 +60,22 @@ class UnpriceableModelWarning(UserWarning):
     :class:`UnpriceableModelError` is additionally raised; in fail-open mode the
     warning is emitted and the call's spend is skipped.
     """
+
+
+class DeadlineExceeded(FloeGuardError):
+    """Raised before a call whose projected duration would blow the SLA.
+
+    The latency twin of :class:`BudgetExceeded`: :meth:`LatencyBudget.check`
+    raises this *instead of* letting the next tool/model call start, so the
+    chain sheds work or falls back to a faster path rather than violating the
+    end-user SLA. This is a cooperative signal — killing an already-running
+    stalled task is the framework's job (asyncio cancellation / AbortSignal),
+    not the guard's.
+    """
+
+    def __init__(self, elapsed_ms: float, sla_ms: float) -> None:
+        self.elapsed_ms = elapsed_ms
+        self.sla_ms = sla_ms
+        super().__init__(
+            f"DEADLINE EXCEEDED — call blocked (elapsed {elapsed_ms:.0f}ms of {sla_ms:.0f}ms SLA)"
+        )

--- a/src/floe_guard/latency.py
+++ b/src/floe_guard/latency.py
@@ -1,0 +1,133 @@
+"""LatencyBudget — a cumulative tool-chain deadline, sibling to BudgetGuard.
+
+BudgetGuard stops an agent before its next call crosses a USD ceiling;
+LatencyBudget stops it before the next call would blow an end-user SLA::
+
+    from floe_guard import LatencyBudget
+
+    deadline = LatencyBudget(sla_ms=5000)
+    ...
+    deadline.check(expected_ms=800)   # raises DeadlineExceeded when projected over
+    if deadline.advisory().near_deadline:
+        use_faster_model()            # taper BEFORE the wall, like near_limit
+    router.pick(max_latency_ms=deadline.remaining_ms)
+
+Design notes (mirroring BudgetGuard's ergonomics):
+
+- **Monotonic clock.** Elapsed time comes from ``time.monotonic()``, never wall
+  time — NTP steps and DST can't corrupt the budget.
+- **Cooperative, not preemptive.** The guard provides the deadline *signal*;
+  killing a stalled in-flight call is the framework's job (asyncio
+  cancellation, an ``AbortSignal``, a thread timeout). ``check()`` prevents the
+  NEXT call from starting; it cannot interrupt one that already did.
+- **Advisory symmetry.** :meth:`advisory` returns ``near_deadline`` /
+  ``used_bps`` / ``remaining_ms``, the latency twin of BudgetGuard's
+  ``near_limit`` / ``used_bps`` / ``remaining_usd`` — taper logic written
+  against one shape ports to the other.
+- **In-process scope.** One instance covers one request/run in one process;
+  distributed/server-side latency tracking is explicitly out of scope.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .errors import DeadlineExceeded
+
+
+@dataclass(frozen=True)
+class LatencyAdvisory:
+    """A context-aware deadline signal — the latency twin of BudgetAdvisory.
+
+    Soft by design: the model may ignore it. The hard-stop
+    (:meth:`LatencyBudget.check`) is what actually sheds the next call.
+    """
+
+    near_deadline: bool
+    used_bps: int  # SLA consumed, basis points 0..10000 (8500 = 85%)
+    remaining_ms: float
+    sla_ms: float
+    elapsed_ms: float
+
+
+class LatencyBudget:
+    """Track cumulative elapsed time across an agentic chain against an SLA.
+
+    Args:
+        sla_ms: the end-to-end deadline in milliseconds. Must be > 0.
+        near_deadline_bps: utilization (basis points, 0..10000) at which
+            :meth:`advisory` flags ``near_deadline`` so the agent can downshift
+            to a faster path before the wall. Default 8000 (80%), matching
+            BudgetGuard's ``near_limit_bps``.
+        on_block: optional callback invoked with ``(elapsed_ms, sla_ms)`` right
+            before :class:`DeadlineExceeded` is raised.
+        clock: seconds-returning monotonic clock, injectable for tests.
+            Defaults to :func:`time.monotonic`.
+
+    The budget starts counting at construction — build it when the request
+    (and its SLA) starts.
+    """
+
+    def __init__(
+        self,
+        sla_ms: float,
+        *,
+        near_deadline_bps: int = 8000,
+        on_block: Callable[[float, float], None] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if not (sla_ms > 0):
+            raise ValueError("sla_ms must be > 0")
+        if not (isinstance(near_deadline_bps, int) and 0 <= near_deadline_bps <= 10000):
+            raise ValueError("near_deadline_bps must be an integer 0..10000")
+        self.sla_ms = float(sla_ms)
+        self.near_deadline_bps = near_deadline_bps
+        self._on_block = on_block
+        self._clock = clock
+        self._started_at = clock()
+
+    @property
+    def elapsed_ms(self) -> float:
+        """Milliseconds since construction (monotonic)."""
+        return (self._clock() - self._started_at) * 1000.0
+
+    @property
+    def remaining_ms(self) -> float:
+        """Milliseconds left before the SLA, floored at 0.
+
+        This is the readable signal a router uses to pick a faster fallback
+        or truncate work mid-chain.
+        """
+        return max(0.0, self.sla_ms - self.elapsed_ms)
+
+    def check(self, expected_ms: float = 0.0) -> None:
+        """Raise :class:`DeadlineExceeded` when the projected elapsed time
+        (now + ``expected_ms`` for the upcoming call) would blow the SLA.
+
+        Call it immediately before each tool/model call. ``expected_ms`` is
+        the caller's estimate for the next call — pass 0 to only gate on time
+        already spent.
+        """
+        if expected_ms < 0:
+            raise ValueError("expected_ms must be >= 0")
+        elapsed = self.elapsed_ms
+        if elapsed + expected_ms > self.sla_ms:
+            if self._on_block is not None:
+                self._on_block(elapsed, self.sla_ms)
+            raise DeadlineExceeded(elapsed, self.sla_ms)
+
+    def advisory(self) -> LatencyAdvisory:
+        """The soft near-deadline signal — symmetric to BudgetGuard.advisory()."""
+        elapsed = self.elapsed_ms
+        # round (not floor): float clock arithmetic can land a hair under an
+        # exact boundary (4099.999…ms of 5000 must read 82%, not 81.99%).
+        used_bps = min(10000, round(elapsed * 10000 / self.sla_ms)) if elapsed > 0 else 0
+        return LatencyAdvisory(
+            near_deadline=used_bps >= self.near_deadline_bps,
+            used_bps=used_bps,
+            remaining_ms=max(0.0, self.sla_ms - elapsed),
+            sla_ms=self.sla_ms,
+            elapsed_ms=elapsed,
+        )

--- a/src/floe_guard/latency.py
+++ b/src/floe_guard/latency.py
@@ -30,6 +30,7 @@ Design notes (mirroring BudgetGuard's ergonomics):
 
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -78,9 +79,13 @@ class LatencyBudget:
         on_block: Callable[[float, float], None] | None = None,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
-        if not (sla_ms > 0):
+        if not (math.isfinite(sla_ms) and sla_ms > 0):
             raise ValueError("sla_ms must be > 0")
-        if not (isinstance(near_deadline_bps, int) and 0 <= near_deadline_bps <= 10000):
+        if (
+            isinstance(near_deadline_bps, bool)
+            or not isinstance(near_deadline_bps, int)
+            or not 0 <= near_deadline_bps <= 10000
+        ):
             raise ValueError("near_deadline_bps must be an integer 0..10000")
         self.sla_ms = float(sla_ms)
         self.near_deadline_bps = near_deadline_bps
@@ -110,7 +115,7 @@ class LatencyBudget:
         the caller's estimate for the next call — pass 0 to only gate on time
         already spent.
         """
-        if expected_ms < 0:
+        if not (math.isfinite(expected_ms) and expected_ms >= 0):
             raise ValueError("expected_ms must be >= 0")
         elapsed = self.elapsed_ms
         if elapsed + expected_ms > self.sla_ms:

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -1,0 +1,96 @@
+"""LatencyBudget — cumulative tool-chain deadline (FLO-624).
+
+Uses an injectable fake monotonic clock so no test ever sleeps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import DeadlineExceeded, LatencyAdvisory, LatencyBudget
+
+
+class FakeClock:
+    """Monotonic-clock stand-in: seconds, advanced manually."""
+
+    def __init__(self) -> None:
+        self.now = 100.0  # arbitrary origin — only deltas matter
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance_ms(self, ms: float) -> None:
+        self.now += ms / 1000.0
+
+
+def make(sla_ms: float = 5000, **kwargs):
+    clock = FakeClock()
+    budget = LatencyBudget(sla_ms, clock=clock, **kwargs)
+    return budget, clock
+
+
+def test_check_passes_with_headroom_and_blocks_when_projected_over() -> None:
+    budget, clock = make(sla_ms=5000)
+    clock.advance_ms(3000)
+    budget.check(expected_ms=1000)  # 3000 + 1000 <= 5000 — fine
+
+    with pytest.raises(DeadlineExceeded) as exc:
+        budget.check(expected_ms=2500)  # 3000 + 2500 > 5000 — shed
+    assert exc.value.sla_ms == 5000
+    assert exc.value.elapsed_ms == pytest.approx(3000)
+
+
+def test_check_without_estimate_gates_on_elapsed_only() -> None:
+    budget, clock = make(sla_ms=1000)
+    clock.advance_ms(999)
+    budget.check()  # still inside
+    clock.advance_ms(2)
+    with pytest.raises(DeadlineExceeded):
+        budget.check()
+
+
+def test_remaining_ms_is_readable_mid_chain_and_floors_at_zero() -> None:
+    budget, clock = make(sla_ms=5000)
+    clock.advance_ms(1500)
+    assert budget.remaining_ms == pytest.approx(3500)
+    clock.advance_ms(9000)
+    assert budget.remaining_ms == 0.0  # floored, never negative
+
+
+def test_advisory_is_symmetric_to_budget_advisory() -> None:
+    budget, clock = make(sla_ms=5000)  # default near_deadline_bps = 8000
+    clock.advance_ms(2500)
+    mid = budget.advisory()
+    assert isinstance(mid, LatencyAdvisory)
+    assert mid.used_bps == 5000
+    assert mid.near_deadline is False
+    assert mid.remaining_ms == pytest.approx(2500)
+
+    clock.advance_ms(1600)  # 4100/5000 = 82%
+    late = budget.advisory()
+    assert late.used_bps == 8200
+    assert late.near_deadline is True
+
+    clock.advance_ms(9000)  # way past — used_bps caps at 10000
+    assert budget.advisory().used_bps == 10000
+
+
+def test_on_block_fires_before_the_raise() -> None:
+    calls: list[tuple[float, float]] = []
+    clock = FakeClock()
+    budget = LatencyBudget(1000, clock=clock, on_block=lambda e, s: calls.append((e, s)))
+    clock.advance_ms(1500)
+    with pytest.raises(DeadlineExceeded):
+        budget.check()
+    assert len(calls) == 1
+    assert calls[0][1] == 1000
+
+
+def test_constructor_and_check_validate_inputs() -> None:
+    with pytest.raises(ValueError):
+        LatencyBudget(0)
+    with pytest.raises(ValueError):
+        LatencyBudget(5000, near_deadline_bps=20000)
+    budget, _ = make()
+    with pytest.raises(ValueError):
+        budget.check(expected_ms=-1)

--- a/tests/test_latency.py
+++ b/tests/test_latency.py
@@ -94,3 +94,30 @@ def test_constructor_and_check_validate_inputs() -> None:
     budget, _ = make()
     with pytest.raises(ValueError):
         budget.check(expected_ms=-1)
+
+
+def test_rejects_non_finite_and_bool_inputs() -> None:
+    # inf would silently disable the deadline; nan slips every comparison.
+    with pytest.raises(ValueError):
+        LatencyBudget(float("inf"))
+    with pytest.raises(ValueError):
+        LatencyBudget(float("nan"))
+    # bool subclasses int — True must not pass as near_deadline_bps.
+    with pytest.raises(ValueError):
+        LatencyBudget(5000, near_deadline_bps=True)
+    budget, _ = make()
+    with pytest.raises(ValueError):
+        budget.check(expected_ms=float("nan"))
+    with pytest.raises(ValueError):
+        budget.check(expected_ms=float("inf"))
+
+
+def test_deadline_message_uses_shared_half_up_rounding() -> None:
+    # Byte-parity with the TS twin on rounding ties (floor(x + 0.5) in both;
+    # Python's :.0f would round 0.5 half-to-even while JS toFixed rounds up).
+    assert str(DeadlineExceeded(0.5, 5000.5)) == (
+        "DEADLINE EXCEEDED — call blocked (elapsed 1ms of 5001ms SLA)"
+    )
+    assert str(DeadlineExceeded(-0.5, 1000)) == (
+        "DEADLINE EXCEEDED — call blocked (elapsed 0ms of 1000ms SLA)"
+    )


### PR DESCRIPTION
## Summary
Adds `LatencyBudget` — BudgetGuard's sibling for **time**. It tracks cumulative elapsed time across an agentic tool chain against an end-user SLA and stops the *next* call before it would blow it, in both the Python and TypeScript packages.

## Changes
- `LatencyBudget(sla_ms)` with `check(expected_ms)` — raises the new `DeadlineExceeded` when projected elapsed time would exceed the SLA (`src/floe_guard/latency.py`, `js/src/latency.ts`)
- `remaining_ms` — readable mid-chain signal for router fallback / truncation
- `advisory()` → `near_deadline` / `used_bps` / `remaining_ms`, symmetric to the budget advisory's `near_limit` (taper logic ports between the two)
- New `DeadlineExceeded` error in both packages (message format byte-identical, matching the existing cross-language convention)
- Monotonic clocks only (`time.monotonic` / `performance.now`); injectable for tests
- Cooperative by design and documented as such: the guard supplies the deadline signal — killing a stalled in-flight call is the framework's job (asyncio cancellation / `AbortSignal`)
- Exports wired, README section, CHANGELOG entry

## Testing
12 new tests (`tests/test_latency.py` + `js/test/latency.test.ts`) using injectable fake clocks — no sleeps. Covers: projected-over blocking, elapsed-only gating, `remaining_ms` flooring at 0, advisory symmetry + 80% default threshold + 10000 bps cap, `on_block` callback, input validation.

- [x] `pytest` passes (168 passed)
- [x] `ruff check .` and `ruff format .` are clean on the files this PR touches (repo-wide has pre-existing violations on `main`, left untouched)
- [x] `npm test` (56 passed) and `npm run typecheck` pass in `js/`
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (Unreleased → Added, py + js)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added latency budgeting to track cumulative elapsed time against an SLA across the next tool/model call.
  * Implemented hard deadline checks using an optional expected duration, raising `DeadlineExceeded` when the projection exceeds the SLA.
  * Added advisory timing/usage signals (e.g., remaining time, near-deadline status, usage ratio) and an optional callback when blocking.
  * Added cross-language support for both Python and TypeScript.

* **Documentation**
  * Documented the new “LatencyBudget — deadlines, the same way” feature with examples.

* **Tests**
  * Added a deterministic test suite covering deadline enforcement, advisory behavior, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->