### PR TITLE
LiveKit Agents adapter — reserve-before / settle-after (closes #39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
       # (instead of skipping). langchain-core covers the LangChain handler
       # tests; litellm covers the callback-swallowing regression tests (the
       # CrewAI adapter tests stub crewai itself, so the heavy extra stays out);
-      # langgraph covers the fan-out reserve/settle and advisory-channel tests.
-      - run: pip install -e ".[dev,langchain,litellm,langgraph]"
+      # langgraph covers the fan-out reserve/settle and advisory-channel tests;
+      # livekit covers the LiveKit voice-agent reserve/settle/release tests
+      # (livekit-agents supports Python >=3.10, so it goes in the base install).
+      - run: pip install -e ".[dev,langchain,litellm,langgraph,livekit]"
       # pipecat-ai requires Python >=3.11, so add it (and exercise the Pipecat
       # adapter tests) on every matrix cell except 3.10 — there the tests
       # importorskip cleanly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.8.0 — 2026-07-23
+
 ### Added (py)
 
 - **LiveKit Agents adapter** (`floe-guard[livekit]`, issue #39):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   on `close` or a bypassed turn. Optional per-second / per-1k-char knobs meter
   STT/TTS spend via `record_tool`. `on_budget_exceeded` async callback for a
   graceful spoken wrap-up instead of a hard cut.
+
 ## py 0.7.0 / js 0.5.0 — 2026-07-21
 
 ### Added (py + js)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added (py)
+
+- **LiveKit Agents adapter** (`floe-guard[livekit]`, issue #39):
+  `LiveKitBudgetGuard.attach(session, agent)` wires the reserve-before /
+  settle-after contract onto a LiveKit `AgentSession` — reserve in the agent's
+  `llm_node`, settle on the session's `metrics_collected` `LLMMetrics`, release
+  on `close` or a bypassed turn. Optional per-second / per-1k-char knobs meter
+  STT/TTS spend via `record_tool`. `on_budget_exceeded` async callback for a
+  graceful spoken wrap-up instead of a hard cut.
+
 ## py 0.6.0 — 2026-07-18
 
 ### Added (py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ langgraph = ["langgraph>=1.0"]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.40"]
 pipecat = ["pipecat-ai>=1.0"]
+livekit = ["livekit-agents>=1.0"]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 
 [project.urls]

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -28,7 +28,7 @@ from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.7.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.8.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -52,7 +52,6 @@ class _TurnSlot:
     """
 
     amount: float
-    owner: object
     open: bool = True
 
 
@@ -90,8 +89,6 @@ class LiveKitBudgetGuard:
         self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
         self._reserved: float = 0.0
         self._pending = False
-        # Identity of the invocation that currently owns the open guard hold.
-        self._reservation_owner: object | None = None
         self._active: _TurnSlot | None = None
         # FIFO of turns that may still emit LLMMetrics (including early-released).
         self._slots: deque[_TurnSlot] = deque()
@@ -109,7 +106,6 @@ class LiveKitBudgetGuard:
             # slot so delayed metrics cannot steal this turn's hold.
             if self._pending:
                 self._early_release_active()
-            owner = object()
             try:
                 amount = self._guard.reserve()
             except BudgetExceeded as exc:
@@ -119,10 +115,9 @@ class LiveKitBudgetGuard:
                     raise
                 await self._on_budget_exceeded(exc)
                 return
-            slot = _TurnSlot(amount=amount, owner=owner)
+            slot = _TurnSlot(amount=amount)
             self._slots.append(slot)
             self._active = slot
-            self._reservation_owner = owner
             self._reserved = amount
             self._pending = True
             try:
@@ -132,9 +127,10 @@ class LiveKitBudgetGuard:
                 async for chunk in stream:
                     yield chunk
             except BaseException:
-                # Release only if this invocation still owns the open hold —
-                # a later turn may already have early-released ours and reserved.
-                if self._reservation_owner is owner:
+                # Release only if this invocation still owns the open hold — a
+                # later turn may already have early-released ours and reserved
+                # its own, making its slot (not ours) the active one.
+                if self._active is slot:
                     self._early_release_active()
                 raise
 
@@ -144,7 +140,6 @@ class LiveKitBudgetGuard:
 
     def _clear_active(self) -> None:
         self._active = None
-        self._reservation_owner = None
         self._reserved = 0.0
         self._pending = False
 

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -1,0 +1,136 @@
+"""LiveKit Agents adapter (optional extra: ``pip install floe-guard[livekit]``).
+
+Like Pipecat, a LiveKit ``AgentSession`` (STT -> LLM -> TTS) has no single call
+site to wrap: turns fire for the life of a call. The two enforcement points are
+the agent's ``llm_node`` (before the LLM call, so a turn is blocked before its
+TTS/audio spend piles on) and the session's ``metrics_collected`` event (real
+usage, after). ``LiveKitBudgetGuard`` holds the reservation state across both.
+
+    from floe_guard import BudgetGuard, ManualPrice
+    from floe_guard.integrations.livekit import LiveKitBudgetGuard
+
+    guard = BudgetGuard(
+        limit_usd=1.00,
+        price_overrides={"gemini-2.0-flash": ManualPrice(0.30e-6, 2.50e-6)},
+    )
+    budget = LiveKitBudgetGuard(guard, model="gemini-2.0-flash")
+
+    session = AgentSession(...)
+    budget.attach(session, agent)      # wire reserve / settle / release
+    await session.start(agent=agent, room=ctx.room)
+
+LiveKit's ``LLMMetrics`` does not report the served model, so cost is settled
+against the ``model`` passed here (unlike the Pipecat adapter, which reads it
+off the frame). STT/TTS spend — often a voice agent's larger bill — is metered
+only if per-unit prices are supplied, since the bundled cost map is LLM-only.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+
+from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
+
+from ..errors import BudgetExceeded
+from ..guard import BudgetGuard
+
+logger = logging.getLogger(__name__)
+
+
+class LiveKitBudgetGuard:
+    """Enforce a BudgetGuard ceiling on a LiveKit ``AgentSession``, one turn at a time.
+
+    Args:
+        guard: the BudgetGuard to enforce.
+        model: model id to settle LLM cost against (LiveKit's LLMMetrics carries
+            no model name). Must be priceable via the cost map or the guard's
+            ``price_overrides``.
+        on_budget_exceeded: optional async callback invoked with the
+            ``BudgetExceeded`` when a turn is blocked, so a bot can speak a
+            graceful "wrapping up" line before the turn ends silently. If
+            omitted, the ``BudgetExceeded`` propagates out of ``llm_node``.
+        stt_usd_per_second: if set, meter ``STTMetrics.audio_duration`` via
+            ``record_tool`` (per-second). Omit to keep the token-only contract.
+        tts_usd_per_1k_chars: if set, meter ``TTSMetrics.characters_count`` via
+            ``record_tool`` (per 1k chars). Omit to keep the token-only contract.
+    """
+
+    def __init__(
+        self,
+        guard: BudgetGuard,
+        model: str,
+        on_budget_exceeded: Callable[[BudgetExceeded], Awaitable[None]] | None = None,
+        *,
+        stt_usd_per_second: float | None = None,
+        tts_usd_per_1k_chars: float | None = None,
+    ):
+        self._guard = guard
+        self._model = model
+        self._on_budget_exceeded = on_budget_exceeded
+        self._stt_usd_per_second = stt_usd_per_second
+        self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
+        self._reserved: float = 0.0
+        self._pending = False
+
+    def attach(self, session, agent) -> None:
+        """Wire reserve (agent.llm_node), settle/meter (metrics_collected) and
+        release (close) onto a session + agent pair."""
+        orig_llm_node = agent.llm_node
+
+        async def _guarded_llm_node(chat_ctx, tools, model_settings):
+            # A previous turn that never settled (no metrics emitted) still holds
+            # its reservation — release before opening this one, or it leaks.
+            if self._pending:
+                self._release_pending()
+            try:
+                self._reserved = self._guard.reserve()
+                self._pending = True
+            except BudgetExceeded as exc:
+                self._pending = False
+                logger.warning("floe-guard blocked a turn: %s", exc)
+                if self._on_budget_exceeded is None:
+                    raise
+                await self._on_budget_exceeded(exc)
+                return
+            stream = orig_llm_node(chat_ctx, tools, model_settings)
+            if inspect.isawaitable(stream):
+                stream = await stream
+            async for chunk in stream:
+                yield chunk
+
+        agent.llm_node = _guarded_llm_node
+        session.on("metrics_collected", self._on_metrics)
+        session.on("close", self._on_close)
+
+    def _release_pending(self) -> None:
+        self._guard.release(self._reserved)
+        self._reserved = 0.0
+        self._pending = False
+
+    def _on_metrics(self, ev) -> None:
+        m = ev.metrics
+        if isinstance(m, LLMMetrics):
+            # Settle whenever usage arrives, even if the reserve hook was bypassed
+            # (then _reserved is 0.0, i.e. a plain record()). A cancelled turn
+            # still reports its partial tokens and releases the reservation here.
+            reserved = self._reserved
+            self._reserved = 0.0
+            self._pending = False
+            self._guard.settle(self._model, m.prompt_tokens, m.completion_tokens, reserved=reserved)
+        elif self._stt_usd_per_second and isinstance(m, STTMetrics):
+            self._guard.record_tool("livekit-stt", m.audio_duration * self._stt_usd_per_second)
+        elif self._tts_usd_per_1k_chars and isinstance(m, TTSMetrics):
+            self._guard.record_tool(
+                "livekit-tts", m.characters_count / 1000 * self._tts_usd_per_1k_chars
+            )
+
+    def _on_close(self, ev) -> None:
+        # Session torn down with a turn still reserved and no usage ever reported
+        # — release it so the reservation doesn't leak against the ceiling.
+        if self._pending:
+            self._release_pending()
+
+
+__all__ = ["LiveKitBudgetGuard"]

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -79,7 +79,9 @@ class LiveKitBudgetGuard:
         release (close) onto a session + agent pair."""
         orig_llm_node = agent.llm_node
 
-        async def _guarded_llm_node(chat_ctx, tools, model_settings):
+        # forward LiveKit's (chat_ctx, tools, model_settings) unchanged, so an
+        # upstream signature change can't break the wrapper.
+        async def _guarded_llm_node(*args, **kwargs):
             # A previous turn that never settled (no metrics emitted) still holds
             # its reservation — release before opening this one, or it leaks.
             if self._pending:
@@ -94,7 +96,7 @@ class LiveKitBudgetGuard:
                     raise
                 await self._on_budget_exceeded(exc)
                 return
-            stream = orig_llm_node(chat_ctx, tools, model_settings)
+            stream = orig_llm_node(*args, **kwargs)
             if inspect.isawaitable(stream):
                 stream = await stream
             async for chunk in stream:

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -96,11 +96,18 @@ class LiveKitBudgetGuard:
                     raise
                 await self._on_budget_exceeded(exc)
                 return
-            stream = orig_llm_node(*args, **kwargs)
-            if inspect.isawaitable(stream):
-                stream = await stream
-            async for chunk in stream:
-                yield chunk
+            try:
+                stream = orig_llm_node(*args, **kwargs)
+                if inspect.isawaitable(stream):
+                    stream = await stream
+                async for chunk in stream:
+                    yield chunk
+            except BaseException:
+                # raise / cancellation before metrics settle would leak the hold
+                # until the next turn or close — release it now if still pending.
+                if self._pending:
+                    self._release_pending()
+                raise
 
         agent.llm_node = _guarded_llm_node
         session.on("metrics_collected", self._on_metrics)

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -121,9 +121,9 @@ class LiveKitBudgetGuard:
             self._reserved = 0.0
             self._pending = False
             self._guard.settle(self._model, m.prompt_tokens, m.completion_tokens, reserved=reserved)
-        elif self._stt_usd_per_second and isinstance(m, STTMetrics):
+        elif self._stt_usd_per_second is not None and isinstance(m, STTMetrics):
             self._guard.record_tool("livekit-stt", m.audio_duration * self._stt_usd_per_second)
-        elif self._tts_usd_per_1k_chars and isinstance(m, TTSMetrics):
+        elif self._tts_usd_per_1k_chars is not None and isinstance(m, TTSMetrics):
             self._guard.record_tool(
                 "livekit-tts", m.characters_count / 1000 * self._tts_usd_per_1k_chars
             )

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 import inspect
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
 
@@ -37,6 +39,21 @@ from ..errors import BudgetExceeded
 from ..guard import BudgetGuard
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TurnSlot:
+    """One llm_node invocation awaiting (or already past) its LLMMetrics event.
+
+    ``open`` means the USD amount is still held on the BudgetGuard. Early
+    release (next turn, exception, close) clears the guard hold but leaves the
+    slot in the FIFO queue so a delayed metrics event settles against this
+    turn's slot (with ``amount`` 0) instead of stealing a later turn's hold.
+    """
+
+    amount: float
+    owner: object
+    open: bool = True
 
 
 class LiveKitBudgetGuard:
@@ -73,6 +90,11 @@ class LiveKitBudgetGuard:
         self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
         self._reserved: float = 0.0
         self._pending = False
+        # Identity of the invocation that currently owns the open guard hold.
+        self._reservation_owner: object | None = None
+        self._active: _TurnSlot | None = None
+        # FIFO of turns that may still emit LLMMetrics (including early-released).
+        self._slots: deque[_TurnSlot] = deque()
 
     def attach(self, session, agent) -> None:
         """Wire reserve (agent.llm_node), settle/meter (metrics_collected) and
@@ -82,20 +104,27 @@ class LiveKitBudgetGuard:
         # forward LiveKit's (chat_ctx, tools, model_settings) unchanged, so an
         # upstream signature change can't break the wrapper.
         async def _guarded_llm_node(*args, **kwargs):
-            # A previous turn that never settled (no metrics emitted) still holds
-            # its reservation — release before opening this one, or it leaks.
+            # A previous turn that never settled still holds its reservation —
+            # release the guard hold before opening this one, but keep a queue
+            # slot so delayed metrics cannot steal this turn's hold.
             if self._pending:
-                self._release_pending()
+                self._early_release_active()
+            owner = object()
             try:
-                self._reserved = self._guard.reserve()
-                self._pending = True
+                amount = self._guard.reserve()
             except BudgetExceeded as exc:
-                self._pending = False
+                self._clear_active()
                 logger.warning("floe-guard blocked a turn: %s", exc)
                 if self._on_budget_exceeded is None:
                     raise
                 await self._on_budget_exceeded(exc)
                 return
+            slot = _TurnSlot(amount=amount, owner=owner)
+            self._slots.append(slot)
+            self._active = slot
+            self._reservation_owner = owner
+            self._reserved = amount
+            self._pending = True
             try:
                 stream = orig_llm_node(*args, **kwargs)
                 if inspect.isawaitable(stream):
@@ -103,30 +132,48 @@ class LiveKitBudgetGuard:
                 async for chunk in stream:
                     yield chunk
             except BaseException:
-                # raise / cancellation before metrics settle would leak the hold
-                # until the next turn or close — release it now if still pending.
-                if self._pending:
-                    self._release_pending()
+                # Release only if this invocation still owns the open hold —
+                # a later turn may already have early-released ours and reserved.
+                if self._reservation_owner is owner:
+                    self._early_release_active()
                 raise
 
         agent.llm_node = _guarded_llm_node
         session.on("metrics_collected", self._on_metrics)
         session.on("close", self._on_close)
 
-    def _release_pending(self) -> None:
-        self._guard.release(self._reserved)
+    def _clear_active(self) -> None:
+        self._active = None
+        self._reservation_owner = None
         self._reserved = 0.0
         self._pending = False
+
+    def _early_release_active(self) -> None:
+        """Drop the open guard hold; leave a zeroed queue slot for delayed metrics."""
+        slot = self._active
+        if slot is None or not slot.open:
+            self._clear_active()
+            return
+        self._guard.release(slot.amount)
+        slot.open = False
+        slot.amount = 0.0
+        self._clear_active()
 
     def _on_metrics(self, ev) -> None:
         m = ev.metrics
         if isinstance(m, LLMMetrics):
-            # Settle whenever usage arrives, even if the reserve hook was bypassed
-            # (then _reserved is 0.0, i.e. a plain record()). A cancelled turn
-            # still reports its partial tokens and releases the reservation here.
-            reserved = self._reserved
-            self._reserved = 0.0
-            self._pending = False
+            # Pop the oldest turn slot. Early-released turns contribute 0 so a
+            # delayed metrics event meters usage without consuming a later hold.
+            # An empty queue (reserve hook bypassed) settles as a plain record().
+            if self._slots:
+                slot = self._slots.popleft()
+                reserved = slot.amount if slot.open else 0.0
+                if slot.open:
+                    slot.open = False
+                if self._active is slot:
+                    self._clear_active()
+            else:
+                reserved = 0.0
             self._guard.settle(self._model, m.prompt_tokens, m.completion_tokens, reserved=reserved)
         elif self._stt_usd_per_second is not None and isinstance(m, STTMetrics):
             self._guard.record_tool("livekit-stt", m.audio_duration * self._stt_usd_per_second)
@@ -136,10 +183,11 @@ class LiveKitBudgetGuard:
             )
 
     def _on_close(self, ev) -> None:
-        # Session torn down with a turn still reserved and no usage ever reported
-        # — release it so the reservation doesn't leak against the ceiling.
+        # Session torn down with a turn still reserved — release it. Drop any
+        # leftover slots so a post-close metrics event cannot touch a stale hold.
         if self._pending:
-            self._release_pending()
+            self._early_release_active()
+        self._slots.clear()
 
 
 __all__ = ["LiveKitBudgetGuard"]

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -1,0 +1,203 @@
+"""Tests for the LiveKit Agents integration.
+
+The adapter hooks two surfaces — the agent's ``llm_node`` (reserve) and the
+session's ``metrics_collected`` / ``close`` events (settle / release). These
+drive them directly through a minimal fake agent + event-emitter session, which
+is all ``attach`` touches; a full LiveKit room/runner isn't needed.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+# The adapter hard-imports livekit-agents at module load, so skip the whole
+# module (rather than erroring collection) when the optional extra is absent.
+pytest.importorskip("livekit.agents")
+
+from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics  # noqa: E402
+
+from floe_guard import BudgetGuard  # noqa: E402
+from floe_guard.errors import BudgetExceeded  # noqa: E402
+from floe_guard.integrations.livekit import LiveKitBudgetGuard  # noqa: E402
+
+
+class _FakeSession:
+    def __init__(self):
+        self._handlers = {}
+
+    def on(self, event, cb):
+        self._handlers[event] = cb
+
+    def emit(self, event, arg):
+        self._handlers[event](arg)
+
+
+class _FakeAgent:
+    async def llm_node(self, chat_ctx, tools, model_settings):
+        for chunk in ("hello", " world"):
+            yield chunk
+
+
+def _attached(guard, **kwargs):
+    agent, session = _FakeAgent(), _FakeSession()
+    budget = LiveKitBudgetGuard(guard, model="gpt-4o", **kwargs)
+    budget.attach(session, agent)
+    return budget, agent, session
+
+
+async def _drive_turn(agent):
+    return [chunk async for chunk in agent.llm_node(None, None, None)]
+
+
+def _llm_metrics(prompt_tokens, completion_tokens, cancelled=False):
+    return LLMMetrics(
+        label="llm",
+        request_id="r",
+        timestamp=0.0,
+        duration=0.0,
+        ttft=0.0,
+        cancelled=cancelled,
+        completion_tokens=completion_tokens,
+        prompt_tokens=prompt_tokens,
+        prompt_cached_tokens=0,
+        total_tokens=prompt_tokens + completion_tokens,
+        tokens_per_second=0.0,
+    )
+
+
+def _event(metric):
+    return types.SimpleNamespace(metrics=metric)
+
+
+@pytest.mark.asyncio
+async def test_turn_streams_through_and_settles_on_metrics():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard)
+
+    chunks = await _drive_turn(agent)
+    assert chunks == ["hello", " world"]  # original llm_node output is preserved
+    assert budget._pending  # reservation held until usage is reported
+
+    session.emit("metrics_collected", _event(_llm_metrics(100, 50)))
+
+    assert guard.advisory().spent_usd > 0
+    assert not budget._pending
+    assert budget._reserved == 0.0
+
+
+@pytest.mark.asyncio
+async def test_on_budget_exceeded_callback_used_instead_of_raising():
+    guard = BudgetGuard(limit_usd=0.0001)
+    called = {}
+
+    async def handle(exc):
+        called["exc"] = exc
+
+    budget, agent, session = _attached(guard, on_budget_exceeded=handle)
+
+    await _drive_turn(agent)  # first turn reserves $0 (no prior cost) and passes
+    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))  # now over ceiling
+
+    chunks = await _drive_turn(agent)  # second turn should be blocked
+    assert chunks == []  # blocked turn yields nothing
+    assert isinstance(called.get("exc"), BudgetExceeded)
+
+
+@pytest.mark.asyncio
+async def test_blocked_turn_raises_without_callback():
+    guard = BudgetGuard(limit_usd=0.0001)
+    budget, agent, session = _attached(guard)
+
+    await _drive_turn(agent)
+    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+
+    with pytest.raises(BudgetExceeded):
+        await _drive_turn(agent)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_settles_and_releases_reservation():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard)
+
+    await _drive_turn(agent)
+    session.emit("metrics_collected", _event(_llm_metrics(0, 0, cancelled=True)))
+
+    assert not budget._pending
+    assert budget._reserved == 0.0
+
+
+@pytest.mark.asyncio
+async def test_close_releases_dangling_reservation():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard)
+
+    await _drive_turn(agent)  # reserves, no metrics emitted
+    assert budget._pending
+    session.emit("close", types.SimpleNamespace())
+
+    assert not budget._pending
+    assert guard._reserved == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_stt_and_tts_metered_only_when_priced():
+    guard = BudgetGuard(limit_usd=100.00)
+    _, _, session = _attached(guard, stt_usd_per_second=0.01, tts_usd_per_1k_chars=0.10)
+
+    session.emit(
+        "metrics_collected",
+        _event(
+            STTMetrics(
+                label="stt",
+                request_id="r",
+                timestamp=0.0,
+                duration=0.0,
+                audio_duration=10.0,
+                streamed=True,
+            )
+        ),
+    )
+    session.emit(
+        "metrics_collected",
+        _event(
+            TTSMetrics(
+                label="tts",
+                request_id="r",
+                timestamp=0.0,
+                ttfb=0.0,
+                duration=0.0,
+                audio_duration=0.0,
+                cancelled=False,
+                characters_count=1000,
+                streamed=True,
+            )
+        ),
+    )
+
+    # 10s * $0.01/s + 1000 chars / 1000 * $0.10 = 0.10 + 0.10
+    assert guard.advisory().spent_usd == pytest.approx(10 * 0.01 + 0.10)
+
+
+@pytest.mark.asyncio
+async def test_stt_tts_ignored_by_default():
+    guard = BudgetGuard(limit_usd=100.00)
+    _, _, session = _attached(guard)  # no per-unit prices
+
+    session.emit(
+        "metrics_collected",
+        _event(
+            STTMetrics(
+                label="stt",
+                request_id="r",
+                timestamp=0.0,
+                duration=0.0,
+                audio_duration=10.0,
+                streamed=True,
+            )
+        ),
+    )
+
+    assert guard.advisory().spent_usd == 0.0

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -8,6 +8,7 @@ is all ``attach`` touches; a full LiveKit room/runner isn't needed.
 
 from __future__ import annotations
 
+import asyncio
 import types
 
 import pytest
@@ -140,6 +141,120 @@ async def test_close_releases_dangling_reservation():
 
     assert not budget._pending
     assert guard._reserved == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_failing_turn_releases_its_own_reservation():
+    guard = BudgetGuard(limit_usd=100.00)
+
+    class _FailingAgent:
+        async def llm_node(self, chat_ctx, tools, model_settings):
+            raise RuntimeError("llm blew up")
+            yield  # make this an async generator  # noqa: RET503
+
+    agent, session = _FailingAgent(), _FakeSession()
+    budget = LiveKitBudgetGuard(guard, model="gpt-4o")
+    budget.attach(session, agent)
+
+    with pytest.raises(RuntimeError, match="llm blew up"):
+        async for _ in agent.llm_node(None, None, None):
+            pass
+
+    assert not budget._pending
+    assert budget._reserved == 0.0
+    assert guard._reserved == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_failing_turn_does_not_release_later_turns_reservation():
+    """If turn A fails after turn B has reserved, A must not free B's hold."""
+    guard = BudgetGuard(limit_usd=100.00)
+    # Seed a non-zero default estimate so reserve() holds real USD.
+    seed_agent, seed_session = _FakeAgent(), _FakeSession()
+    seed = LiveKitBudgetGuard(guard, model="gpt-4o")
+    seed.attach(seed_session, seed_agent)
+    await _drive_turn(seed_agent)
+    seed_session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+
+    a_ready = asyncio.Event()
+    a_may_fail = asyncio.Event()
+    calls = {"n": 0}
+
+    class _OverlapAgent:
+        async def llm_node(self, chat_ctx, tools, model_settings):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                a_ready.set()
+                await a_may_fail.wait()
+                raise RuntimeError("turn A interrupted")
+            yield "b-ok"
+
+    agent, session = _OverlapAgent(), _FakeSession()
+    budget = LiveKitBudgetGuard(guard, model="gpt-4o")
+    budget.attach(session, agent)
+
+    async def drive_a():
+        with pytest.raises(RuntimeError, match="turn A interrupted"):
+            async for _ in agent.llm_node(None, None, None):
+                pass
+
+    task_a = asyncio.create_task(drive_a())
+    await a_ready.wait()
+
+    # Turn B reserves while A is still in flight (and still owns its cleanup path).
+    chunks = [c async for c in agent.llm_node(None, None, None)]
+    assert chunks == ["b-ok"]
+    assert budget._pending
+    b_reserved = budget._reserved
+    assert b_reserved > 0
+    assert guard._reserved == pytest.approx(b_reserved)
+
+    a_may_fail.set()
+    await task_a
+
+    # A's exception cleanup must not have released B's reservation.
+    assert budget._pending
+    assert budget._reserved == pytest.approx(b_reserved)
+    assert guard._reserved == pytest.approx(b_reserved)
+
+
+@pytest.mark.asyncio
+async def test_delayed_metrics_do_not_steal_later_turns_reservation():
+    """Turn A's late LLMMetrics must not settle against turn B's hold."""
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard)
+
+    # Seed a non-zero default estimate so holds are real USD.
+    await _drive_turn(agent)
+    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+
+    # Turn A reserves and finishes streaming; metrics not yet emitted.
+    await _drive_turn(agent)
+    assert budget._pending
+    a_reserved = budget._reserved
+    assert a_reserved > 0
+
+    # Turn B starts: early-releases A's guard hold, then reserves its own.
+    await _drive_turn(agent)
+    assert budget._pending
+    b_reserved = budget._reserved
+    assert b_reserved > 0
+    assert guard._reserved == pytest.approx(b_reserved)
+
+    # A's delayed metrics arrive first — must meter A without consuming B.
+    session.emit("metrics_collected", _event(_llm_metrics(100, 50)))
+    assert budget._pending
+    assert budget._reserved == pytest.approx(b_reserved)
+    assert guard._reserved == pytest.approx(b_reserved)
+
+    spent_after_a = guard.advisory().spent_usd
+
+    # B's metrics settle B's own hold.
+    session.emit("metrics_collected", _event(_llm_metrics(200, 100)))
+    assert not budget._pending
+    assert budget._reserved == 0.0
+    assert guard._reserved == pytest.approx(0.0)
+    assert guard.advisory().spent_usd > spent_after_a
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The gap
`floe-guard` has a Pipecat voice adapter but none for **LiveKit Agents** — the other widely-used Python voice-agent framework. Same shape as Pipecat: a running `AgentSession` (STT → LLM → TTS) with turns firing for the life of a call, so there's no single call site to wrap like the OpenAI/Anthropic adapters.

## Surface (mirrors `pipecat.py`'s reserve/settle/release contract)
`LiveKitBudgetGuard.attach(session, agent)` wires:
- **reserve()** — in the agent's `llm_node`, before the LLM call, so a turn is blocked before its TTS/audio spend piles on. Raising `BudgetExceeded` here (or invoking the optional `on_budget_exceeded` async callback) stops the turn.
- **settle()** — on the session's `metrics_collected` `LLMMetrics` (`prompt_tokens` / `completion_tokens`), passing the held reservation.
- **release()** — on `close` or a bypassed/never-settled turn, so a reservation never leaks against the ceiling.

LiveKit's `LLMMetrics` reports no served model, so cost settles against the configured `model`.

## Reservation-lifecycle edge cases covered
- back-to-back turns where the previous turn never settled → release before opening the new reservation;
- session close / error with a turn still reserved → release;
- settle whenever usage arrives even if the reserve hook was bypassed (plain `record()` with zero reservation).

## One design question
The Pipecat adapter meters **LLM tokens only**. LiveKit's `metrics_collected` also surfaces `STTMetrics.audio_duration` and `TTSMetrics.characters_count` — often a voice agent's larger bill. This adapter optionally books those via `record_tool()` behind per-unit knobs (`stt_usd_per_second` / `tts_usd_per_1k_chars`), since the bundled cost map is LLM-only. Happy to keep strictly to the token contract like Pipecat if you'd prefer — just wanted to match your intent.

## Conventions
New module `integrations/livekit.py` behind a `[livekit]` extra; `tests/test_livekit_adapter.py` skips cleanly when `livekit-agents` isn't installed; core stays dependency-free; `ruff` + `pytest` green.

Dogfooded end-to-end in a LiveKit voice agent of my own: reserve-before block, settle-after, STT/TTS metering, and release-on-teardown all verified live in addition to the unit tests.

Closes #39.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LiveKit Agents integration to enforce per-turn budget limits, reserving budget while streaming and then settling/releasing using session-reported LLM metrics.
  * Optional STT/TTS cost metering is supported when per-unit pricing is configured.
  * When budget is exceeded, the session can either trigger an async wrap-up callback or raise an error if no callback is provided.
  * Added the `livekit` installation extra.
* **Documentation**
  * Updated the changelog with an Unreleased entry for the LiveKit integration.
* **Tests**
  * Added coverage for streaming reservation, budget-exceeded behavior (callback vs raise), metrics settlement/cancellation, STT/TTS metering, and cleanup on session close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->