### PR TITLE
Feat/anthropic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ response = guarded_completion(guard, client, model="claude-3-7-sonnet-20250219",
 Same reserve-before / record-after contract as the OpenAI adapter; Anthropic's
 `input_tokens` / `output_tokens` are mapped onto the guard's prompt/completion
 pricing. Use `guarded_acompletion` with an `AsyncAnthropic` client for async.
+See [`examples/anthropic_adapter.py`](examples/anthropic_adapter.py) for a
+runnable demo of the adapter's native prompt-cache pricing — a cached read
+costs a fraction of a fresh one (no API key needed).
 
 ### Vercel AI SDK
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,9 @@ response = guarded_completion(guard, client, model="gpt-4o", messages=[...])
 
 `guarded_completion` reserves the budget before the call (raising
 `BudgetExceeded` so a blocked call never reaches OpenAI) and records spend after.
-Use `guarded_acompletion` with an `AsyncOpenAI` client for async.
+Use `guarded_acompletion` with an `AsyncOpenAI` client for async. See
+[`examples/openai_adapter.py`](examples/openai_adapter.py) for a runnable
+hard-stop demo (no API key needed).
 
 ### Anthropic
 

--- a/examples/anthropic_adapter.py
+++ b/examples/anthropic_adapter.py
@@ -1,0 +1,129 @@
+"""floe-guard + the Anthropic adapter — runs with NO API key, NO account, NO network.
+
+Same reserve-before / settle-after contract as ``examples/openai_adapter.py``,
+but this adapter has something the OpenAI one doesn't: native prompt-cache
+pricing (PR #27). A cached read of the same tokens costs a fraction of a fresh
+read — ``cache_read_input_tokens`` prices at 0.1x the input rate, vs. 1.25x
+(5m TTL) or 2.0x (1h TTL) to *write* the cache in the first place. See
+``_CACHE_READ_MULTIPLIER`` / ``_CACHE_CREATION_MULTIPLIER`` in
+``floe_guard/pricing.py``.
+
+This demo simulates a multi-turn conversation that re-sends a large shared
+context (e.g. a codebase excerpt pasted as a system prompt): turn 1 writes it
+to the cache, turns 2+ read it back near-free. A probe call measures what
+that same turn would have cost had it re-sent the context uncached, so the
+comparison is priced by the real engine — not a hardcoded number that could
+drift from the bundled cost map.
+
+The client below is a duck-typed stub (same shape the adapter's own tests
+use), so this needs no ``anthropic`` install and no ``ANTHROPIC_API_KEY``.
+
+Run:  python examples/anthropic_adapter.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.anthropic import guarded_completion
+
+MODEL = "claude-3-7-sonnet-20250219"
+
+# A large shared context (e.g. a codebase excerpt) re-sent on every turn, plus
+# a small new question and a short reply.
+CONTEXT_TOKENS = 6_000
+QUESTION_TOKENS = 40
+OUTPUT_TOKENS = 150
+
+
+@dataclass
+class _CacheCreation:
+    ephemeral_5m_input_tokens: int = 0
+    ephemeral_1h_input_tokens: int = 0
+
+
+@dataclass
+class _Usage:
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation: _CacheCreation = field(default_factory=_CacheCreation)
+
+
+@dataclass
+class _Response:
+    model: str
+    usage: _Usage
+
+
+class _Messages:
+    """Stub of ``client.messages`` — no network, fixed token usage per call."""
+
+    def __init__(self, usage: _Usage) -> None:
+        self._usage = usage
+
+    def create(self, **kwargs: object) -> _Response:
+        return _Response(model=MODEL, usage=self._usage)
+
+
+class _Client:
+    """Duck-typed stand-in for ``anthropic.Anthropic`` — same shape, no network."""
+
+    def __init__(self, usage: _Usage) -> None:
+        self.messages = _Messages(usage)
+
+
+def _call(guard: BudgetGuard, usage: _Usage) -> float:
+    """Run one guarded call against a stub returning ``usage`` and return its cost."""
+    before = guard.spent_usd
+    guarded_completion(guard, _Client(usage), model=MODEL, max_tokens=1024, messages=[])
+    return guard.spent_usd - before
+
+
+def main() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+
+    print(f"Simulating a conversation that re-sends a {CONTEXT_TOKENS}-token context...\n")
+
+    # Turn 1: nothing cached yet — write the context to the 5m-TTL cache.
+    cold_usage = _Usage(
+        input_tokens=QUESTION_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+        cache_creation_input_tokens=CONTEXT_TOKENS,
+        cache_creation=_CacheCreation(ephemeral_5m_input_tokens=CONTEXT_TOKENS),
+    )
+    cold_cost = _call(guard, cold_usage)
+    print(f"  turn 1 (cache write): ${cold_cost:.5f}")
+
+    # Turns 2-3: same context, now served from cache.
+    warm_usage = _Usage(
+        input_tokens=QUESTION_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+        cache_read_input_tokens=CONTEXT_TOKENS,
+    )
+    warm_cost = _call(guard, warm_usage)
+    print(f"  turn 2 (cache read):  ${warm_cost:.5f}")
+    warm_cost_2 = _call(guard, warm_usage)
+    print(f"  turn 3 (cache read):  ${warm_cost_2:.5f}")
+
+    # Probe: what would turn 2 have cost if it re-sent the context uncached
+    # (no cache_read_input_tokens — just a plain, full-price input)? Measured
+    # via a throwaway guard through the same pricing engine, so this can't
+    # drift from whatever the bundled cost map says today.
+    probe_guard = BudgetGuard(limit_usd=1.00)
+    uncached_usage = _Usage(
+        input_tokens=CONTEXT_TOKENS + QUESTION_TOKENS, output_tokens=OUTPUT_TOKENS
+    )
+    uncached_cost = _call(probe_guard, uncached_usage)
+
+    savings = uncached_cost - warm_cost
+    multiple = uncached_cost / warm_cost if warm_cost else float("inf")
+    print(f"\nSame turn, uncached: ${uncached_cost:.5f}")
+    print(f"Cached read was ${savings:.5f} cheaper ({multiple:.1f}x less) than resending fresh.")
+    print(f"\nTotal spent over 3 turns: ${guard.spent_usd:.5f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/openai_adapter.py
+++ b/examples/openai_adapter.py
@@ -1,0 +1,86 @@
+"""floe-guard + the OpenAI adapter — runs with NO API key, NO account, NO network.
+
+``examples/runaway_loop.py`` drives the guard directly (``check()`` /
+``record()``). This demo instead goes through
+``floe_guard.integrations.openai.guarded_completion`` — the real
+reserve-before / settle-after wrapper you'd point at a live ``openai.OpenAI``
+client — so it exercises the actual hard-stop contract: a blocked call raises
+``BudgetExceeded`` *before* ``client.chat.completions.create`` ever runs.
+
+The client below is a duck-typed stub (same shape the adapter's own tests use)
+that returns a fixed ``usage`` block instead of calling OpenAI, so this needs
+no ``openai`` install and no ``OPENAI_API_KEY``.
+
+Run:  python examples/openai_adapter.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from floe_guard import BudgetExceeded, BudgetGuard
+from floe_guard.integrations.openai import guarded_completion
+
+MODEL = "gpt-4o"
+
+
+@dataclass
+class _Usage:
+    prompt_tokens: int
+    completion_tokens: int
+
+
+@dataclass
+class _Response:
+    model: str
+    usage: _Usage
+
+
+class _Completions:
+    """Stub of ``client.chat.completions`` — no network, fixed token usage."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def create(self, **kwargs: object) -> _Response:
+        self.call_count += 1
+        # A real call reached here — this is what the hard-stop must prevent
+        # once the budget is exhausted.
+        return _Response(model=MODEL, usage=_Usage(prompt_tokens=1_000, completion_tokens=1_000))
+
+
+class _Chat:
+    def __init__(self, completions: _Completions) -> None:
+        self.completions = completions
+
+
+class _Client:
+    """Duck-typed stand-in for ``openai.OpenAI`` — same shape, no network."""
+
+    def __init__(self) -> None:
+        self.chat = _Chat(_Completions())
+
+
+def main() -> None:
+    # gpt-4o at 1k in + 1k out ~= $0.0125/call, so a $0.05 ceiling clears
+    # exactly 4 calls before the 5th is blocked pre-flight.
+    guard = BudgetGuard(limit_usd=0.05)
+    client = _Client()
+
+    print(f"Starting with a ${guard.limit_usd:.2f} budget against a stub OpenAI client...\n")
+    call = 0
+    while True:
+        call += 1
+        messages = [{"role": "user", "content": "go"}]
+        try:
+            response = guarded_completion(guard, client, model=MODEL, messages=messages)
+        except BudgetExceeded:
+            calls_made = client.chat.completions.call_count
+            print(f"\nCall #{call} blocked before reaching the client.")
+            print(f"client.chat.completions.create was invoked {calls_made} times (not {call}).")
+            break
+        print(f"  call #{call}: served by {response.model}  (running total ${guard.spent_usd:.4f})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a no-API-key, no-network runnable example for the Anthropic adapter
(`guarded_completion`). Unlike the OpenAI example, this one demonstrates the
adapter's native prompt-cache pricing (PR #27) — a cached read costs a
fraction of a fresh one — since that's a feature the OpenAI adapter doesn't
have. Addresses the "docs and examples" area from CONTRIBUTING.md.

## Changes
- New file: examples/anthropic_adapter.py — simulates a 3-turn conversation
  reusing a shared context; turn 1 writes it to cache, turns 2–3 read it back
  cheaply. Includes a probe call (priced through the same pricing engine, not
  hardcoded) showing what an uncached turn would have cost, for comparison.
- README.md: link to the new example from the Anthropic section

## Testing
- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [ ] `npm test` and `npm run typecheck` pass in `js/` — n/a, no TypeScript changes
- [ ] Cost-map copies still match — n/a, cost map untouched
- [ ] CHANGELOG.md updated — n/a, this is a docs/example addition, not a behavior change

## Related issues
No related issue — this addresses the general "docs and examples" ask in
CONTRIBUTING.md, not a specific tracked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added runnable OpenAI and Anthropic adapter demos to the README.
  * OpenAI example demonstrates enforcing a spending limit and blocking calls after the budget is exceeded.
  * Anthropic example demonstrates multi-turn prompt caching, per-turn costs, savings, and total spend.
  * Both demos run without API keys, external installations, or network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->