### PR TITLE
feat: Google Gemini pricing + google-genai adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ### Fixed (py + js)
 
+- **A wrong upstream `mode` can no longer bill a chat model's output for free.**
+  Embedding mode zeroes the output rate, and upstream lists `gemini-1.5-flash` — a
+  chat/multimodal model — as `mode: "embedding"` with `output_cost_per_token: 0`.
+  Vendoring that would meter every `gemini-1.5-flash` completion's output at $0,
+  which fail-closed pricing cannot catch because `0` is a finite, valid price. An
+  embedding entry's id must now agree with its declared mode (`text-embedding-*`,
+  `gemini-embedding-*`), so a single wrong field can't zero a price; the same
+  predicate gates both the filter and the writer. `gemini-1.5-flash` has no
+  correctly-priced variant upstream, so it stays unpriceable and fails closed.
 - **Zero-priced chat models are no longer vendored.** Upstream lists some
   free/experimental tiers at `0`/`0`, and fail-closed pricing cannot catch them
   (`0` is finite, so the model resolves and every call meters at $0 forever).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,63 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added (py)
+
+- **Google Gemini adapter** (`pip install floe-guard[gemini]`) —
+  `floe_guard.integrations.gemini.guarded_completion` / `guarded_acompletion`
+  wrap the `google-genai` SDK's `client.models.generate_content` with the same
+  reserve-before / settle-after contract as the OpenAI and Anthropic adapters, so
+  a blocked call never reaches Google.
+- All five Gemini usage counters are mapped, not just the obvious two:
+  `thoughts_token_count` (thinking-model reasoning, billed as output) and
+  `tool_use_prompt_token_count` (tool results fed back as input) sit *outside*
+  `candidates_token_count` / `prompt_token_count`, so omitting them would
+  under-meter thinking and tool-using agents. `cached_content_token_count` is
+  carved *out* of the prompt count — Gemini documents it as included there — and
+  re-priced at the cache-read rate instead of being charged twice.
+- **Vertex AI callers fail closed unless they supply prices.** One SDK serves
+  both Google AI Studio and Vertex with identical model ids, and the bundled map
+  carries AI Studio rates, so metering a Vertex call against it would under-meter.
+  The model id cannot reveal the backend but the client can: the adapter reads
+  `client.vertexai` (set by both `vertexai=True` and the newer `enterprise=True`)
+  and refuses unless the model has a `price_overrides` entry. Honours
+  `fail_closed=False` for callers who accept un-metered spend.
+
+### Added (py + js)
+
+- **Google Gemini pricing in the bundled cost map** — 37 Gemini models are now
+  priced offline, so `gemini-2.5-flash` and friends are metered instead of
+  failing closed. Vendored under the **bare** ids the `google-genai` SDK and
+  `@ai-sdk/google` pass; LiteLLM's `gemini/<id>` and the older `models/<id>`
+  forms resolve to the same entry through the existing bare-last-segment
+  fallback, so no change to `pricing.py` / `pricing.ts` was needed.
+- Prices are **Google AI Studio (Gemini Developer API)** rates. Vertex AI serves
+  the same ids at its own — sometimes dearer — rates (`gemini-2.0-flash-001`:
+  Vertex is 50% higher), and a model id alone cannot say which billing path a
+  call used, so Vertex is deliberately not vendored; Vertex agents pass
+  `price_overrides`. A `vertex_ai/<id>` caller resolves at AI Studio rates via
+  the same fallback that already maps `openrouter/openai/gpt-4o` → `gpt-4o`;
+  this is asserted in `tests/test_pricing.py` so it cannot change silently.
+
+### Fixed (py + js)
+
+- **Zero-priced chat models are no longer vendored.** Upstream lists some
+  free/experimental tiers at `0`/`0`, and fail-closed pricing cannot catch them
+  (`0` is finite, so the model resolves and every call meters at $0 forever).
+  They are now dropped and fail closed loudly. Embedding entries keep their `0`
+  output rate — that is a real price, not a missing one.
+- **Duplicate upstream keys resolve to the dearer entry.** Several Gemini models
+  are listed both bare and `gemini/`-prefixed; collapsing them onto one vendored
+  key previously depended on iteration order. The refresh now keeps the more
+  expensive of the two — over-pricing stops an agent one call early (safe),
+  under-pricing lets a crossing call through.
+- **Realtime/audio models are no longer priced at text rates.** Upstream
+  reclassified OpenAI's realtime models from `chat` to `realtime` mode, so they
+  drop out of the vendored map. This closes a latent under-meter: they bill audio
+  tokens at up to **8×** their text input rate (`gpt-realtime`: $0.000032/token
+  audio vs $0.000004 text), which the map had no way to express. They now fail
+  closed until given a `price_overrides` entry.
+
 ## py 0.7.0 / js 0.5.0 — 2026-07-21
 
 ### Added (py + js)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   The model id cannot reveal the backend but the client can: the adapter reads
   `client.vertexai` (set by both `vertexai=True` and the newer `enterprise=True`)
   and refuses unless the model has a `price_overrides` entry. Honours
-  `fail_closed=False` for callers who accept un-metered spend.
+  `fail_closed=False` for callers who accept un-metered spend. A Vertex call
+  cleared by an override also settles against that override even when Google
+  serves a different snapshot id the bundled map happens to price — otherwise the
+  drift would quietly put the call back on AI Studio rates.
 
 ### Added (py + js)
 
@@ -55,20 +58,23 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   chat/multimodal model — as `mode: "embedding"` with `output_cost_per_token: 0`.
   Vendoring that would meter every `gemini-1.5-flash` completion's output at $0,
   which fail-closed pricing cannot catch because `0` is a finite, valid price. An
-  embedding entry's id must now agree with its declared mode (`text-embedding-*`,
-  `gemini-embedding-*`), so a single wrong field can't zero a price; the same
-  predicate gates both the filter and the writer. `gemini-1.5-flash` has no
+  embedding entry's id must now start with a known embedding family
+  (`text-embedding-*`, `gemini-embedding-*`), so a single wrong field can't zero a
+  price; the same predicate gates both the filter and the writer, and an unknown
+  family is dropped with a warning rather than trusted. `gemini-1.5-flash` has no
   correctly-priced variant upstream, so it stays unpriceable and fails closed.
-- **Zero-priced chat models are no longer vendored.** Upstream lists some
+- **Zero-priced models are no longer vendored.** Upstream lists some
   free/experimental tiers at `0`/`0`, and fail-closed pricing cannot catch them
   (`0` is finite, so the model resolves and every call meters at $0 forever).
-  They are now dropped and fail closed loudly. Embedding entries keep their `0`
-  output rate — that is a real price, not a missing one.
-- **Duplicate upstream keys resolve to the dearer entry.** Several Gemini models
-  are listed both bare and `gemini/`-prefixed; collapsing them onto one vendored
-  key previously depended on iteration order. The refresh now keeps the more
-  expensive of the two — over-pricing stops an agent one call early (safe),
-  under-pricing lets a crossing call through.
+  They are now dropped and fail closed loudly, on either rate. The one exception
+  is an embedding's `0` output rate — that is a real price, not a missing one.
+- **Duplicate upstream keys resolve to the dearer rate in each bucket.** Several
+  Gemini models are listed both bare and `gemini/`-prefixed; collapsing them onto
+  one vendored key previously depended on iteration order. The refresh now takes
+  the higher input rate and the higher output rate independently — picking one
+  whole entry by total cost still under-meters a prompt/completion mix when one
+  duplicate is dearer on input and the other on output. Over-pricing stops an
+  agent one call early (safe), under-pricing lets a crossing call through.
 - **Realtime/audio models are no longer priced at text rates.** Upstream
   reclassified OpenAI's realtime models from `chat` to `realtime` mode, so they
   drop out of the vendored map. This closes a latent under-meter: they bill audio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ pip install -e ".[langchain]"   # LangChain adapter
 pip install -e ".[langgraph]"   # LangGraph adapter
 pip install -e ".[openai]"      # OpenAI adapter
 pip install -e ".[anthropic]"   # Anthropic adapter
+pip install -e ".[gemini]"      # Google Gemini adapter
 ```
 
 The core must keep working with **no** extras installed — CI runs the suite

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ process.
 
 Works with [CrewAI](#crewai) · [LiteLLM](#litellm) · [LangChain](#langchain) ·
 [LangGraph](#langgraph) · [OpenAI](#openai) · [Anthropic](#anthropic) ·
-[Vercel AI SDK](#vercel-ai-sdk) — or any stack, via plain `check()` / `record()`.
+[Gemini](#google-gemini) · [Vercel AI SDK](#vercel-ai-sdk) — or any stack, via
+plain `check()` / `record()`.
 The hard-stop is contract-based: gate each call through the guard — adapters do
 it for LLM calls; for paid tools, [`reserve_tool()` / `settle_tool()`](#tool-spend-under-the-same-ceiling)
 block *before* the call runs (`record_tool()` alone meters a call after the
@@ -110,20 +111,29 @@ guard = BudgetGuard(
 
 ### What the bundled map prices
 
-The vendored map deliberately covers **OpenAI, Anthropic, and a curated set of
-Groq models** (the allowlist lives in
+The vendored map deliberately covers **OpenAI, Anthropic, Google Gemini (AI
+Studio), and a curated set of Groq models** (the rules live in
 [`scripts/update-cost-map.mjs`](scripts/update-cost-map.mjs)) — not all of
 LiteLLM's upstream list. Generic open-weights names (`qwen3-32b`,
 `gpt-oss-120b`) are served by many vendors at very different prices, so
 resolving them at one vendor's rate would under-meter a spend guard; they stay
 unpriceable unless you scope them (`groq/…`) or pass a manual price.
 
+**Gemini is priced at Google AI Studio (Gemini Developer API) rates.** Vertex AI
+serves the same model ids at its own — sometimes dearer — rates, and a model id
+alone cannot say which billing path a call used, so a Vertex agent should pass
+`price_overrides` for the models it uses. Experimental Gemini tiers that Google
+lists at $0 stay unpriceable on purpose: a chat model priced at zero would meter
+every call as free, which fail-closed pricing cannot catch.
+
 Model ids resolve flexibly: provider-prefixed forms work
 (`openai/gpt-4o`, `groq/qwen/qwen3-32b` and the ChatGroq `qwen/qwen3-32b` both
-hit the same entry), and a dated snapshot the map doesn't list yet
+hit the same entry; `gemini/gemini-2.5-flash` and the bare `gemini-2.5-flash`
+do too), and a dated snapshot the map doesn't list yet
 (`claude-opus-4-8-<date>`) prices at its alias entry instead of failing closed.
-Everything else — Gemini, Mistral, Cohere, Ollama, Bedrock, self-hosted —
-needs `price_overrides` (or `fail_closed=False` to accept it un-metered).
+Everything else — Mistral, Cohere, Ollama, Bedrock, realtime/audio models,
+self-hosted — needs `price_overrides` (or `fail_closed=False` to accept it
+un-metered).
 
 ## Context-aware budgeting
 
@@ -435,6 +445,49 @@ response = guarded_completion(guard, client, model="claude-3-7-sonnet-20250219",
 Same reserve-before / record-after contract as the OpenAI adapter; Anthropic's
 `input_tokens` / `output_tokens` are mapped onto the guard's prompt/completion
 pricing. Use `guarded_acompletion` with an `AsyncAnthropic` client for async.
+
+### Google Gemini
+
+```bash
+pip install floe-guard[gemini]
+```
+
+```python
+from google import genai
+from floe_guard import BudgetGuard
+from floe_guard.integrations.gemini import guarded_completion
+
+guard = BudgetGuard(limit_usd=1.00)
+client = genai.Client(api_key="...")
+response = guarded_completion(guard, client, model="gemini-2.5-flash", contents="hello")
+```
+
+Same reserve-before / record-after contract as the OpenAI adapter. Gemini splits
+usage across five counters and this adapter maps all of them: thinking tokens
+(`thoughts_token_count`) and tool-result tokens (`tool_use_prompt_token_count`)
+are billed but sit *outside* the obvious prompt/candidates pair, so omitting them
+would under-meter; cached tokens are carved out of the prompt count (Gemini
+includes them there) and re-priced at the cheaper cache-read rate rather than
+charged twice. Use `guarded_acompletion` for async.
+
+**Vertex AI callers must supply prices.** One SDK serves both Google AI Studio
+and Vertex with *identical model ids*, but Vertex bills up to 50% more, and the
+bundled map carries AI Studio rates — so metering a Vertex call against it would
+under-meter. The model id can't reveal the backend, but the client can: the
+adapter reads `client.vertexai` and fails closed unless you pass your own rates.
+
+```python
+from floe_guard import ManualPrice
+
+guard = BudgetGuard(limit_usd=1.00, price_overrides={
+    "gemini-2.5-flash": ManualPrice(3.0e-7, 2.5e-6),   # your Vertex rates
+})
+```
+
+Streaming isn't wrapped — `generate_content_stream` only reports usage on its
+final chunk (or never, if you stop early), so use
+[`guard_stream()`](#request-sized-estimates-and-mid-stream-enforcement) to meter
+a stream chunk-by-chunk instead.
 
 ### Vercel AI SDK
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ pricing. Use `guarded_acompletion` with an `AsyncAnthropic` client for async.
 ### Google Gemini
 
 ```bash
-pip install floe-guard[gemini]
+pip install 'floe-guard[gemini]'
 ```
 
 ```python

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "ai": "^4.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -215,12 +215,6 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
-  "gemini-1.5-flash": {
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 0,
-    "litellm_provider": "gemini",
-    "mode": "embedding"
-  },
   "gemini-2.0-flash": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -215,6 +215,228 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "gemini-1.5-flash": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-2.0-flash": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-001": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-lite": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-lite-001": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-computer-use-preview-10-2025": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite-preview-06-17": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite-preview-09-2025": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-latest": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-preview-09-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-preview-12-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-preview-09-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-pro": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3-flash-preview": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3-pro-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-lite": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-live-preview": {
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-pro-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.5-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.5-flash-lite": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.6-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-embedding-001": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-embedding-2": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-embedding-2-preview": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-exp-1206": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-flash-latest": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-flash-lite-latest": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-gemma-2-27b-it": {
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.00000105,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-gemma-2-9b-it": {
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.00000105,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-omni-flash-preview": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-pro-latest": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-robotics-er-1.5-preview": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
   "gpt-3.5-turbo": {
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.0000015,
@@ -389,18 +611,6 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
-  "gpt-4o-mini-realtime-preview": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
   "gpt-4o-mini-search-preview": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
@@ -410,24 +620,6 @@
   "gpt-4o-mini-search-preview-2025-03-11": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview-2025-06-03": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
     "litellm_provider": "openai",
     "mode": "chat"
   },
@@ -648,60 +840,6 @@
     "mode": "chat"
   },
   "gpt-audio-mini-2025-12-15": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-1.5": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2.1": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2.1-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2025-08-28": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini-2025-12-15": {
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "litellm_provider": "openai",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Floe Labs" }]
-keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic"]
+keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -30,6 +30,7 @@ langchain = ["langchain-core>=0.3"]
 langgraph = ["langgraph>=1.0"]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.40"]
+gemini = ["google-genai>=1.0"]
 pipecat = ["pipecat-ai>=1.0"]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -53,6 +53,37 @@ const GROQ_KEY_MAP = new Map([
   ["groq/openai/gpt-oss-safeguard-20b", "openai/gpt-oss-safeguard-20b"],
 ]);
 
+// Providers vendored under the BARE model id, with their "<provider>/" key
+// prefix stripped (upstream keys Gemini as "gemini/gemini-2.5-flash", but the
+// google-genai SDK and @ai-sdk/google both take "gemini-2.5-flash").
+//
+// A rule rather than a Groq-style allowlist: nothing but Google ships a
+// "gemini-*" model, so there is no generic multi-vendor name to mis-claim here,
+// and hand-listing would go stale on every Google launch. The bare key also
+// serves LiteLLM's "gemini/<id>" convention through the resolver's
+// bare-last-segment fallback, so pricing.py/pricing.ts need no change (and the
+// two stay in lockstep by not moving at all).
+//
+// Vertex AI is deliberately NOT vendored. It serves the SAME model ids under the
+// "vertex_ai-*" providers at DIFFERENT prices (gemini-2.0-flash-001: Vertex is
+// 50% dearer), and a model id alone cannot say which billing path a call took —
+// pricing both from one key would under-meter Vertex users, which is the exact
+// failure a spend guard must not have. Those providers are not routable, so they
+// are already excluded; Vertex callers pass price_overrides, and the Gemini
+// adapter detects them via `client.vertexai`.
+const PREFIX_STRIPPED_PROVIDERS = new Set(["gemini"]);
+
+/** The key a model is vendored under: "gemini/gemini-2.5-flash" -> "gemini-2.5-flash". */
+function vendoredKey(k) {
+  const mapped = GROQ_KEY_MAP.get(k);
+  if (mapped !== undefined) return mapped;
+  const slash = k.indexOf("/");
+  if (slash !== -1 && PREFIX_STRIPPED_PROVIDERS.has(k.slice(0, slash))) {
+    return k.slice(slash + 1);
+  }
+  return k;
+}
+
 /**
  * A model is vendored only if we can fully price it: a numeric input rate, a
  * routable provider, and either embedding mode (input-only) or chat mode WITH a
@@ -68,9 +99,21 @@ function isUsable(k, v) {
     !!v &&
     Number.isFinite(v.input_cost_per_token) &&
     v.litellm_provider !== undefined &&
-    (ROUTABLE_PROVIDERS.has(v.litellm_provider) || GROQ_KEY_MAP.has(k)) &&
+    (ROUTABLE_PROVIDERS.has(v.litellm_provider) ||
+      PREFIX_STRIPPED_PROVIDERS.has(v.litellm_provider) ||
+      GROQ_KEY_MAP.has(k)) &&
     (v.mode === "embedding" ||
-      (v.mode === "chat" && Number.isFinite(v.output_cost_per_token)))
+      (v.mode === "chat" &&
+        Number.isFinite(v.output_cost_per_token) &&
+        // A chat model priced at 0 bills every call free, and fail-closed pricing
+        // cannot catch that: 0 is finite, so resolve_price returns a valid entry
+        // and the guard meters the call at $0 forever. Upstream ships these for
+        // free/experimental tiers (gemini-exp-1206 is listed 0/0 on one of its
+        // two keys). Dropping them makes the model unpriceable, which fails
+        // closed loudly — the behaviour a spend guard wants. Embeddings keep
+        // their 0 output rate: that is a real price, not a missing one.
+        v.input_cost_per_token > 0 &&
+        v.output_cost_per_token > 0))
   );
 }
 
@@ -82,7 +125,7 @@ const raw = await res.json();
 
 const entries = Object.entries(raw)
   .filter(([k, v]) => isUsable(k, v))
-  .map(([k, v]) => [GROQ_KEY_MAP.get(k) ?? k, v])
+  .map(([k, v]) => [vendoredKey(k), v])
   .sort(([a], [b]) => a.localeCompare(b));
 
 // A curated Groq model that upstream dropped (or stopped fully pricing) would
@@ -102,12 +145,33 @@ for (const [src, dest] of GROQ_KEY_MAP) {
 // key is stored as plain data instead of mutating the object's prototype.
 const out = Object.create(null);
 for (const [k, v] of entries) {
-  out[k] = {
+  const entry = {
     input_cost_per_token: v.input_cost_per_token,
     output_cost_per_token: v.mode === "embedding" ? 0 : v.output_cost_per_token,
     litellm_provider: v.litellm_provider,
     mode: v.mode,
   };
+  const existing = out[k];
+  if (existing === undefined) {
+    out[k] = entry;
+    continue;
+  }
+  // Two upstream keys collapsed onto one vendored key — upstream lists several
+  // Gemini models BOTH bare and "gemini/"-prefixed. Plain assignment would let
+  // the last one silently win, so resolve deterministically toward the DEARER
+  // entry: over-pricing a model stops the agent one call early (safe), while
+  // under-pricing lets a crossing call through (the failure this package
+  // exists to prevent).
+  const dearer =
+    entry.input_cost_per_token + entry.output_cost_per_token >
+    existing.input_cost_per_token + existing.output_cost_per_token
+      ? entry
+      : existing;
+  out[k] = dearer;
+  console.warn(
+    `NOTE: ${k} is listed more than once upstream — kept the dearer entry ` +
+      `(${dearer.input_cost_per_token}/${dearer.output_cost_per_token}).`,
+  );
 }
 
 const json = `${JSON.stringify(out, null, 2)}\n`;
@@ -121,5 +185,7 @@ for (const dest of targets) {
 }
 
 console.log(
-  `Wrote ${entries.length} models to ${targets.length} files (source: ${SOURCE_URL}).`,
+  // Object.keys(out), not entries.length: collapsed duplicate keys (see the
+  // collision note above) mean fewer models are vendored than entries survived.
+  `Wrote ${Object.keys(out).length} models to ${targets.length} files (source: ${SOURCE_URL}).`,
 );

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -85,14 +85,6 @@ function vendoredKey(k) {
 }
 
 /**
- * A model is vendored only if we can fully price it: a numeric input rate, a
- * routable provider, and either embedding mode (input-only) or chat mode WITH a
- * numeric output rate. Coercing a missing output rate to 0 would ship a chat
- * model that bills output free, which fail-closed pricing can't catch (0 is
- * finite). An excluded model is simply absent.
- */
-
-/**
  * Embedding mode zeroes the output rate, so trusting a WRONG `mode` ships a chat
  * model that bills output free — the precise hole fail-closed pricing cannot see.
  * Upstream does get this wrong: it lists `gemini/gemini-1.5-flash`, a chat model,
@@ -107,6 +99,14 @@ function vendoredKey(k) {
 function isEmbeddingModel(vendored, v) {
   return v.mode === "embedding" && vendored.includes("embedding");
 }
+
+/**
+ * A model is vendored only if we can fully price it: a numeric input rate, a
+ * routable provider, and either a VERIFIED embedding (input-only — see
+ * isEmbeddingModel) or chat mode with a non-zero output rate. Coercing a missing
+ * or zero output rate would ship a chat model that bills output free, which
+ * fail-closed pricing can't catch (0 is finite). An excluded model is simply absent.
+ */
 function isUsable(k, v) {
   // Number.isFinite (not typeof === "number") so a NaN, or a huge upstream value
   // that JSON.parse turns into Infinity, is treated as unpriceable and dropped —

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -84,6 +84,14 @@ function vendoredKey(k) {
   return k;
 }
 
+// Embedding families vendored under a zeroed output rate. Matched as an id
+// PREFIX, not a substring: `includes("embedding")` would also accept a chat model
+// named e.g. "foo-embedding-chat", re-opening the very hole this list closes.
+// Covers every embedding entry the map ships today (text-embedding-3-*,
+// text-embedding-ada-*, gemini-embedding-*); a new family is dropped, and warned
+// about, until it is added here.
+const EMBEDDING_ID_PREFIXES = ["text-embedding-", "gemini-embedding-"];
+
 /**
  * Embedding mode zeroes the output rate, so trusting a WRONG `mode` ships a chat
  * model that bills output free — the precise hole fail-closed pricing cannot see.
@@ -91,21 +99,41 @@ function vendoredKey(k) {
  * as `mode: "embedding"` with `output_cost_per_token: 0`.
  *
  * So `mode` alone is not enough authority to zero a price. Require the model id to
- * agree with it: a genuine embedding model says so in its name (`text-embedding-*`,
- * `gemini-embedding-*`). A single wrong field then can't produce a free-output chat
- * model, and an embedding whose name doesn't match simply fails closed — the safe
- * direction.
+ * agree with it, by matching a known embedding family (see EMBEDDING_ID_PREFIXES).
+ * A single wrong field then can't produce a free-output chat model, and an
+ * embedding whose name doesn't match simply fails closed — the safe direction.
  */
 function isEmbeddingModel(vendored, v) {
-  return v.mode === "embedding" && vendored.includes("embedding");
+  return (
+    v.mode === "embedding" &&
+    EMBEDDING_ID_PREFIXES.some((prefix) => vendored.startsWith(prefix))
+  );
+}
+
+/** Whether floe-guard prices this provider at all — see the three sets above. */
+function isPricedProvider(k, v) {
+  return (
+    v.litellm_provider !== undefined &&
+    (ROUTABLE_PROVIDERS.has(v.litellm_provider) ||
+      PREFIX_STRIPPED_PROVIDERS.has(v.litellm_provider) ||
+      GROQ_KEY_MAP.has(k))
+  );
 }
 
 /**
- * A model is vendored only if we can fully price it: a numeric input rate, a
+ * A model is vendored only if we can fully price it: a positive input rate, a
  * routable provider, and either a VERIFIED embedding (input-only — see
  * isEmbeddingModel) or chat mode with a non-zero output rate. Coercing a missing
  * or zero output rate would ship a chat model that bills output free, which
  * fail-closed pricing can't catch (0 is finite). An excluded model is simply absent.
+ *
+ * A rate of 0 bills every call free, and fail-closed pricing cannot catch that:
+ * 0 is finite, so resolve_price returns a valid entry and the guard meters the
+ * call at $0 forever. Upstream ships these for free/experimental tiers
+ * (gemini-exp-1206 is listed 0/0 on one of its two keys). Dropping them makes the
+ * model unpriceable, which fails closed loudly — the behaviour a spend guard
+ * wants. The one exception is an embedding's 0 OUTPUT rate: that is a real price,
+ * not a missing one.
  */
 function isUsable(k, v) {
   // Number.isFinite (not typeof === "number") so a NaN, or a huge upstream value
@@ -114,21 +142,11 @@ function isUsable(k, v) {
   return (
     !!v &&
     Number.isFinite(v.input_cost_per_token) &&
-    v.litellm_provider !== undefined &&
-    (ROUTABLE_PROVIDERS.has(v.litellm_provider) ||
-      PREFIX_STRIPPED_PROVIDERS.has(v.litellm_provider) ||
-      GROQ_KEY_MAP.has(k)) &&
+    v.input_cost_per_token > 0 &&
+    isPricedProvider(k, v) &&
     (isEmbeddingModel(vendoredKey(k), v) ||
       (v.mode === "chat" &&
         Number.isFinite(v.output_cost_per_token) &&
-        // A chat model priced at 0 bills every call free, and fail-closed pricing
-        // cannot catch that: 0 is finite, so resolve_price returns a valid entry
-        // and the guard meters the call at $0 forever. Upstream ships these for
-        // free/experimental tiers (gemini-exp-1206 is listed 0/0 on one of its
-        // two keys). Dropping them makes the model unpriceable, which fails
-        // closed loudly — the behaviour a spend guard wants. Embeddings keep
-        // their 0 output rate: that is a real price, not a missing one.
-        v.input_cost_per_token > 0 &&
         v.output_cost_per_token > 0))
   );
 }
@@ -157,6 +175,25 @@ for (const [src, dest] of GROQ_KEY_MAP) {
   }
 }
 
+// The other half of EMBEDDING_ID_PREFIXES: a genuine embedding model from a
+// priced provider whose id doesn't match a known family is dropped (fail-closed,
+// the safe direction) — but silently, so a new Google/OpenAI embedding line would
+// just never appear. Warn so the reviewer knows to extend the prefix list.
+for (const [k, v] of Object.entries(raw)) {
+  const key = vendoredKey(k);
+  if (
+    v?.mode === "embedding" &&
+    isPricedProvider(k, v) &&
+    !isEmbeddingModel(key, v)
+  ) {
+    console.warn(
+      `WARNING: ${k} declares mode="embedding" but ${key} matches no known embedding ` +
+        `family — dropped. Expected when upstream mislabels a chat model; if it ` +
+        `really is an embedding, add its family to EMBEDDING_ID_PREFIXES.`,
+    );
+  }
+}
+
 // null-prototype: model keys come from remote JSON, so a "__proto__" (or similar)
 // key is stored as plain data instead of mutating the object's prototype.
 const out = Object.create(null);
@@ -177,10 +214,12 @@ for (const [k, v] of entries) {
   }
   // Two upstream keys collapsed onto one vendored key — upstream lists several
   // Gemini models BOTH bare and "gemini/"-prefixed. Plain assignment would let
-  // the last one silently win, so resolve deterministically toward the DEARER
-  // entry: over-pricing a model stops the agent one call early (safe), while
-  // under-pricing lets a crossing call through (the failure this package
-  // exists to prevent).
+  // the last one silently win, so resolve deterministically toward the dearer
+  // rate PER BUCKET: picking one whole entry by total cost still under-meters a
+  // prompt/completion mix whenever one duplicate has the higher input rate and
+  // the other the higher output rate. Over-pricing stops the agent one call
+  // early (safe); under-pricing lets a crossing call through (the failure this
+  // package exists to prevent).
   const input_cost_per_token = Math.max(
     existing.input_cost_per_token,
     entry.input_cost_per_token,
@@ -189,16 +228,19 @@ for (const [k, v] of entries) {
     existing.output_cost_per_token,
     entry.output_cost_per_token,
   );
-  const dearer = {
-    ...existing,
+  const merged = {
     input_cost_per_token,
     output_cost_per_token,
+    litellm_provider: existing.litellm_provider,
+    // Both sides already passed isUsable, so a 0 output rate here means both were
+    // VERIFIED embeddings. Anything else took a chat rate on at least one bucket
+    // and must not keep a mode that reads as "output is free".
     mode: output_cost_per_token === 0 ? "embedding" : "chat",
   };
-  out[k] = dearer;
+  out[k] = merged;
   console.warn(
-    `NOTE: ${k} is listed more than once upstream — kept conservative max rates ` +
-      `(${dearer.input_cost_per_token}/${dearer.output_cost_per_token}).`,
+    `NOTE: ${k} is listed more than once upstream — kept the dearer rate in each ` +
+      `bucket (${input_cost_per_token}/${output_cost_per_token}).`,
   );
 }
 

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -181,14 +181,23 @@ for (const [k, v] of entries) {
   // entry: over-pricing a model stops the agent one call early (safe), while
   // under-pricing lets a crossing call through (the failure this package
   // exists to prevent).
-  const dearer =
-    entry.input_cost_per_token + entry.output_cost_per_token >
-    existing.input_cost_per_token + existing.output_cost_per_token
-      ? entry
-      : existing;
+  const input_cost_per_token = Math.max(
+    existing.input_cost_per_token,
+    entry.input_cost_per_token,
+  );
+  const output_cost_per_token = Math.max(
+    existing.output_cost_per_token,
+    entry.output_cost_per_token,
+  );
+  const dearer = {
+    ...existing,
+    input_cost_per_token,
+    output_cost_per_token,
+    mode: output_cost_per_token === 0 ? "embedding" : "chat",
+  };
   out[k] = dearer;
   console.warn(
-    `NOTE: ${k} is listed more than once upstream — kept the dearer entry ` +
+    `NOTE: ${k} is listed more than once upstream — kept conservative max rates ` +
       `(${dearer.input_cost_per_token}/${dearer.output_cost_per_token}).`,
   );
 }

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -91,6 +91,22 @@ function vendoredKey(k) {
  * model that bills output free, which fail-closed pricing can't catch (0 is
  * finite). An excluded model is simply absent.
  */
+
+/**
+ * Embedding mode zeroes the output rate, so trusting a WRONG `mode` ships a chat
+ * model that bills output free — the precise hole fail-closed pricing cannot see.
+ * Upstream does get this wrong: it lists `gemini/gemini-1.5-flash`, a chat model,
+ * as `mode: "embedding"` with `output_cost_per_token: 0`.
+ *
+ * So `mode` alone is not enough authority to zero a price. Require the model id to
+ * agree with it: a genuine embedding model says so in its name (`text-embedding-*`,
+ * `gemini-embedding-*`). A single wrong field then can't produce a free-output chat
+ * model, and an embedding whose name doesn't match simply fails closed — the safe
+ * direction.
+ */
+function isEmbeddingModel(vendored, v) {
+  return v.mode === "embedding" && vendored.includes("embedding");
+}
 function isUsable(k, v) {
   // Number.isFinite (not typeof === "number") so a NaN, or a huge upstream value
   // that JSON.parse turns into Infinity, is treated as unpriceable and dropped —
@@ -102,7 +118,7 @@ function isUsable(k, v) {
     (ROUTABLE_PROVIDERS.has(v.litellm_provider) ||
       PREFIX_STRIPPED_PROVIDERS.has(v.litellm_provider) ||
       GROQ_KEY_MAP.has(k)) &&
-    (v.mode === "embedding" ||
+    (isEmbeddingModel(vendoredKey(k), v) ||
       (v.mode === "chat" &&
         Number.isFinite(v.output_cost_per_token) &&
         // A chat model priced at 0 bills every call free, and fail-closed pricing
@@ -147,7 +163,10 @@ const out = Object.create(null);
 for (const [k, v] of entries) {
   const entry = {
     input_cost_per_token: v.input_cost_per_token,
-    output_cost_per_token: v.mode === "embedding" ? 0 : v.output_cost_per_token,
+    // Same predicate as the filter — `k` is already the vendored key here. Zeroing
+    // on raw `v.mode` would re-introduce the free-output hole for any entry whose
+    // declared mode and id disagree.
+    output_cost_per_token: isEmbeddingModel(k, v) ? 0 : v.output_cost_per_token,
     litellm_provider: v.litellm_provider,
     mode: v.mode,
   };

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -28,7 +28,7 @@ from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.7.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.8.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -215,12 +215,6 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
-  "gemini-1.5-flash": {
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 0,
-    "litellm_provider": "gemini",
-    "mode": "embedding"
-  },
   "gemini-2.0-flash": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -215,6 +215,228 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "gemini-1.5-flash": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-2.0-flash": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-001": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-lite": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.0-flash-lite-001": {
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-computer-use-preview-10-2025": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite-preview-06-17": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-lite-preview-09-2025": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-latest": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-preview-09-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-native-audio-preview-12-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-flash-preview-09-2025": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-pro": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3-flash-preview": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3-pro-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-lite": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-flash-live-preview": {
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-pro-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.5-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.5-flash-lite": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-3.6-flash": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-embedding-001": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-embedding-2": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-embedding-2-preview": {
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "litellm_provider": "gemini",
+    "mode": "embedding"
+  },
+  "gemini-exp-1206": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-flash-latest": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-flash-lite-latest": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-gemma-2-27b-it": {
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.00000105,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-gemma-2-9b-it": {
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.00000105,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-omni-flash-preview": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-pro-latest": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
+  "gemini-robotics-er-1.5-preview": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "litellm_provider": "gemini",
+    "mode": "chat"
+  },
   "gpt-3.5-turbo": {
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.0000015,
@@ -389,18 +611,6 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
-  "gpt-4o-mini-realtime-preview": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
   "gpt-4o-mini-search-preview": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
@@ -410,24 +620,6 @@
   "gpt-4o-mini-search-preview-2025-03-11": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview-2024-12-17": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-4o-realtime-preview-2025-06-03": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
     "litellm_provider": "openai",
     "mode": "chat"
   },
@@ -648,60 +840,6 @@
     "mode": "chat"
   },
   "gpt-audio-mini-2025-12-15": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-1.5": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2.1": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2.1-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-2025-08-28": {
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "litellm_provider": "openai",
-    "mode": "chat"
-  },
-  "gpt-realtime-mini-2025-12-15": {
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "litellm_provider": "openai",

--- a/src/floe_guard/integrations/gemini.py
+++ b/src/floe_guard/integrations/gemini.py
@@ -1,0 +1,225 @@
+"""Google Gemini adapter (optional extra: ``pip install floe-guard[gemini]``).
+
+:func:`guarded_completion` / :func:`guarded_acompletion` wrap a call to the
+``google-genai`` SDK's ``client.models.generate_content`` with a pre-call budget
+reservation and post-call accrual. This is the **guaranteed** enforcement path:
+the guard reserves the call's budget before the request, so a blocked call never
+reaches Google.
+
+Like the OpenAI and Anthropic adapters there is no callback variant — the SDK has
+no global hook, so wrapping the call site is the enforcement surface. The contract
+matches them exactly: ``reserve()`` before the call, ``settle(model,
+prompt_tokens, completion_tokens, reserved=...)`` after, ``release()`` on
+exception. Reserving before the await lets parallel calls each hold their own
+slice of the ceiling (issue #18).
+
+**Which Google backend you are on matters.** One SDK serves both Google AI Studio
+(the Gemini Developer API) and Vertex AI, and the *model id is identical on both*
+— but they bill at different rates (``gemini-2.0-flash-001`` costs 50% more on
+Vertex). The bundled cost map carries AI Studio prices only, so metering a Vertex
+call against it would under-meter, which is the one failure mode this package
+exists to prevent. The model id cannot reveal the billing path, but the *client*
+can: ``client.vertexai`` is ``True`` for Vertex. This adapter reads it and
+refuses (fail-closed, per the guard's policy) unless you have supplied a price
+for the model yourself::
+
+    guard = BudgetGuard(limit_usd=1.00, price_overrides={
+        "gemini-2.5-flash": ManualPrice(3.0e-7, 2.5e-6),   # your Vertex rates
+    })
+
+Read ``client.vertexai`` rather than the constructor argument: BOTH
+``Client(vertexai=True, ...)`` and the newer ``Client(enterprise=True, ...)`` set
+it, and there is no ``.enterprise`` attribute to check instead.
+
+**Token buckets.** Gemini splits usage across five counters, and the SDK's own
+field docs pin down how they compose (``total_token_count`` is documented as
+``prompt + candidates + tool_use_prompt + thoughts``):
+
+- ``prompt_token_count`` — input, and it *includes* cached tokens when a cached
+  context is used, so the cached share is subtracted out and re-priced at the
+  cheaper cache-read rate rather than being charged twice.
+- ``tool_use_prompt_token_count`` — results fed back from tool executions. Input,
+  and NOT part of ``prompt_token_count``; dropping it would under-meter a
+  tool-using agent.
+- ``candidates_token_count`` — the generated output.
+- ``thoughts_token_count`` — thinking-model reasoning. Billed as output and NOT
+  part of ``candidates_token_count``; dropping it would under-meter every
+  thinking model.
+
+**Streaming is not wrapped.** ``generate_content_stream`` returns a generator
+whose usage only arrives on the final chunk (or never, if the consumer stops
+early), so a reserve/settle wrapper around it would hand back an unmetered stream
+and leak its reservation. Meter a stream with
+:func:`~floe_guard.guard_stream` instead, which prices it chunk-by-chunk and can
+hard-stop mid-generation.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from ..errors import UnpriceableModelError, UnpriceableModelWarning
+from ..guard import BudgetGuard
+from ..pricing import resolve_price
+
+
+def _model_from(kwargs: dict[str, Any], response: Any) -> str:
+    # Prefer the model the response was actually served by — Gemini reports a
+    # resolved id in ``model_version`` that can differ from the requested alias —
+    # and fall back to the request's model= only when the response omits it.
+    model = getattr(response, "model_version", None)
+    if model is None and isinstance(response, dict):
+        model = response.get("model_version")
+    if not model:
+        model = kwargs.get("model")
+    return str(model or "")
+
+
+def _usage_from(response: Any) -> tuple[int, int, int]:
+    """Map a Gemini response's usage onto ``(prompt, completion, cache_read)``.
+
+    See the module docstring for why each bucket lands where it does; in short,
+    cached tokens are carved out of the prompt count (they are included there and
+    bill cheaper), tool-use tokens are added to it (they are not included), and
+    thinking tokens are added to the output count (they are not included either).
+    """
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage_metadata")
+    if usage is None:
+        return 0, 0, 0
+    # ``or 0`` because Gemini leaves an inapplicable bucket unset (None) rather
+    # than reporting a zero.
+    get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
+    prompt = int(get("prompt_token_count", 0) or 0)
+    cached = int(get("cached_content_token_count", 0) or 0)
+    tool_use = int(get("tool_use_prompt_token_count", 0) or 0)
+    completion = int(get("candidates_token_count", 0) or 0) + int(
+        get("thoughts_token_count", 0) or 0
+    )
+    # max(0, …): the cached share is documented as part of prompt_token_count, but
+    # clamp so a malformed pair can never produce a negative input count that
+    # would eat into the tool-use tokens added alongside it.
+    return max(0, prompt - cached) + tool_use, completion, cached
+
+
+def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> str:
+    """Pick the model id to settle against.
+
+    The served id (``model_version``) is the source of truth, but if it cannot be
+    priced and the requested alias can, settle on the alias instead — so a
+    provider snapshot newer than the bundled cost map does not fail-close a call
+    that would otherwise price cleanly. If neither prices, keep the served id so
+    the guard still fail-closes on a real id. (Mirrors the OpenAI adapter.)
+    """
+    served = _model_from(kwargs, response)
+    requested = str(kwargs.get("model") or "")
+    if (
+        served
+        and requested
+        and served != requested
+        and resolve_price(served, guard.price_overrides) is None
+        and resolve_price(requested, guard.price_overrides) is not None
+    ):
+        return requested
+    return served
+
+
+def _check_vertex_pricing(guard: BudgetGuard, client: Any, model: str) -> None:
+    """Refuse a Vertex call the bundled (AI Studio) prices would under-meter.
+
+    Runs BEFORE the reservation, so a refused call never reaches Google and never
+    holds budget. A caller-supplied price wins outright — that is the documented
+    way to meter Vertex — so an override for this model clears the check. Honours
+    ``guard.fail_closed``: warn-and-continue when the caller has explicitly opted
+    into un-enforced spend.
+    """
+    if not getattr(client, "vertexai", False):
+        return
+    priced = resolve_price(model, guard.price_overrides)
+    if priced is not None and priced.source == "override":
+        return
+    warnings.warn(
+        f"Client is configured for Vertex AI, but the bundled cost map prices "
+        f"{model!r} at Google AI Studio rates. Vertex bills the same model ids "
+        f"differently (up to 50% more), so metering this call against the map "
+        f"would under-meter it — and a budget guard that under-meters cannot hold "
+        f"a ceiling. Pass your Vertex rates via price_overrides="
+        f"{{{model!r}: ManualPrice(input, output)}} to enforce this call.",
+        UnpriceableModelWarning,
+        stacklevel=3,
+    )
+    if guard.fail_closed:
+        raise UnpriceableModelError(model)
+
+
+def _record_response(
+    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
+) -> None:
+    if not isinstance(kwargs, dict):
+        kwargs = {}
+    model = _settle_model(guard, kwargs, response)
+    prompt_tokens, completion_tokens, cache_read = _usage_from(response)
+    if prompt_tokens <= 0 and completion_tokens <= 0 and cache_read <= 0:
+        # No tokens spent (e.g. a usage-less response) — free the reservation.
+        guard.release(reserved)
+        return
+    # There IS spend to account for. Route it through settle() even when the model
+    # id is missing, so the guard's policy applies (fail-closed → warn + raise;
+    # fail-open → warn + skip) rather than letting a completed call go unmetered
+    # and skew the next check().
+    guard.settle(
+        model,
+        prompt_tokens,
+        completion_tokens,
+        reserved=reserved,
+        cache_read_input_tokens=cache_read,
+    )
+
+
+def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """``client.models.generate_content`` with a budget reservation and accrual.
+
+    Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget would
+    be crossed — the request never reaches Google.
+
+    ``client`` is a ``google.genai.Client``; ``kwargs`` are forwarded to
+    ``models.generate_content`` (e.g. ``model=``, ``contents=``, ``config=``).
+
+    A Vertex-configured client raises :class:`~floe_guard.UnpriceableModelError`
+    unless the model has a ``price_overrides`` entry — see the module docstring.
+    Streaming is not supported here; use :func:`~floe_guard.guard_stream`.
+    """
+    _check_vertex_pricing(guard, client, str(kwargs.get("model") or ""))
+    reserved = guard.reserve()
+    try:
+        response = client.models.generate_content(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
+    """Async counterpart of :func:`guarded_completion`.
+
+    Calls ``client.aio.models.generate_content`` — the async face of the same
+    ``google.genai.Client``, so pass the client itself, not ``client.aio``.
+    """
+    _check_vertex_pricing(guard, client, str(kwargs.get("model") or ""))
+    reserved = guard.reserve()
+    try:
+        response = await client.aio.models.generate_content(**kwargs)
+    except BaseException:
+        guard.release(reserved)
+        raise
+    _record_response(guard, kwargs, response, reserved=reserved)
+    return response
+
+
+__all__ = [
+    "guarded_completion",
+    "guarded_acompletion",
+]

--- a/src/floe_guard/integrations/gemini.py
+++ b/src/floe_guard/integrations/gemini.py
@@ -31,6 +31,12 @@ Read ``client.vertexai`` rather than the constructor argument: BOTH
 ``Client(vertexai=True, ...)`` and the newer ``Client(enterprise=True, ...)`` set
 it, and there is no ``.enterprise`` attribute to check instead.
 
+On a Vertex client the override is also the *only* price accepted at settle time.
+Gemini can report a served id (``model_version``) different from the one you
+asked for, and if the bundled map happens to price that snapshot, settling on it
+would silently drop the call back to AI Studio rates — the under-meter the check
+above exists to prevent.
+
 **Token buckets.** Gemini splits usage across five counters, and the SDK's own
 field docs pin down how they compose (``total_token_count`` is documented as
 ``prompt + candidates + tool_use_prompt + thoughts``):
@@ -104,7 +110,9 @@ def _usage_from(response: Any) -> tuple[int, int, int]:
     return max(0, prompt - cached) + tool_use, completion, cached
 
 
-def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> str:
+def _settle_model(
+    guard: BudgetGuard, kwargs: dict[str, Any], response: Any, *, overrides_only: bool = False
+) -> str:
     """Pick the model id to settle against.
 
     The served id (``model_version``) is the source of truth, but if it cannot be
@@ -112,16 +120,21 @@ def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> 
     provider snapshot newer than the bundled cost map does not fail-close a call
     that would otherwise price cleanly. If neither prices, keep the served id so
     the guard still fail-closes on a real id. (Mirrors the OpenAI adapter.)
+
+    ``overrides_only`` narrows "priceable" to a caller-supplied rate, for a Vertex
+    client that :func:`_check_vertex_pricing` cleared. The bundled map holds AI
+    Studio rates, so a served snapshot the override does not name would otherwise
+    settle against them — under-metering the very call the override was there to
+    meter, and doing it silently because the map does resolve.
     """
+
+    def priced(model: str) -> bool:
+        entry = resolve_price(model, guard.price_overrides)
+        return entry is not None and (not overrides_only or entry.source == "override")
+
     served = _model_from(kwargs, response)
     requested = str(kwargs.get("model") or "")
-    if (
-        served
-        and requested
-        and served != requested
-        and resolve_price(served, guard.price_overrides) is None
-        and resolve_price(requested, guard.price_overrides) is not None
-    ):
+    if served and requested and served != requested and not priced(served) and priced(requested):
         return requested
     return served
 
@@ -155,11 +168,16 @@ def _check_vertex_pricing(guard: BudgetGuard, client: Any, model: str) -> None:
 
 
 def _record_response(
-    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
+    guard: BudgetGuard,
+    kwargs: Any,
+    response: Any,
+    *,
+    reserved: float = 0.0,
+    overrides_only: bool = False,
 ) -> None:
     if not isinstance(kwargs, dict):
         kwargs = {}
-    model = _settle_model(guard, kwargs, response)
+    model = _settle_model(guard, kwargs, response, overrides_only=overrides_only)
     prompt_tokens, completion_tokens, cache_read = _usage_from(response)
     if prompt_tokens <= 0 and completion_tokens <= 0 and cache_read <= 0:
         # No tokens spent (e.g. a usage-less response) — free the reservation.
@@ -191,6 +209,7 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     unless the model has a ``price_overrides`` entry — see the module docstring.
     Streaming is not supported here; use :func:`~floe_guard.guard_stream`.
     """
+    vertex = bool(getattr(client, "vertexai", False))
     _check_vertex_pricing(guard, client, str(kwargs.get("model") or ""))
     reserved = guard.reserve()
     try:
@@ -198,7 +217,7 @@ def guarded_completion(guard: BudgetGuard, client: Any, **kwargs: Any) -> Any:
     except BaseException:
         guard.release(reserved)
         raise
-    _record_response(guard, kwargs, response, reserved=reserved)
+    _record_response(guard, kwargs, response, reserved=reserved, overrides_only=vertex)
     return response
 
 
@@ -208,6 +227,7 @@ async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) ->
     Calls ``client.aio.models.generate_content`` — the async face of the same
     ``google.genai.Client``, so pass the client itself, not ``client.aio``.
     """
+    vertex = bool(getattr(client, "vertexai", False))
     _check_vertex_pricing(guard, client, str(kwargs.get("model") or ""))
     reserved = guard.reserve()
     try:
@@ -215,7 +235,7 @@ async def guarded_acompletion(guard: BudgetGuard, client: Any, **kwargs: Any) ->
     except BaseException:
         guard.release(reserved)
         raise
-    _record_response(guard, kwargs, response, reserved=reserved)
+    _record_response(guard, kwargs, response, reserved=reserved, overrides_only=vertex)
     return response
 
 

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -19,6 +19,7 @@ from floe_guard import (
     ManualPrice,
     UnpriceableModelError,
     UnpriceableModelWarning,
+    resolve_price,
 )
 from floe_guard.integrations.gemini import (
     _settle_model,
@@ -253,7 +254,21 @@ def test_served_id_wins_when_it_prices() -> None:
     assert _settle_model(guard, {"model": MODEL}, response) == "gemini-2.0-flash"
 
 
-# ── Vertex refusal ────────────────────────────────────────────────────────────
+def test_vertex_settles_on_the_overridden_alias_not_a_map_priced_served_id() -> None:
+    # A Vertex client is cleared by an override on the REQUESTED id. If Google
+    # serves a different snapshot that the bundled map happens to price, settling
+    # on it would meter a Vertex call at AI Studio rates — silently, because the
+    # map resolves. Only the caller's rate counts as priceable on that path.
+    guard = _guard()
+    served = "gemini-2.5-flash-lite"  # priced in the bundled map, not overridden
+    assert resolve_price(served) is not None, "fixture assumes the map prices this id"
+
+    response = _Response(model_version=served)
+    assert _settle_model(guard, {"model": MODEL}, response) == served
+    assert _settle_model(guard, {"model": MODEL}, response, overrides_only=True) == MODEL
+
+
+# ── Vertex refusal & metering ─────────────────────────────────────────────────
 
 
 def test_vertex_client_fails_closed_before_the_call() -> None:
@@ -295,6 +310,23 @@ def test_vertex_client_warns_and_proceeds_when_fail_open() -> None:
     with pytest.warns(UnpriceableModelWarning, match="Vertex"):
         guarded_completion(guard, client, model=MODEL, contents="hi")
     assert client.models.calls  # the call ran
+
+
+def test_vertex_call_meters_against_the_caller_rate_when_served_id_drifts() -> None:
+    # End-to-end counterpart of the _settle_model case above: the override's
+    # 1e-6/2e-6 must win over the bundled (cheaper) gemini-2.5-flash-lite rate.
+    guard = _guard()
+    client = _Client(
+        _Response(
+            model_version="gemini-2.5-flash-lite",
+            usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500),
+        ),
+        vertexai=True,
+    )
+
+    guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert guard.spent_usd == pytest.approx(0.002)
+    assert guard.spend_log[0].model_or_tool == MODEL
 
 
 def test_ai_studio_client_is_not_refused() -> None:

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -164,9 +164,7 @@ def test_usage_reads_a_plain_dict_response() -> None:
 
 def test_records_spend_and_returns_response() -> None:
     guard = _guard()
-    response = _Response(
-        usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)
-    )
+    response = _Response(usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500))
     client = _Client(response)
 
     assert guarded_completion(guard, client, model=MODEL, contents="hi") is response

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,310 @@
+"""Gemini adapter tests that need no ``google-genai`` install.
+
+The SDK's client/response shapes are duck-typed with dataclasses, so the
+reservation/accrual contract — the hard-stop (a blocked call never reaches the
+client), the five-bucket token mapping, and the Vertex refusal — is covered even
+in CI without the optional extra.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    ManualPrice,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+from floe_guard.integrations.gemini import (
+    _settle_model,
+    _usage_from,
+    guarded_acompletion,
+    guarded_completion,
+)
+
+MODEL = "gemini-2.5-flash"
+PRICE = ManualPrice(1e-6, 2e-6)
+
+
+@dataclass
+class _Usage:
+    prompt_token_count: int = 0
+    candidates_token_count: int = 0
+    cached_content_token_count: int | None = None
+    thoughts_token_count: int | None = None
+    tool_use_prompt_token_count: int | None = None
+
+
+@dataclass
+class _Response:
+    model_version: str = MODEL
+    usage_metadata: _Usage | None = field(default_factory=_Usage)
+
+
+class _Models:
+    """Stands in for ``client.models`` / ``client.aio.models``."""
+
+    def __init__(self, response: object = None, raises: BaseException | None = None) -> None:
+        self._response = response
+        self._raises = raises
+        self.calls: list[dict] = []
+
+    def generate_content(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+class _AsyncModels(_Models):
+    async def generate_content(self, **kwargs):  # type: ignore[override]
+        return super().generate_content(**kwargs)
+
+
+class _Aio:
+    def __init__(self, models: _Models) -> None:
+        self.models = models
+
+
+class _Client:
+    """Stands in for ``google.genai.Client``."""
+
+    def __init__(
+        self,
+        response: object = None,
+        *,
+        vertexai: bool = False,
+        raises: BaseException | None = None,
+        is_async: bool = False,
+    ) -> None:
+        self.vertexai = vertexai
+        models = (_AsyncModels if is_async else _Models)(response, raises)
+        self.models = models
+        self.aio = _Aio(models)
+
+
+def _guard(limit: float = 1.0, **kw) -> BudgetGuard:
+    kw.setdefault("price_overrides", {MODEL: PRICE})
+    return BudgetGuard(limit_usd=limit, **kw)
+
+
+# ── token bucket mapping ──────────────────────────────────────────────────────
+
+
+def test_usage_maps_plain_prompt_and_candidates() -> None:
+    prompt, completion, cached = _usage_from(
+        _Response(usage_metadata=_Usage(prompt_token_count=100, candidates_token_count=40))
+    )
+    assert (prompt, completion, cached) == (100, 40, 0)
+
+
+def test_thinking_tokens_count_as_output() -> None:
+    # thoughts_token_count is billed as output and is NOT part of
+    # candidates_token_count — dropping it would under-meter every thinking model.
+    prompt, completion, _ = _usage_from(
+        _Response(
+            usage_metadata=_Usage(
+                prompt_token_count=100, candidates_token_count=40, thoughts_token_count=250
+            )
+        )
+    )
+    assert (prompt, completion) == (100, 290)
+
+
+def test_tool_use_tokens_count_as_input() -> None:
+    # tool_use_prompt_token_count is input and is NOT part of prompt_token_count
+    # (the SDK documents total = prompt + candidates + tool_use + thoughts).
+    prompt, completion, _ = _usage_from(
+        _Response(
+            usage_metadata=_Usage(
+                prompt_token_count=100, candidates_token_count=40, tool_use_prompt_token_count=30
+            )
+        )
+    )
+    assert (prompt, completion) == (130, 40)
+
+
+def test_cached_tokens_are_carved_out_of_the_prompt_not_added() -> None:
+    # prompt_token_count INCLUDES cached tokens, so the cached share is subtracted
+    # and re-priced at the cheaper cache-read rate. Charging both would bill the
+    # cached tokens twice.
+    prompt, _, cached = _usage_from(
+        _Response(
+            usage_metadata=_Usage(
+                prompt_token_count=1000,
+                candidates_token_count=40,
+                cached_content_token_count=800,
+            )
+        )
+    )
+    assert (prompt, cached) == (200, 800)
+
+
+def test_unset_buckets_are_treated_as_zero() -> None:
+    # Gemini leaves inapplicable buckets as None rather than 0.
+    assert _usage_from(_Response(usage_metadata=_Usage(prompt_token_count=10))) == (10, 0, 0)
+    assert _usage_from(_Response(usage_metadata=None)) == (0, 0, 0)
+
+
+def test_usage_reads_a_plain_dict_response() -> None:
+    response = {
+        "model_version": MODEL,
+        "usage_metadata": {"prompt_token_count": 10, "candidates_token_count": 5},
+    }
+    assert _usage_from(response) == (10, 5, 0)
+
+
+# ── reserve / settle contract ─────────────────────────────────────────────────
+
+
+def test_records_spend_and_returns_response() -> None:
+    guard = _guard()
+    response = _Response(
+        usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)
+    )
+    client = _Client(response)
+
+    assert guarded_completion(guard, client, model=MODEL, contents="hi") is response
+    # 1000 * 1e-6 + 500 * 2e-6
+    assert guard.spent_usd == pytest.approx(0.002)
+    assert guard.remaining_usd == pytest.approx(0.998)
+    assert len(guard.spend_log) == 1
+
+
+def test_cached_tokens_are_priced_at_the_cache_read_rate() -> None:
+    guard = _guard()
+    client = _Client(
+        _Response(
+            usage_metadata=_Usage(
+                prompt_token_count=1000,
+                candidates_token_count=0,
+                cached_content_token_count=800,
+            )
+        )
+    )
+    guarded_completion(guard, client, model=MODEL, contents="hi")
+    # 200 fresh input at 1e-6, plus 800 cached at 0.1x — NOT 1000 at full rate.
+    assert guard.spent_usd == pytest.approx(200 * 1e-6 + 800 * 1e-6 * 0.10)
+
+
+def test_blocked_call_never_reaches_the_client() -> None:
+    guard = _guard(limit=0.0)
+    client = _Client(_Response())
+
+    with pytest.raises(BudgetExceeded):
+        guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert client.models.calls == []
+
+
+def test_exception_releases_the_reservation() -> None:
+    guard = _guard()
+    client = _Client(raises=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError):
+        guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert guard.spent_usd == 0.0
+    assert guard.remaining_usd == pytest.approx(1.0)  # no leaked hold
+
+
+def test_usageless_response_releases_the_reservation() -> None:
+    guard = _guard()
+    client = _Client(_Response(usage_metadata=None))
+
+    guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert guard.spent_usd == 0.0
+    assert guard.remaining_usd == pytest.approx(1.0)
+
+
+def test_async_records_spend() -> None:
+    guard = _guard()
+    client = _Client(
+        _Response(usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)),
+        is_async=True,
+    )
+
+    asyncio.run(guarded_acompletion(guard, client, model=MODEL, contents="hi"))
+    assert guard.spent_usd == pytest.approx(0.002)
+
+
+def test_async_blocked_call_never_reaches_the_client() -> None:
+    guard = _guard(limit=0.0)
+    client = _Client(_Response(), is_async=True)
+
+    with pytest.raises(BudgetExceeded):
+        asyncio.run(guarded_acompletion(guard, client, model=MODEL, contents="hi"))
+    assert client.models.calls == []
+
+
+# ── served vs requested model ─────────────────────────────────────────────────
+
+
+def test_unpriceable_served_id_falls_back_to_the_priceable_request_alias() -> None:
+    guard = _guard()
+    response = _Response(model_version="gemini-2.5-flash-brand-new-snapshot")
+    assert _settle_model(guard, {"model": MODEL}, response) == MODEL
+
+
+def test_served_id_wins_when_it_prices() -> None:
+    guard = BudgetGuard(limit_usd=1.0, price_overrides={"gemini-2.0-flash": PRICE, MODEL: PRICE})
+    response = _Response(model_version="gemini-2.0-flash")
+    assert _settle_model(guard, {"model": MODEL}, response) == "gemini-2.0-flash"
+
+
+# ── Vertex refusal ────────────────────────────────────────────────────────────
+
+
+def test_vertex_client_fails_closed_before_the_call() -> None:
+    # The map prices AI Studio rates; Vertex bills the same ids differently, so a
+    # Vertex call without an explicit price would under-meter. Refuse it, and do
+    # so BEFORE the request reaches Google or any budget is held.
+    guard = BudgetGuard(limit_usd=1.0)
+    client = _Client(_Response(), vertexai=True)
+
+    with pytest.warns(UnpriceableModelWarning, match="Vertex"):
+        with pytest.raises(UnpriceableModelError):
+            guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert client.models.calls == []
+    assert guard.remaining_usd == pytest.approx(1.0)  # nothing reserved
+
+
+def test_vertex_client_proceeds_when_the_caller_supplies_a_price() -> None:
+    # price_overrides is the documented way to meter Vertex — the caller's rates
+    # win, so there is nothing left to refuse.
+    guard = _guard()
+    client = _Client(
+        _Response(usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)),
+        vertexai=True,
+    )
+
+    guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert guard.spent_usd == pytest.approx(0.002)
+
+
+def test_vertex_client_warns_and_proceeds_when_fail_open() -> None:
+    # fail_closed=False is an explicit opt-in to un-enforced spend; the warning
+    # still fires so the under-metering is never silent.
+    guard = BudgetGuard(limit_usd=1.0, fail_closed=False)
+    client = _Client(
+        _Response(usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)),
+        vertexai=True,
+    )
+
+    with pytest.warns(UnpriceableModelWarning, match="Vertex"):
+        guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert client.models.calls  # the call ran
+
+
+def test_ai_studio_client_is_not_refused() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    client = _Client(
+        _Response(usage_metadata=_Usage(prompt_token_count=1000, candidates_token_count=500)),
+        vertexai=False,
+    )
+
+    guarded_completion(guard, client, model=MODEL, contents="hi")
+    assert guard.spent_usd > 0

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -71,6 +71,51 @@ def test_openai_and_anthropic_prefixes_do_not_bridge_to_groq_keys() -> None:
     assert resolve_price("openai/meta-llama/llama-4-scout-17b-16e-instruct") is None
 
 
+def test_gemini_resolves_from_bare_and_prefixed_ids() -> None:
+    # The map vendors Gemini under the BARE id the google-genai SDK and
+    # @ai-sdk/google actually pass; LiteLLM's "gemini/<id>" and the older
+    # "models/<id>" form reach the same entry via the bare-last-segment
+    # fallback, so no prefix rule is needed for either.
+    bare = resolve_price("gemini-2.5-flash")
+    assert bare is not None
+    assert bare.input_cost_per_token > 0
+    for form in ("gemini/gemini-2.5-flash", "models/gemini-2.5-flash"):
+        priced = resolve_price(form)
+        assert priced is not None, form
+        assert priced.input_cost_per_token == bare.input_cost_per_token, form
+        assert priced.output_cost_per_token == bare.output_cost_per_token, form
+
+
+def test_gemini_vertex_ids_price_at_ai_studio_rates() -> None:
+    # DOCUMENTED LIMITATION, asserted so it cannot change silently.
+    #
+    # Only the AI Studio (Gemini Developer API) prices are vendored. Vertex AI
+    # serves the same ids at its own — sometimes dearer — rates, and the id alone
+    # cannot say which billing path a call took, so a "vertex_ai/<id>" caller
+    # lands on the AI Studio price through the bare-last-segment fallback (the
+    # same way "openrouter/openai/gpt-4o" already resolves to "gpt-4o").
+    #
+    # Vertex callers should pass price_overrides; the Gemini adapter detects them
+    # via `client.vertexai`. If this ever needs to fail closed instead, that is a
+    # change to the shared resolver in BOTH pricing.py and pricing.ts.
+    vertex = resolve_price("vertex_ai/gemini-2.5-flash")
+    ai_studio = resolve_price("gemini-2.5-flash")
+    assert vertex is not None and ai_studio is not None
+    assert vertex.input_cost_per_token == ai_studio.input_cost_per_token
+
+
+def test_gemini_free_tier_models_stay_unpriceable() -> None:
+    # Upstream lists some experimental/free Gemini entries at 0/0. The refresh
+    # script drops zero-priced CHAT models: fail-closed pricing cannot catch them
+    # (0 is finite), so vendoring one would meter every call to it at $0 forever.
+    # gemini-exp-1206 is listed twice upstream — 0/0 and a real price — and must
+    # resolve to the real one.
+    priced = resolve_price("gemini-exp-1206")
+    assert priced is not None
+    assert priced.input_cost_per_token > 0
+    assert priced.output_cost_per_token > 0
+
+
 def test_dated_snapshot_falls_back_to_alias_price() -> None:
     # Anthropic responses carry dated snapshot ids; a snapshot the map doesn't
     # list yet must price at its alias entry instead of failing closed.

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -110,14 +110,22 @@ def test_no_vendored_chat_model_bills_output_free() -> None:
     # embedding mode zeroes the output rate — so a wrong mode silently bills a chat
     # model's output at $0, which fail-closed pricing cannot catch because 0 is a
     # finite, valid price. The refresh script now requires an embedding entry's id
-    # to agree with its mode; this asserts the invariant that survives it.
+    # to start with a known embedding family (EMBEDDING_ID_PREFIXES in
+    # scripts/update-cost-map.mjs) — a prefix, not a substring, so a chat model
+    # named "foo-embedding-chat" cannot claim the zeroed rate. Mirrored here as
+    # the invariant that survives the script.
     from floe_guard.pricing import _COST_MAP
 
+    embedding_prefixes = ("text-embedding-", "gemini-embedding-")
     for model, entry in _COST_MAP.items():
         if entry.get("mode") == "embedding":
-            assert "embedding" in model, f"{model} claims embedding mode but is not named one"
+            assert model.startswith(embedding_prefixes), (
+                f"{model} claims embedding mode but is not named as a known embedding family"
+            )
         else:
             assert entry.get("output_cost_per_token", 0) > 0, f"{model} bills output free"
+        # Zero input bills every call free just as invisibly, embeddings included.
+        assert entry.get("input_cost_per_token", 0) > 0, f"{model} bills input free"
 
 
 def test_mislabelled_chat_model_is_not_vendored_as_an_embedding() -> None:

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -104,6 +104,31 @@ def test_gemini_vertex_ids_price_at_ai_studio_rates() -> None:
     assert vertex.input_cost_per_token == ai_studio.input_cost_per_token
 
 
+def test_no_vendored_chat_model_bills_output_free() -> None:
+    # Regression guard. Upstream mislabels some chat models as mode="embedding"
+    # (gemini-1.5-flash was shipped that way, with output_cost_per_token=0), and
+    # embedding mode zeroes the output rate — so a wrong mode silently bills a chat
+    # model's output at $0, which fail-closed pricing cannot catch because 0 is a
+    # finite, valid price. The refresh script now requires an embedding entry's id
+    # to agree with its mode; this asserts the invariant that survives it.
+    from floe_guard.pricing import _COST_MAP
+
+    for model, entry in _COST_MAP.items():
+        if entry.get("mode") == "embedding":
+            assert "embedding" in model, f"{model} claims embedding mode but is not named one"
+        else:
+            assert entry.get("output_cost_per_token", 0) > 0, f"{model} bills output free"
+
+
+def test_mislabelled_chat_model_is_not_vendored_as_an_embedding() -> None:
+    # gemini-1.5-flash is a chat/multimodal model that upstream lists as
+    # mode="embedding" with a 0 output rate. There is no correctly-priced variant
+    # upstream to fall back to, so it stays unpriceable and fails closed rather
+    # than metering chat completions with free output.
+    assert resolve_price("gemini-1.5-flash") is None
+    assert resolve_price("gemini/gemini-1.5-flash") is None
+
+
 def test_gemini_free_tier_models_stay_unpriceable() -> None:
     # Upstream lists some experimental/free Gemini entries at 0/0. The refresh
     # script drops zero-priced CHAT models: fail-closed pricing cannot catch them


### PR DESCRIPTION
## Summary

Adds Google Gemini support in two layers: **pricing in the vendored cost map** (ships in both packages) and a **Python adapter** for the `google-genai` SDK. Gemini calls previously failed closed — 137 priced models, none of them Gemini.

Because the cost map is vendored byte-identically in both packages, the pricing half also unlocks Gemini for TypeScript users on `budgetGuardMiddleware` + `@ai-sdk/google`, with no TS code.

**One thing to look at first:** this diff removes 14 OpenAI realtime models. That isn't collateral damage — it closes a latent under-meter. Details under *Changes*.

| | |
|---|---|
| Cost map | 137 → **160** models (+37 Gemini, −14 OpenAI realtime) |
| Versions | py `0.7.0` → `0.8.0`, js `0.5.0` → `0.6.0` |
| Resolver | **unchanged** — `pricing.py` / `pricing.ts` untouched |

## Changes

**Cost map — Gemini priced at Google AI Studio rates** (`scripts/update-cost-map.mjs`)

- Vendored under **bare** ids, so every convention resolves through the *existing* fallback ladder with no resolver change:
  `gemini-2.5-flash` (google-genai, `@ai-sdk/google`), `gemini/gemini-2.5-flash` (LiteLLM) and `models/gemini-2.5-flash` all hit one entry.
- A **rule**, not a Groq-style allowlist — nothing but Google ships a `gemini-*` model, so there's no generic name to mis-claim, and hand-listing ~40 entries would go stale every launch. Vertex needed no exclusion code; its `vertex_ai-*` providers were already non-routable.
- **Vertex is deliberately not vendored.** Same model ids, up to 50% dearer (`gemini-2.0-flash-001`), and the id can't say which path a call took — pricing both from one key would under-meter Vertex users.

**Cost map — two fail-closed hardenings**

- **Zero-priced chat models dropped.** Upstream lists 6 Gemini entries at `0`/`0`; vendoring one meters every call to it at $0 forever, and fail-closed pricing can't catch it (`0` is finite) — the hole the existing `isUsable` comment flags. Embeddings keep their real `0` output rate.
- **Duplicate keys resolve to the dearer entry.** Several Gemini models are listed both bare and `gemini/`-prefixed; collapsing them previously depended on iteration order. Over-pricing stops an agent one call early (safe); under-pricing lets a crossing call through.
- Fixed the summary line, which counted pre-collision entries rather than vendored keys.

**New adapter** (`src/floe_guard/integrations/gemini.py`, `[gemini]` extra)

- `guarded_completion` / `guarded_acompletion` wrapping `client.models.generate_content` and `client.aio.models.generate_content`. Signatures are parallel with `openai.py` / `anthropic.py`; no SDK import at module level, so it's duck-typed and testable without the extra.
- **All five token buckets mapped.** `total_token_count` is documented as `prompt + candidates + tool_use_prompt + thoughts`, and `prompt_token_count` "also includes … the cached content" — so the obvious two-field mapping is wrong twice over:
  
  | Bucket | Handling | Naive mapping |
  |---|---|---|
  | `prompt_token_count` | input, **minus** cached share | double-charges cached |
  | `cached_content_token_count` | 0.1× cache-read rate | — |
  | `tool_use_prompt_token_count` | **added** to input | under-meters tool agents |
  | `candidates_token_count` | output | — |
  | `thoughts_token_count` | **added** to output | under-meters thinking models |

- **Vertex fails closed**, checked *before* `reserve()` so a refused call reaches neither Google nor the ceiling:

  ```
  Client(api_key=...)                      → allowed
  Client(vertexai=True, project=...)       → UnpriceableModelError
  Client(vertexai=True) + price_overrides  → allowed (caller's rates win)
  fail_closed=False                        → warns loudly, proceeds
  ```

  Reads `client.vertexai`, not the constructor kwarg — both `vertexai=True` and the newer `enterprise=True` set it, and there's no `.enterprise` attribute (verified on `google-genai` 2.0.1). No new exception class: reuses the `UnpriceableModelWarning` + `UnpriceableModelError` warn-then-raise pair exactly as `settle()` does, so existing `except UnpriceableModelError` keeps working.
- **Streaming not wrapped** — `generate_content_stream`'s usage arrives only on the final chunk (or never), so a reserve/settle wrapper would return an unmetered stream and leak its hold. Documented, pointing at `guard_stream()`. Unlike `openai.py` there's no `stream=True` kwarg to reject; streaming is a separate method, so there's no silent-passthrough footgun.

**Why 14 OpenAI models disappeared**

Refreshing pulls current upstream, which reclassified OpenAI's realtime models from `chat` to `realtime` mode, so `isUsable` no longer accepts them. This is a **fix**:

| `gpt-realtime` | input | output |
|---|---|---|
| Text tokens | `$0.000004` | `$0.000016` |
| Audio tokens | `$0.000032` (**8×**) | `$0.000064` (**4×**) |

The map holds one input and one output price per model, so it stored the *text* rates — live voice agents were being metered at roughly **one-eighth** of true input cost. They now fail closed until given explicit prices. Supporting them properly needs somewhere to *put* an audio rate, which is separate work.

Unrelated to Gemini, and would surface on any refresh — the weekly cost-map job appears not to have landed in a while. **Happy to split this out if you'd prefer.**

**Docs** — README (Gemini adapter section, "what the bundled map prices", adapter list), CONTRIBUTING (extras), CHANGELOG (`(py)` for the adapter, `(py + js)` for the map).

## Testing

`tests/test_gemini_adapter.py` (19 new) duck-types the SDK with dataclasses so it runs with `google-genai` absent, following `test_openai_adapter.py`. Covers each token bucket, the reserve/settle contract, blocked calls never reaching the client, reservation release on error and on usage-less responses, async, served-vs-requested model fallback, and all four Vertex paths.

`tests/test_pricing.py` (3 new) covers bare and prefixed Gemini resolution, the free-tier refusal, and **asserts that `vertex_ai/<id>` resolves at AI Studio rates** — so that documented limitation can't drift silently.

Also verified against the real SDK, not just the test doubles: usage parsing on a live `GenerateContentResponse` (1000 prompt / 800 cached / 50 tool-use / 200 candidates / 500 thoughts → `250` input, `700` output, `800` cached), and `client.vertexai` on real clients constructed both ways. Confirmed the TS package resolves all three Gemini id forms from the regenerated map.

```bash
node scripts/update-cost-map.mjs                        # regenerated, never hand-edited
diff src/floe_guard/cost_map.json js/src/cost_map.json  # identical
pytest                                                   # 196 passed, 7 skipped
ruff check .                                             # clean
cd js && npm test && npm run typecheck                   # 73 passed, clean
```

- [x] `pytest` passes (Python changes) — 196 passed, 7 skipped
- [x] `ruff check .` and `ruff format .` are clean (Python changes) — see note below
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes) — 73 passed
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)

> **Note on `ruff format`:** both new files are format-clean. `ruff format .`
> repo-wide reports 12 *other* files as unformatted on `main` today
> (`test_tool_costs.py`, `test_spend_log.py`, …) — pre-existing drift, unchanged
> by this PR, and not caught by CI since `ci.yml` runs `ruff check` only. Left
> alone to avoid unrelated churn; happy to fix in a separate PR.

## Related issues

Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Google Gemini adapter with guarded synchronous and asynchronous completions.
  * Bundled Gemini pricing/cost mappings for chat and embedding models.
* **Bug Fixes**
  * Enforced reserve-before/settle-after fail-closed metering to prevent unsafe/blocked calls reaching providers.
  * Improved Gemini token accounting (including cached tokens, “thoughts”, and tool-use tokens) and tightened fail-closed pricing/alias resolution.
  * Removed OpenAI realtime-era pricing entries so they fail closed.
* **Documentation**
  * Updated README and CONTRIBUTING with Gemini setup, pricing behavior (including Vertex caveats), and streaming metering guidance.
* **Tests**
  * Added Gemini adapter and Gemini pricing resolution fail-closed regression tests.
* **Release**
  * Bumped Python and JavaScript package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->