### PR TITLE
feat: budget-aware retry / graceful-degradation helper (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+### Added (py + js)
+
+- **Budget-aware retry helper** (`with_budget_retry` / `withBudgetRetry`,
+  issue #45): retry normally when budget is healthy, ask a caller-supplied
+  degrade callback for a cheaper retry plan when `advisory().near_limit` /
+  `nearLimit` is set, and hard-block an over-budget retry with `check()` before
+  it runs. Ships with a no-network Python example.
+
 ## py 0.8.0 — 2026-07-23
 
 ### Added (py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.9.0 / js 0.6.0 — 2026-07-23
+
 ### Added (py + js)
 
 - **Budget-aware retry helper** (`with_budget_retry` / `withBudgetRetry`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## py 0.9.1 — 2026-07-23
+
+### Fixed (py)
+
+- **Budget-aware retry**: reject non-integer `max_attempts`, and catch
+  `Exception` (not `BaseException`) so `KeyboardInterrupt` /
+  `SystemExit` / `CancelledError` propagate instead of being retried.
+
 ## py 0.9.0 / js 0.6.0 — 2026-07-23
 
 ### Added (py + js)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,39 @@ ignore it; `check()` is what enforces the ceiling. See
 [`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
 (no API key).
 
+### Budget-aware retry
+
+Blind retries can spend the same expensive path again right when the agent is
+running out of headroom. `with_budget_retry()` composes over the existing guard:
+retry normally while budget is healthy, ask your code for a cheaper retry plan
+when `advisory().near_limit` is true, and call `check(estimated_cost)` before
+each retry so an over-budget retry never runs.
+
+```python
+from floe_guard import BudgetGuard, RetryPlan, with_budget_retry
+
+guard = BudgetGuard(limit_usd=1.00)
+
+def premium_model():
+    return call_model("gpt-4o")
+
+def mini_model():
+    return call_model("gpt-4o-mini")
+
+result = with_budget_retry(
+    guard,
+    premium_model,
+    estimated_cost=0.20,
+    max_attempts=2,
+    on_degrade=lambda exc, adv: RetryPlan(call=mini_model, estimated_cost=0.01),
+)
+```
+
+The helper does not rank models or know provider pricing; the caller defines
+what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
+`withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
+for a no-network demo.
+
 This is the **same advisory shape** hosted Floe returns on every proxied call
 (the `X-Floe-Budget-Advisory` header), so the logic you write here ports
 unchanged — hosted just answers across *every* vendor and cap with server-truth

--- a/examples/budget_retry.py
+++ b/examples/budget_retry.py
@@ -1,0 +1,50 @@
+"""Budget-aware retry / graceful degradation demo.
+
+Run with:
+
+    python examples/budget_retry.py
+
+No API key, no network. The first call fails near the cap, so the retry helper
+asks the caller for a cheaper path and checks that the cheaper retry fits before
+running it.
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetGuard, RetryPlan, with_budget_retry
+
+
+class TransientProviderError(RuntimeError):
+    pass
+
+
+def main() -> None:
+    guard = BudgetGuard(limit_usd=1.00, near_limit_bps=8000)
+    guard.record_tool("previous-work", 0.85)
+    calls = {"premium": 0, "mini": 0}
+
+    def premium_model() -> str:
+        calls["premium"] += 1
+        raise TransientProviderError("temporary upstream timeout")
+
+    def mini_model() -> str:
+        calls["mini"] += 1
+        return "retried on cheaper model"
+
+    def degrade(_exc: BaseException, _advisory) -> RetryPlan[str]:
+        return RetryPlan(call=mini_model, estimated_cost=0.01)
+
+    result = with_budget_retry(
+        guard,
+        premium_model,
+        estimated_cost=0.20,
+        max_attempts=2,
+        on_degrade=degrade,
+    )
+
+    print(result)
+    print(calls)
+
+
+if __name__ == "__main__":
+    main()

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "ai": "^4.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -33,5 +33,10 @@ export {
   resolvePrice,
   priceTokens,
 } from "./pricing.js";
+export {
+  withBudgetRetry,
+  type BudgetRetryOptions,
+  type RetryPlan,
+} from "./retry.js";
 
 export * as pricing from "./pricing.js";

--- a/js/src/retry.ts
+++ b/js/src/retry.ts
@@ -1,0 +1,82 @@
+import { BudgetExceeded } from "./errors.js";
+import { type BudgetAdvisory, BudgetGuard } from "./guard.js";
+
+export interface RetryPlan<T> {
+  /** Operation to run for this retry attempt. */
+  call: () => T | Promise<T>;
+  /**
+   * Estimated retry cost passed to `guard.check()` before the retry runs.
+   * Leave undefined to use the guard's default last-call estimate.
+   */
+  estimatedCost?: number;
+}
+
+export interface BudgetRetryOptions<T> {
+  /** Estimated cost for retrying the original call. */
+  estimatedCost?: number;
+  /** Total attempts, including the first call. Default: 2. */
+  maxAttempts?: number;
+  /** Choose a cheaper retry plan when `guard.advisory().nearLimit` is true. */
+  onDegrade?: (
+    error: unknown,
+    advisory: BudgetAdvisory,
+  ) => RetryPlan<T> | Promise<RetryPlan<T> | undefined> | undefined;
+  /** Decide whether an error is retryable. Defaults to all non-budget errors. */
+  retryIf?: (error: unknown) => boolean;
+}
+
+function defaultRetryIf(error: unknown): boolean {
+  return !(error instanceof BudgetExceeded);
+}
+
+/**
+ * Run `call` with budget-aware retries.
+ *
+ * The first attempt runs unchanged. If it fails with a retryable error, the
+ * helper retries as-is with ample budget, asks `onDegrade` for a cheaper plan
+ * when near the limit, and always calls `guard.check(estimatedCost)` before a
+ * retry so an over-budget retry is blocked before it runs.
+ */
+export async function withBudgetRetry<T>(
+  guard: BudgetGuard,
+  call: () => T | Promise<T>,
+  options: BudgetRetryOptions<T> = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 2;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError(`maxAttempts must be an integer >= 1, got ${maxAttempts}`);
+  }
+  const retryIf = options.retryIf ?? defaultRetryIf;
+  let plan: RetryPlan<T> = { call, estimatedCost: options.estimatedCost };
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await plan.call();
+    } catch (error) {
+      if (attempt >= maxAttempts || !retryIf(error)) {
+        throw error;
+      }
+      plan = await nextPlan(guard, error, plan, options.onDegrade);
+    }
+  }
+
+  throw new Error("unreachable");
+}
+
+async function nextPlan<T>(
+  guard: BudgetGuard,
+  error: unknown,
+  current: RetryPlan<T>,
+  onDegrade: BudgetRetryOptions<T>["onDegrade"],
+): Promise<RetryPlan<T>> {
+  const advisory = guard.advisory();
+  if (advisory.nearLimit && onDegrade !== undefined) {
+    const degraded = await onDegrade(error, advisory);
+    if (degraded !== undefined) {
+      guard.check(degraded.estimatedCost);
+      return degraded;
+    }
+  }
+  guard.check(current.estimatedCost);
+  return current;
+}

--- a/js/test/retry.test.ts
+++ b/js/test/retry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { BudgetExceeded, BudgetGuard, type RetryPlan, withBudgetRetry } from "../src/index.js";
+
+class RetryableError extends Error {}
+
+describe("withBudgetRetry", () => {
+  it("retries the same call when budget is ample", async () => {
+    const guard = new BudgetGuard(1.0);
+    let primaryCalls = 0;
+
+    const result = await withBudgetRetry(
+      guard,
+      () => {
+        primaryCalls += 1;
+        if (primaryCalls === 1) throw new RetryableError("temporary failure");
+        return "primary-ok";
+      },
+      { estimatedCost: 0.05, maxAttempts: 2 },
+    );
+
+    expect(result).toBe("primary-ok");
+    expect(primaryCalls).toBe(2);
+  });
+
+  it("uses a degraded retry plan when near the limit", async () => {
+    const guard = new BudgetGuard(1.0, { nearLimitBps: 8000 });
+    guard.recordTool("seed", 0.85);
+    let primaryCalls = 0;
+    let cheapCalls = 0;
+
+    const result = await withBudgetRetry(
+      guard,
+      () => {
+        primaryCalls += 1;
+        throw new RetryableError("temporary failure");
+      },
+      {
+        estimatedCost: 0.2,
+        maxAttempts: 2,
+        onDegrade: (error): RetryPlan<string> => {
+          expect(error).toBeInstanceOf(RetryableError);
+          return {
+            estimatedCost: 0.01,
+            call: () => {
+              cheapCalls += 1;
+              return "cheap-ok";
+            },
+          };
+        },
+      },
+    );
+
+    expect(result).toBe("cheap-ok");
+    expect(primaryCalls).toBe(1);
+    expect(cheapCalls).toBe(1);
+  });
+
+  it("aborts before a retry whose estimate would cross the budget", async () => {
+    const guard = new BudgetGuard(1.0, { onBlock: () => undefined });
+    guard.recordTool("seed", 0.95);
+    let primaryCalls = 0;
+
+    await expect(
+      withBudgetRetry(
+        guard,
+        () => {
+          primaryCalls += 1;
+          throw new RetryableError("temporary failure");
+        },
+        { estimatedCost: 0.1, maxAttempts: 2 },
+      ),
+    ).rejects.toBeInstanceOf(BudgetExceeded);
+    expect(primaryCalls).toBe(1);
+  });
+
+  it("does not retry non-retryable failures", async () => {
+    const guard = new BudgetGuard(1.0);
+    let primaryCalls = 0;
+
+    await expect(
+      withBudgetRetry(
+        guard,
+        () => {
+          primaryCalls += 1;
+          throw new TypeError("bad request");
+        },
+        {
+          estimatedCost: 0.01,
+          retryIf: (error) => !(error instanceof TypeError),
+        },
+      ),
+    ).rejects.toThrow("bad request");
+    expect(primaryCalls).toBe(1);
+  });
+
+  it("rejects invalid maxAttempts", async () => {
+    await expect(
+      withBudgetRetry(new BudgetGuard(1.0), () => "ok", { maxAttempts: 0 }),
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.9.0"
+version = "0.9.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.8.0"
+version = "0.9.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -29,7 +29,7 @@ from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.9.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.9.1"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -26,6 +26,7 @@ from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
+from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
 __version__ = "0.8.0"  # keep in lockstep with pyproject.toml
@@ -38,6 +39,9 @@ __all__ = [
     "LatencyAdvisory",
     "StreamGuard",
     "guard_stream",
+    "RetryPlan",
+    "with_budget_retry",
+    "async_with_budget_retry",
     "BudgetExceeded",
     "DeadlineExceeded",
     "FloeGuardError",

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -29,7 +29,7 @@ from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.8.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.9.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/retry.py
+++ b/src/floe_guard/retry.py
@@ -33,16 +33,26 @@ class RetryPlan(Generic[T]):
     estimated_cost: float | None = None
 
 
-RetryPredicate = Callable[[BaseException], bool]
-DegradeCallback = Callable[[BaseException, BudgetAdvisory], RetryPlan[T] | None]
+RetryPredicate = Callable[[Exception], bool]
+DegradeCallback = Callable[[Exception, BudgetAdvisory], RetryPlan[T] | None]
 AsyncDegradeCallback = Callable[
-    [BaseException, BudgetAdvisory],
+    [Exception, BudgetAdvisory],
     RetryPlan[Awaitable[T]] | Awaitable[RetryPlan[Awaitable[T]] | None] | None,
 ]
 
 
-def _default_retry_if(exc: BaseException) -> bool:
+def _default_retry_if(exc: Exception) -> bool:
     return not isinstance(exc, BudgetExceeded)
+
+
+def _validate_max_attempts(max_attempts: int) -> None:
+    # Same int-not-bool contract as BudgetGuard.near_limit_bps.
+    if (
+        isinstance(max_attempts, bool)
+        or not isinstance(max_attempts, int)
+        or max_attempts < 1
+    ):
+        raise ValueError(f"max_attempts must be an int >= 1, got {max_attempts!r}")
 
 
 def with_budget_retry(
@@ -66,18 +76,18 @@ def with_budget_retry(
       over-budget retry aborts before spending.
 
     ``max_attempts`` includes the first attempt. The last retryable exception is
-    re-raised when attempts are exhausted.
+    re-raised when attempts are exhausted. Control-flow exceptions
+    (``KeyboardInterrupt``, ``SystemExit``, ``CancelledError``) are not caught.
     """
 
-    if max_attempts < 1:
-        raise ValueError(f"max_attempts must be >= 1, got {max_attempts!r}")
+    _validate_max_attempts(max_attempts)
     should_retry = retry_if or _default_retry_if
     plan = RetryPlan(call=call, estimated_cost=estimated_cost)
 
     for attempt in range(1, max_attempts + 1):
         try:
             return plan.call()
-        except BaseException as exc:
+        except Exception as exc:
             if attempt >= max_attempts or not should_retry(exc):
                 raise
             plan = _next_plan(guard, exc, plan, on_degrade)
@@ -96,15 +106,14 @@ async def async_with_budget_retry(
 ) -> T:
     """Async variant of :func:`with_budget_retry`."""
 
-    if max_attempts < 1:
-        raise ValueError(f"max_attempts must be >= 1, got {max_attempts!r}")
+    _validate_max_attempts(max_attempts)
     should_retry = retry_if or _default_retry_if
     plan = RetryPlan(call=call, estimated_cost=estimated_cost)
 
     for attempt in range(1, max_attempts + 1):
         try:
             return await plan.call()
-        except BaseException as exc:
+        except Exception as exc:
             if attempt >= max_attempts or not should_retry(exc):
                 raise
             plan = await _next_async_plan(guard, exc, plan, on_degrade)
@@ -114,7 +123,7 @@ async def async_with_budget_retry(
 
 def _next_plan(
     guard: BudgetGuard,
-    exc: BaseException,
+    exc: Exception,
     current: RetryPlan[T],
     on_degrade: DegradeCallback[T] | None,
 ) -> RetryPlan[T]:
@@ -130,7 +139,7 @@ def _next_plan(
 
 async def _next_async_plan(
     guard: BudgetGuard,
-    exc: BaseException,
+    exc: Exception,
     current: RetryPlan[Awaitable[T]],
     on_degrade: AsyncDegradeCallback[T] | None,
 ) -> RetryPlan[Awaitable[T]]:

--- a/src/floe_guard/retry.py
+++ b/src/floe_guard/retry.py
@@ -1,0 +1,149 @@
+"""Budget-aware retry helpers.
+
+The helpers here are deliberately thin: they do not implement transport
+retries, model ranking, or provider-specific pricing. They only decide whether
+the next retry should run under the current budget, and let callers supply a
+cheaper retry path when the guard is near its limit.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from .errors import BudgetExceeded
+from .guard import BudgetAdvisory, BudgetGuard
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RetryPlan(Generic[T]):
+    """A concrete retry attempt.
+
+    ``call`` is the operation to run for this retry. ``estimated_cost`` is passed
+    to :meth:`BudgetGuard.check` immediately before the retry, so a retry that
+    cannot fit the remaining budget is blocked before it runs. Use ``None`` to
+    fall back to the guard's normal last-call estimate.
+    """
+
+    call: Callable[[], T]
+    estimated_cost: float | None = None
+
+
+RetryPredicate = Callable[[BaseException], bool]
+DegradeCallback = Callable[[BaseException, BudgetAdvisory], RetryPlan[T] | None]
+AsyncDegradeCallback = Callable[
+    [BaseException, BudgetAdvisory],
+    RetryPlan[Awaitable[T]] | Awaitable[RetryPlan[Awaitable[T]] | None] | None,
+]
+
+
+def _default_retry_if(exc: BaseException) -> bool:
+    return not isinstance(exc, BudgetExceeded)
+
+
+def with_budget_retry(
+    guard: BudgetGuard,
+    call: Callable[[], T],
+    *,
+    estimated_cost: float | None = None,
+    max_attempts: int = 2,
+    on_degrade: DegradeCallback[T] | None = None,
+    retry_if: RetryPredicate | None = None,
+) -> T:
+    """Run ``call`` with budget-aware retries.
+
+    The first attempt runs unchanged. If it fails with a retryable exception,
+    the helper consults the guard:
+
+    * with ample budget, retry the same ``call``;
+    * when ``advisory().near_limit`` is true and ``on_degrade`` is supplied, let
+      the caller provide a cheaper :class:`RetryPlan`;
+    * before every retry, call ``guard.check(plan.estimated_cost)`` so an
+      over-budget retry aborts before spending.
+
+    ``max_attempts`` includes the first attempt. The last retryable exception is
+    re-raised when attempts are exhausted.
+    """
+
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be >= 1, got {max_attempts!r}")
+    should_retry = retry_if or _default_retry_if
+    plan = RetryPlan(call=call, estimated_cost=estimated_cost)
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return plan.call()
+        except BaseException as exc:
+            if attempt >= max_attempts or not should_retry(exc):
+                raise
+            plan = _next_plan(guard, exc, plan, on_degrade)
+
+    raise RuntimeError("unreachable")
+
+
+async def async_with_budget_retry(
+    guard: BudgetGuard,
+    call: Callable[[], Awaitable[T]],
+    *,
+    estimated_cost: float | None = None,
+    max_attempts: int = 2,
+    on_degrade: AsyncDegradeCallback[T] | None = None,
+    retry_if: RetryPredicate | None = None,
+) -> T:
+    """Async variant of :func:`with_budget_retry`."""
+
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be >= 1, got {max_attempts!r}")
+    should_retry = retry_if or _default_retry_if
+    plan = RetryPlan(call=call, estimated_cost=estimated_cost)
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await plan.call()
+        except BaseException as exc:
+            if attempt >= max_attempts or not should_retry(exc):
+                raise
+            plan = await _next_async_plan(guard, exc, plan, on_degrade)
+
+    raise RuntimeError("unreachable")
+
+
+def _next_plan(
+    guard: BudgetGuard,
+    exc: BaseException,
+    current: RetryPlan[T],
+    on_degrade: DegradeCallback[T] | None,
+) -> RetryPlan[T]:
+    advisory = guard.advisory()
+    if advisory.near_limit and on_degrade is not None:
+        degraded = on_degrade(exc, advisory)
+        if degraded is not None:
+            guard.check(degraded.estimated_cost)
+            return degraded
+    guard.check(current.estimated_cost)
+    return current
+
+
+async def _next_async_plan(
+    guard: BudgetGuard,
+    exc: BaseException,
+    current: RetryPlan[Awaitable[T]],
+    on_degrade: AsyncDegradeCallback[T] | None,
+) -> RetryPlan[Awaitable[T]]:
+    advisory = guard.advisory()
+    if advisory.near_limit and on_degrade is not None:
+        degraded = on_degrade(exc, advisory)
+        if inspect.isawaitable(degraded):
+            degraded = await degraded
+        if degraded is not None:
+            guard.check(degraded.estimated_cost)
+            return degraded
+    guard.check(current.estimated_cost)
+    return current
+
+
+__all__ = ["RetryPlan", "with_budget_retry", "async_with_budget_retry"]

--- a/tests/test_budget_retry.py
+++ b/tests/test_budget_retry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from floe_guard import (
@@ -97,6 +99,41 @@ def test_non_retryable_failure_is_raised_without_retry() -> None:
 def test_invalid_max_attempts_rejected() -> None:
     with pytest.raises(ValueError, match="max_attempts"):
         with_budget_retry(BudgetGuard(limit_usd=1.00), lambda: "ok", max_attempts=0)
+
+
+@pytest.mark.parametrize("bad", [1.5, True, "2"])
+def test_non_integer_max_attempts_rejected(bad: object) -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        with_budget_retry(BudgetGuard(limit_usd=1.00), lambda: "ok", max_attempts=bad)  # type: ignore[arg-type]
+
+
+def test_keyboard_interrupt_is_not_retried() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"primary": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        with_budget_retry(guard, primary, estimated_cost=0.01, max_attempts=3)
+
+    assert calls == {"primary": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_cancelled_error_is_not_retried() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"primary": 0}
+
+    async def primary() -> str:
+        calls["primary"] += 1
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await async_with_budget_retry(guard, primary, estimated_cost=0.01, max_attempts=3)
+
+    assert calls == {"primary": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/test_budget_retry.py
+++ b/tests/test_budget_retry.py
@@ -1,0 +1,128 @@
+"""Budget-aware retry helper tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    RetryPlan,
+    async_with_budget_retry,
+    with_budget_retry,
+)
+
+
+class RetryableError(RuntimeError):
+    pass
+
+
+def test_ample_budget_retries_same_call() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"primary": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        if calls["primary"] == 1:
+            raise RetryableError("temporary failure")
+        return "primary-ok"
+
+    assert with_budget_retry(guard, primary, estimated_cost=0.05, max_attempts=2) == "primary-ok"
+    assert calls == {"primary": 2}
+
+
+def test_near_limit_failure_retries_with_degraded_plan() -> None:
+    guard = BudgetGuard(limit_usd=1.00, near_limit_bps=8000)
+    guard.record_tool("seed", 0.85)
+    calls = {"primary": 0, "cheap": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        raise RetryableError("temporary failure")
+
+    def cheap() -> str:
+        calls["cheap"] += 1
+        return "cheap-ok"
+
+    def degrade(exc: BaseException, _advisory) -> RetryPlan[str]:
+        assert isinstance(exc, RetryableError)
+        return RetryPlan(call=cheap, estimated_cost=0.01)
+
+    result = with_budget_retry(
+        guard,
+        primary,
+        estimated_cost=0.20,
+        max_attempts=2,
+        on_degrade=degrade,
+    )
+
+    assert result == "cheap-ok"
+    assert calls == {"primary": 1, "cheap": 1}
+
+
+def test_over_budget_retry_aborts_before_second_call() -> None:
+    guard = BudgetGuard(limit_usd=1.00, on_block=lambda *_: None)
+    guard.record_tool("seed", 0.95)
+    calls = {"primary": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        raise RetryableError("temporary failure")
+
+    with pytest.raises(BudgetExceeded):
+        with_budget_retry(guard, primary, estimated_cost=0.10, max_attempts=2)
+
+    assert calls == {"primary": 1}
+
+
+def test_non_retryable_failure_is_raised_without_retry() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"primary": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        raise ValueError("bad request")
+
+    with pytest.raises(ValueError, match="bad request"):
+        with_budget_retry(
+            guard,
+            primary,
+            estimated_cost=0.01,
+            retry_if=lambda exc: not isinstance(exc, ValueError),
+        )
+
+    assert calls == {"primary": 1}
+
+
+def test_invalid_max_attempts_rejected() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        with_budget_retry(BudgetGuard(limit_usd=1.00), lambda: "ok", max_attempts=0)
+
+
+@pytest.mark.asyncio
+async def test_async_helper_degrades_near_limit() -> None:
+    guard = BudgetGuard(limit_usd=1.00, near_limit_bps=8000)
+    guard.record_tool("seed", 0.85)
+    calls = {"primary": 0, "cheap": 0}
+
+    async def primary() -> str:
+        calls["primary"] += 1
+        raise RetryableError("temporary failure")
+
+    async def cheap() -> str:
+        calls["cheap"] += 1
+        return "cheap-ok"
+
+    async def degrade(_exc: BaseException, _advisory):
+        return RetryPlan(call=cheap, estimated_cost=0.01)
+
+    result = await async_with_budget_retry(
+        guard,
+        primary,
+        estimated_cost=0.20,
+        max_attempts=2,
+        on_degrade=degrade,
+    )
+
+    assert result == "cheap-ok"
+    assert calls == {"primary": 1, "cheap": 1}


### PR DESCRIPTION
## Summary

Closes #45.

Agents already know how much budget is left (`remaining_usd` / `advisory().near_limit`), but retries did not use that signal. A failed call would either retry the same expensive path or not think about budget at all.

This PR adds a thin helper — `with_budget_retry` (Python) and `withBudgetRetry` (TypeScript) — that decides **whether** to retry based on budget headroom. It does **not** pick models or own the HTTP/retry transport. The caller still owns what "cheaper" means via `on_degrade`.

### Behavior in plain English

Imagine a $1 budget and a call that fails once:

| Situation | What the helper does |
| --- | --- |
| **Ample budget** (lots of money left) | Retry the **same** call again |
| **Near the limit** (~80% spent by default) | Call your `on_degrade` callback so **you** can switch to a cheaper model / path |
| **Retry would go over the ceiling** | Call `guard.check(estimated_cost)` and **abort** — no second spend |

### Tiny example

```python
from floe_guard import BudgetGuard, RetryPlan, with_budget_retry

guard = BudgetGuard(limit_usd=1.00)

def on_degrade(exc, advisory):
    # YOU choose the cheaper model — floe-guard only asks when near_limit
    return RetryPlan(call=mini_model, estimated_cost=0.01)

result = with_budget_retry(
    guard,
    premium_model,
    estimated_cost=0.20,
    max_attempts=2,
    on_degrade=on_degrade,
)
```

Try the no-network demo: `python examples/budget_retry.py`

### What this is / is not

- **Is:** an opt-in composition helper over live primitives (`advisory`, `check`)
- **Is not:** automatic wiring into OpenAI / Anthropic / LiveKit / LangChain adapters
- **Is not:** model ranking, provider pricing, or server-side retry (out of scope per #45)

## What changed

- Python: `src/floe_guard/retry.py` — `with_budget_retry`, `async_with_budget_retry`, `RetryPlan`
- TypeScript: `js/src/retry.ts` — `withBudgetRetry`
- Example: `examples/budget_retry.py`
- Tests: `tests/test_budget_retry.py`, `js/test/retry.test.ts`
- Docs: README + CHANGELOG

## Test plan

- [x] `python -m pytest tests/test_budget_retry.py -v` — 6/6 passed
- [x] `npm test -- test/retry.test.ts` (in `js/`) — 5/5 passed
- [x] `python examples/budget_retry.py` — near-limit path prints cheaper-model success
- [ ] Reviewer: skim acceptance cases (ample / near-limit / over-cap) in the tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added budget-aware retry helpers for Python (sync/async) and TypeScript, including configurable retry plans, retryability, and “near-limit” graceful degradation.
  * Budget is checked before each retry; retries are blocked when they would exceed the available budget.
* **Documentation**
  * Added a “Budget-aware retry” section with Python and TypeScript examples and behavior details.
* **Tests**
  * Added sync/async tests for normal retries, degraded-plan fallback, over-budget blocking, non-retryable errors, and invalid retry settings.
* **Bug Fixes**
  * Improved Python validation/retry behavior: non-integer `max_attempts` is rejected and only `Exception` types are retried (excluding interrupt/cancellation errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->