### PR TITLE
feat: add token ceilings and per-step budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,20 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.11.0 / js 0.8.0
+## Unreleased — py 0.12.0 / js 0.9.0
 
 ### Added (py + js)
 
+- **Aggregate token ceilings and per-step USD/token budgets** (issue #46):
+  optional `token_limit` / `tokenLimit` tracks every metered LLM token alongside
+  dollars; request-sized token reservations hard-block before a call and remain
+  safe under parallel fan-out. `guard.step(...)` creates an explicit scoped
+  guard with fresh sub-ceilings while retaining the parent's aggregate totals.
+- **Token and step advisory headroom**: `advisory()` now reports aggregate token
+  utilization plus the active step's USD/token remaining values. The existing
+  `near_limit` / `nearLimit` taper signal also flips for a near token or step
+  ceiling. Token blocks raise `TokenBudgetExceeded`; aggregate-only behavior and
+  numeric reservation handles are unchanged when the new limits are absent.
 - **`advisory()` exposes `expected_cost` + `est_calls_remaining`** (`expectedCost`
   / `estCallsRemaining` in TS, issue #49): the guard's own next-call estimate and
   how many more calls the remaining budget buys, so a planner can see call
@@ -19,6 +29,13 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   before the first call is recorded; `est_calls_remaining` / `estCallsRemaining`
   is `None` / `null` until then (unknown, not zero).
   Additive fields — existing advisory consumers are unaffected.
+
+### Fixed (py + js)
+
+- Token budget errors now follow the existing hard-stop paths in LiteLLM,
+  Pipecat, LiveKit, and budget-aware retries. TypeScript step scopes also remain
+  active for promise-like callbacks, and the new options/advisory types stay
+  source-compatible with aggregate-only consumers.
 
 ## py 0.10.0 / js 0.7.0 — 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ### Fixed (py + js)
 
+- Typed token/step reservation handles are now immutable and identity-validated
+  against guard-owned state, so modified, copied, forged, foreign, or reused
+  handles fail before they can alter another caller's in-flight totals.
 - Token budget errors now follow the existing hard-stop paths in LiteLLM,
   Pipecat, LiveKit, and budget-aware retries. TypeScript step scopes also remain
   active for promise-like callbacks, and the new options/advisory types stay

--- a/CODEBASE_CONVENTIONS.md
+++ b/CODEBASE_CONVENTIONS.md
@@ -1,0 +1,430 @@
+# Codebase conventions
+
+This guide records the engineering conventions already present in `floe-guard`.
+Use it with [`CONTRIBUTING.md`](CONTRIBUTING.md), which remains the source of
+truth for setup, contribution flow, and release mechanics.
+
+The goal is not to make every contribution look identical. It is to preserve the
+contracts that make this package trustworthy: stop paid work before it crosses a
+limit, never silently under-meter, remain safe under concurrency, keep the core
+dependency-free, and be explicit about what cannot be guaranteed.
+
+## Start with the contract
+
+Before changing code, write down:
+
+1. Where enforcement happens **before** the paid operation.
+2. Where actual usage is recorded after success.
+3. How an in-flight reservation is released on failure, cancellation, missing
+   usage, or an unsupported response.
+4. Whether the behavior exists in both Python and TypeScript and, if so, which
+   names and wire shapes must remain equivalent.
+5. Which public docs, examples, exports, versions, and changelog entries the
+   change affects.
+
+For anything safety-sensitive, prefer the conservative outcome. A false low
+price or a swallowed error weakens the product's core promise; an explicit
+refusal is visible and recoverable.
+
+## Repository map
+
+| Path | Responsibility | Constraints |
+|---|---|---|
+| `src/floe_guard/` | Python package and framework-agnostic core | Python 3.10+; no required runtime dependencies |
+| `src/floe_guard/integrations/` | Optional framework and provider adapters | Imports must not make the bare core require the framework extra |
+| `tests/` | Python unit, regression, adapter, concurrency, and example tests | Must pass both with CI's adapter extras and with no extras installed |
+| `examples/` | Small runnable demonstrations | Prefer no API key, no account, and no network |
+| `js/src/` | TypeScript core and Vercel AI SDK middleware | Node 18+, ES2022, strict TypeScript |
+| `js/test/` | Vitest behavioral and regression tests | Keep shared contracts aligned with Python |
+| `scripts/update-cost-map.mjs` | Curates the vendored provider cost map | Update both package copies together |
+| `.github/workflows/` | CI, version guards, publishing, and map refresh | Treat these workflows as enforced contribution constraints |
+
+## Invariants that take priority over local style
+
+### Enforce in the call path
+
+A listener that observes a completed call cannot prevent that call. New
+integrations should wrap the actual operation and follow the established
+reserve/settle lifecycle:
+
+```text
+validate unsupported modes
+    -> estimate when the request can be sized
+    -> reserve before external work
+    -> perform the operation
+    -> settle from actual usage
+```
+
+If the operation fails before `settle()` takes ownership, release its
+reservation and re-raise. Once `settle()` is called, do not release the same
+reservation again: `settle()` owns its disposal even when it raises.
+
+The sequential `check()` / `record()` API remains useful, but it is not a
+replacement for `reserve()` / `settle()` when calls can overlap.
+
+### Fail closed when spend cannot be measured
+
+Unknown models, missing model IDs, absent or malformed usage, non-finite values,
+and provider-specific prices that cannot be identified must not silently become
+zero-cost work. Route completed spend through the guard's configured policy so
+the default raises an explicit error. Only honor fail-open behavior when the
+caller has deliberately configured it.
+
+Validate inputs that could poison comparisons or totals. In particular, reject
+`NaN`, infinities, negative costs, invalid reservation handles, and booleans
+where a real integer is required.
+
+### Preserve concurrency safety
+
+State shared by parallel callers belongs under the existing lock or synchronous
+reservation boundary. Never split a check and its state mutation across an
+`await`, external call, or separately acquired lock.
+
+Every reservation must have exactly one terminal path:
+
+- settled after valid usage;
+- released after an exception;
+- released when a response or stream ends without usage; or
+- retained only while the corresponding operation is genuinely in flight.
+
+Tests should prove both the ceiling and cleanup. An assertion such as
+`remaining >= 0` is not enough when the property is clamped; assert the exact
+restored balance or inspect the in-flight value in a regression test.
+
+### Keep pricing conservative
+
+The cost map is a safety input, not ordinary reference data. Never infer a cheap
+rate across billing backends when the model ID cannot identify the backend.
+When aliases or duplicate entries disagree, choose behavior that cannot
+under-meter. Document deliberate exclusions.
+
+The following files must remain byte-identical:
+
+```text
+src/floe_guard/cost_map.json
+js/src/cost_map.json
+```
+
+Refresh them through `scripts/update-cost-map.mjs`; do not hand-edit one copy.
+
+### Keep the core dependency-free
+
+The Python project's required dependency list is intentionally empty.
+Framework integrations belong in `src/floe_guard/integrations/` and their
+packages belong in optional extras in `pyproject.toml`.
+
+The TypeScript middleware deliberately does not import `ai`, including for
+types. It uses the structural surface shared by AI SDK v4 and v5 so one build
+supports both peer versions. Preserve that compatibility unless the project
+explicitly changes its support policy.
+
+## Python conventions
+
+### Layout and imports
+
+- Begin modules with a docstring that explains purpose, contract, and important
+  limitations. Integration modules also identify the optional extra.
+- Use `from __future__ import annotations`.
+- Order imports as standard library, third party, then local; Ruff enforces the
+  ordering.
+- Use relative imports within `floe_guard`.
+- Keep public exports explicit in `src/floe_guard/__init__.py` and module-level
+  `__all__` lists where the module defines a public surface.
+- Prefix implementation helpers and internal state with `_`.
+
+### Typing and data shapes
+
+- Type public functions, methods, constructor parameters, return values, and
+  meaningful internal helpers.
+- Prefer built-in generics (`dict[str, object]`, `tuple[int, int]`) and `X | None`.
+- Use frozen dataclasses for immutable public value objects.
+- Use `Literal` when a field has a small closed vocabulary.
+- Preserve stable serialization schemas. Optional fields are omitted when the
+  established wire contract says they are absent; do not casually replace
+  omission with `null`.
+- When an optional SDK returns both objects and dictionaries, normalize both
+  shapes in a small private helper.
+
+### Naming
+
+- Modules, functions, methods, parameters, and local variables use
+  `snake_case`.
+- Classes, exceptions, dataclasses, and type-like objects use `PascalCase`.
+- Constants use `UPPER_SNAKE_CASE`; private constants add a leading underscore.
+- Test names describe behavior and outcome, for example
+  `test_usageless_response_releases_the_reservation`.
+- Prefer domain terms already used by the public contract: `limit`, `spent`,
+  `remaining`, `reserve`, `settle`, `release`, `advisory`, `prompt_tokens`, and
+  `completion_tokens`.
+
+### Functions and control flow
+
+- Keep provider-shape extraction, model selection, validation, and lifecycle
+  wiring in separate focused helpers.
+- Return early for unsupported or no-usage cases.
+- Catch the narrowest hierarchy that preserves lifecycle correctness. Adapter
+  wrappers catch `BaseException` when cleanup must also run for cancellation or
+  interruption, then immediately re-raise. Retry helpers deliberately catch
+  `Exception` so process-level exceptions are not retried.
+- Invoke callbacks and raise user-visible errors outside locks.
+- Avoid clever abstractions when a short explicit branch makes ownership of a
+  reservation or fallback easier to audit.
+
+### Documentation and comments
+
+Public classes and functions use docstrings that explain behavior, parameters,
+returns, raised errors, and honest limitations where relevant. Use Sphinx roles
+such as `:class:`, `:meth:`, and `:func:` when cross-referencing Python APIs.
+
+Comments explain **why**, especially for:
+
+- provider quirks;
+- counterintuitive token accounting;
+- concurrency ownership;
+- fail-closed decisions;
+- compatibility workarounds; and
+- regression context or issue numbers.
+
+Do not narrate straightforward syntax. If a subtle invariant depends on a line,
+put the explanation next to that line.
+
+### Formatting and lint
+
+Ruff is authoritative:
+
+- target Python: 3.10;
+- line length: 100;
+- lint families: `E`, `F`, `I`, `UP`, `B`, and `W`.
+
+Do not reformat unrelated files. Use a targeted `# type: ignore[code]` only when
+an external type surface requires it, and explain non-obvious ignores.
+
+## TypeScript conventions
+
+### Module and API style
+
+- Use ES modules and include `.js` in relative import specifiers.
+- Export the package surface explicitly from `js/src/index.ts`.
+- Export public interfaces and type aliases with their implementations.
+- Use `camelCase` for variables, functions, methods, properties, and option
+  fields; use `PascalCase` for classes, interfaces, and exported types.
+- Mirror shared Python concepts idiomatically:
+  `spent_usd` becomes `spentUsd`, `reserve_tool` becomes `reserveTool`, and so
+  on. Stable cross-runtime wire formats such as exported JSONL remain
+  `snake_case`.
+- Prefer `unknown` at untrusted boundaries and narrow it before use. `any` is
+  reserved for framework compatibility surfaces where multiple supported SDK
+  versions cannot share a useful imported type.
+
+### Documentation and compatibility
+
+Use JSDoc for public APIs and module comments for compatibility or lifecycle
+contracts. Explain casts that compensate for a lagging library type definition.
+
+The compiler runs in strict mode. The package builds ESM and CommonJS outputs,
+declarations, and source maps targeting ES2022. A TypeScript change is not
+complete until it builds, type-checks, and passes Vitest.
+
+## Integration conventions
+
+A provider adapter should generally contain:
+
+1. a module docstring describing the optional extra and enforcement surface;
+2. private helpers to extract the served model and usage from supported response
+   shapes;
+3. a model-selection helper that prefers the served model but uses a priceable
+   requested alias when documented and safe;
+4. explicit rejection of modes that cannot be metered honestly;
+5. synchronous and asynchronous wrappers when the SDK exposes both; and
+6. an explicit `__all__` for its supported public entry points.
+
+Do not import an optional framework from the package root. Adapter tests should
+use small fakes where possible and `pytest.importorskip` when the real framework
+is necessary, so the bare installation remains valid.
+
+New adapters must test at least:
+
+- successful accrual and return-value passthrough;
+- blocking before the provider method is reached;
+- synchronous and asynchronous behavior, when both exist;
+- provider exceptions releasing the reservation;
+- missing usage releasing or failing according to the documented contract;
+- unpriceable or missing model behavior;
+- served-model versus requested-alias behavior;
+- unsupported streaming or other modes; and
+- concurrency when the integration can fan out.
+
+## Testing conventions
+
+### Python
+
+- Put tests in `tests/test_<area>.py`.
+- Use plain `test_<behavior>()` functions and explicit return annotations.
+- Prefer small local fakes over network calls or credentials.
+- Use `pytest.raises(..., match=...)` for both error type and meaningful message
+  when the message is contractual.
+- Use `pytest.warns` for fail-open/fail-closed warning behavior.
+- Test boundary values, invalid types, non-finite numbers, and cleanup paths.
+- Add a regression comment or issue reference when the test protects a subtle
+  previously broken invariant.
+- Async tests use `pytest-asyncio`; keep synchronous and asynchronous contracts
+  equivalent.
+
+The pytest configuration promotes `UnpriceableModelWarning` to an error unless
+a test handles it explicitly. Do not suppress it globally.
+
+### TypeScript
+
+- Put tests in `js/test/<area>.test.ts`.
+- Use Vitest's `describe`, `it`, `expect`, and `vi`.
+- Keep fakes local and deterministic.
+- Use `Promise.all` / `Promise.allSettled` to reproduce concurrency behavior,
+  and assert that excess work was actually blocked.
+- Add parity tests when a shared Python/TypeScript behavior or serialized shape
+  changes.
+
+### Test the public contract
+
+Prefer driving behavior through public methods instead of mutating private state.
+Inspect private state only when no public value can prove the invariant—for
+example, verifying that a clamped balance did not hide a leaked reservation.
+
+Examples are part of the tested product surface. Keep them runnable and verify
+important examples through tests when practical.
+
+## Cross-language parity
+
+Python and TypeScript do not have identical feature sets, but shared features
+should agree on:
+
+- validation and fail-closed behavior;
+- boundary and floating-point tolerance semantics;
+- reservation ownership and concurrency guarantees;
+- advisory meaning and defaults;
+- spend-event fields and JSONL schema;
+- pricing resolution and the vendored map; and
+- equivalent documentation examples.
+
+When changing a shared concept, search both trees before editing:
+
+```bash
+rg "concept_name|conceptName" src tests js/src js/test README.md js/README.md
+```
+
+If parity is intentionally not provided, say so in the main README and the
+package-specific documentation instead of implying support.
+
+## User-facing changes
+
+For a public behavior or API change, review all of the following:
+
+- `src/floe_guard/__init__.py` and/or `js/src/index.ts`;
+- the relevant package README;
+- root `README.md` and its adapter matrix;
+- a small runnable example, if the feature benefits from one;
+- `CHANGELOG.md`;
+- package versions; and
+- tests in every affected language.
+
+The changelog follows Keep a Changelog and Semantic Versioning. Python and
+TypeScript versions are independent, and entries identify `py`, `js`, or
+`py + js`. Add user-facing changes under the current `Unreleased` entry and use
+the established `Added`, `Changed`, or `Fixed` sections.
+
+Package source or packaging metadata changes trigger the version guard:
+
+- Python: changes under `src/floe_guard/` or to `pyproject.toml` require a new
+  `pyproject.toml` version unless the PR is deliberately labeled
+  `skip-version-guard`.
+- TypeScript: changes under `js/src/` or to `js/package.json` require a new
+  `js/package.json` version under the same exception.
+
+When bumping Python, keep `src/floe_guard/__init__.py::__version__` in lockstep.
+When bumping npm, update both `js/package.json` and `js/package-lock.json`.
+Publishing is automated after CI succeeds on `main`; do not add ad hoc publish
+steps to a feature contribution.
+
+## Documentation and example style
+
+- Lead with the concrete guarantee or limitation.
+- Use direct language: “raises before the call,” “fails closed,” and “no API
+  key” are preferred over broad marketing claims.
+- Distinguish guaranteed enforcement from advisory or estimate-based behavior.
+- State unsupported cases explicitly.
+- Keep examples small, copyable, and focused on one behavior.
+- Label partial framework snippets as fragments; do not present undefined
+  surrounding objects as a complete runnable program.
+- Preserve the project's terms: “local,” “in-process,” “no telemetry,”
+  “estimate-based,” and “hosted Floe” have specific documented meanings.
+
+## Scope and change discipline
+
+- Prefer small, focused changes with behavior-describing tests.
+- Reuse existing helpers and lifecycle contracts before introducing a parallel
+  abstraction.
+- Avoid unrelated cleanup, renaming, dependency upgrades, or formatting.
+- Preserve backward compatibility unless the change explicitly proposes a
+  breaking release.
+- Open an issue before a large architectural change, as requested in
+  `CONTRIBUTING.md`.
+- Never weaken an existing check merely to make a provider response pass. First
+  establish why the response can be metered safely.
+
+## Verification checklist
+
+Run the checks relevant to the changed surface. Before a full run, focused tests
+are useful while iterating.
+
+### Python
+
+```bash
+python -m pip install -e ".[dev]"
+ruff check .
+ruff format --check .
+pytest -q
+```
+
+If an adapter changed, install its optional extra and run its focused test file.
+Also consider the bare-core contract: optional imports must not break a test run
+with only `.[dev]` installed.
+
+### TypeScript
+
+```bash
+cd js
+npm ci
+npm run build
+npm run typecheck
+npm test
+```
+
+### Repository-wide checks
+
+```bash
+git diff --check
+git diff --exit-code -- src/floe_guard/cost_map.json js/src/cost_map.json
+```
+
+Then review the diff as a maintainer would:
+
+- Is the paid operation blocked before it starts?
+- Can any error, cancellation, or missing-usage path leak a reservation?
+- Can any input make spend appear lower than it is?
+- Does parallel execution preserve the ceiling?
+- Does the bare Python core still import without extras?
+- Are Python and TypeScript still aligned where the feature is shared?
+- Do tests prove the failure path, not only the happy path?
+- Are public exports, docs, changelog, and versions complete?
+- Are limitations described honestly?
+
+## Source-of-truth hierarchy
+
+When this guide and the repository disagree, use this order:
+
+1. tests and CI-enforced behavior;
+2. current implementation contracts and public API;
+3. `CONTRIBUTING.md`, package metadata, and READMEs;
+4. this guide.
+
+Update this document when an accepted contribution establishes a new recurring
+convention. Do not preserve a stale rule merely because it is written here.

--- a/README.md
+++ b/README.md
@@ -450,11 +450,13 @@ from floe_guard.integrations.langchain import budget_guard_callback_handler
 
 guard = BudgetGuard(limit_usd=1.00)
 llm = ChatOpenAI(model="gpt-4o", callbacks=[budget_guard_callback_handler(guard)])
-llm.invoke("hello")            # checks budget before the call, records spend after
+llm.invoke("hello")            # reserves before the call, settles spend after
 ```
 
-The handler checks the budget on LLM start (raising `BudgetExceeded` aborts the
-call before it runs) and records token usage on LLM end.
+The handler reserves each LangChain `run_id` on LLM start, settles its token
+usage on LLM end, and releases the hold on error. Parallel calls therefore
+cannot race through the aggregate or scoped-step ceiling. `BudgetExceeded` or
+`TokenBudgetExceeded` aborts a blocked call before it runs.
 
 ### LangGraph
 
@@ -614,14 +616,13 @@ run) and `record()`s priced usage after — same semantics as the Python guard. 
 ## Voice adapters (STT → LLM → TTS)
 
 A voice pipeline has no single call site to wrap: the LLM sits inside a running
-session and turns fire continuously for the life of a call. So instead of a
-function wrapper, these adapters enforce **per turn** — reserve before the LLM
-call (so a turn is blocked *before* its TTS/audio spend piles on top of a call
-that would already cross the ceiling), settle on the real usage the pipeline
-reports, and release a turn that ends without ever reporting usage (an
-interrupted turn) so the reservation never leaks against the ceiling. The token
-cost map is LLM-only, so STT/TTS spend is metered only when you supply per-unit
-prices. Both voice adapters are **Python-only** today.
+session and turns fire continuously for the life of a call. These adapters
+therefore enforce per turn, but their interception points differ. LiveKit can
+check before entering its LLM node. Pipecat's processor sits after the LLM, so
+it can stop downstream TTS and later pipeline work but cannot prevent the
+current provider charge. The token cost map is LLM-only, so STT/TTS spend is
+metered only when you supply per-unit prices. Both voice adapters are
+**Python-only** today.
 
 ### Pipecat (voice)
 
@@ -630,9 +631,10 @@ pip install floe-guard[pipecat]
 ```
 
 Drop a `FloeBudgetGuardProcessor` into the pipeline directly after the LLM
-service. It reserves on each turn's `LLMFullResponseStartFrame` and settles from
-the `LLMUsageMetricsData` Pipecat emits — so the pipeline's `PipelineTask` must
-be created with `enable_metrics=True, enable_usage_metrics=True`.
+service. It reserves when the already-started turn emits
+`LLMFullResponseStartFrame` and settles from the `LLMUsageMetricsData` Pipecat
+emits — so the pipeline's `PipelineTask` must be created with
+`enable_metrics=True, enable_usage_metrics=True`.
 
 ```python
 from pipecat.pipeline.pipeline import Pipeline
@@ -647,7 +649,7 @@ pipeline = Pipeline([
     stt,
     context_aggregator.user(),
     llm,
-    FloeBudgetGuardProcessor(guard, model="gpt-4o"),   # meters AND hard-stops
+    FloeBudgetGuardProcessor(guard, model="gpt-4o"),   # meters; stops downstream work
     tts,
     transport.output(),
     context_aggregator.assistant(),
@@ -661,9 +663,9 @@ task = PipelineTask(
 > **Fragment** — `transport`, `stt`, `llm`, `tts`, and `context_aggregator` are your existing Pipecat objects; this shows only where the guard sits in a pipeline you already have. For a complete, runnable demo (no API key, no network), see [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
 
 By default a USD- or token-blocked turn pushes a fatal `ErrorFrame` that
-terminates the
-pipeline — the hard-stop every other adapter gives you. Pass an
-`on_budget_exceeded` async callback to speak a graceful "wrapping up" line first
+terminates downstream pipeline work. The current LLM request has already
+started; this prevents TTS and subsequent turns, not that provider charge. Pass
+an `on_budget_exceeded` async callback to speak a graceful "wrapping up" line
 instead of cutting the call dead.
 
 ### LiveKit (voice)
@@ -730,8 +732,9 @@ session. A voice/telephony builder on a Node stack should either drive the LLM
 turn through the Vercel AI middleware and meter STT/TTS spend by hand via
 `recordTool`, or run the LLM leg through the **hosted [Floe proxy](#upgrade-to-hosted-floe)**
 (un-bypassable, cross-vendor) — or use the Python Pipecat / LiveKit adapters
-above, which enforce the whole turn. No native TypeScript Pipecat/LiveKit voice
-adapter ships in this release.
+above. LiveKit checks before its LLM node; Pipecat meters the turn and stops
+downstream work after the LLM starts. No native TypeScript Pipecat/LiveKit
+voice adapter ships in this release.
 
 For wiring floe-guard into an existing voice pipeline, see the Floe docs:
 **[Add Floe to your existing pipeline](https://floe-labs.gitbook.io/docs/getting-started/integrate-existing-pipeline)**.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,58 @@ Everything else — Mistral, Cohere, Ollama, Bedrock, realtime/audio models,
 self-hosted — needs `price_overrides` (or `fail_closed=False` to accept it
 un-metered).
 
+## Token ceilings and per-step budgets
+
+Dollars are not the only useful hard limit. Add `token_limit` to cap aggregate
+LLM tokens across the run; paid tools still consume the shared USD ceiling but
+do not consume tokens:
+
+```python
+from floe_guard import BudgetGuard
+
+guard = BudgetGuard(limit_usd=5.00, token_limit=100_000)
+
+# Size both dimensions before the call. Omitting the token estimate falls back
+# to the previous LLM call's token count (0 on a fresh guard).
+handle = guard.reserve(estimated_cost=0.02, estimated_tokens=4_096)
+response = call_model()
+guard.settle(
+    response.model,
+    response.usage.prompt_tokens,
+    response.usage.completion_tokens,
+    reserved=handle,
+)
+```
+
+`spent_tokens` counts every metered LLM bucket: prompt, completion, cache
+creation, one-hour cache creation, and cache reads. When a projected call would
+cross the token ceiling, `check()` / `reserve()` raises
+`TokenBudgetExceeded` before the provider runs.
+
+Use a scoped step guard for a fresh sub-budget without resetting aggregate
+totals:
+
+```python
+with guard.step(max_usd=0.10, max_tokens=4_000) as step:
+    advisory = step.advisory()
+    model = "flash-model" if advisory.near_limit else "premium-model"
+    handle = step.reserve(estimated_cost=0.01, estimated_tokens=800)
+    response = call_model(model)
+    step.settle(
+        response.model,
+        response.usage.prompt_tokens,
+        response.usage.completion_tokens,
+        reserved=handle,
+    )
+```
+
+The scoped guard is explicit so overlapping agent steps remain isolated; pass
+`step` anywhere an adapter normally receives `guard`. Its advisory adds
+aggregate token utilization plus step USD/token headroom, and the existing
+`near_limit` signal flips when any configured aggregate or step ceiling reaches
+`near_limit_bps`. See [`examples/step_budget.py`](examples/step_budget.py) for a
+no-network router/downshift demo.
+
 ## Context-aware budgeting
 
 The hard-stop is the guarantee; `advisory()` is the *upside*. Read it before a
@@ -195,7 +247,8 @@ result = with_budget_retry(
 The helper does not rank models or know provider pricing; the caller defines
 what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
 `withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
-for a no-network demo.
+for a no-network demo. USD and token budget errors are terminal by default and
+are never retried.
 
 This is the **same advisory shape** hosted Floe returns on every proxied call
 (the `X-Floe-Budget-Advisory` header), so the logic you write here ports
@@ -379,7 +432,8 @@ Prefer the LiteLLM-native callback? Register `budget_guard_callback(guard)` on
 `litellm.callbacks` — but know its limit: LiteLLM runs callbacks inside
 `except Exception`, so the callback's enforcement raise can be swallowed and
 your loop keeps going. The callback records any violation on its `tripped`
-attribute and logs it at ERROR level; consult `tripped` in your own loop, or
+attribute and logs it at ERROR level; USD and token violations both latch.
+Consult `tripped` in your own loop, or
 use `guarded_completion` (which enforces at the call site) for the guaranteed
 stop. Wrapper enforcement is tested against litellm 1.91.x.
 
@@ -606,7 +660,8 @@ task = PipelineTask(
 
 > **Fragment** — `transport`, `stt`, `llm`, `tts`, and `context_aggregator` are your existing Pipecat objects; this shows only where the guard sits in a pipeline you already have. For a complete, runnable demo (no API key, no network), see [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
 
-By default a blocked turn pushes a fatal `ErrorFrame` that terminates the
+By default a USD- or token-blocked turn pushes a fatal `ErrorFrame` that
+terminates the
 pipeline — the hard-stop every other adapter gives you. Pass an
 `on_budget_exceeded` async callback to speak a graceful "wrapping up" line first
 instead of cutting the call dead.
@@ -643,7 +698,8 @@ await session.start(agent=agent, room=ctx.room)
 
 Pass `stt_usd_per_second` / `tts_usd_per_1k_chars` to also meter STT/TTS spend
 (often a voice agent's larger bill) via `record_tool`, and an `on_budget_exceeded`
-async callback to speak a wrap-up line before a turn ends. See
+async callback to handle either a USD or token block and speak a wrap-up line
+before a turn ends. See
 [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
 
 ## Adapter matrix

--- a/examples/step_budget.py
+++ b/examples/step_budget.py
@@ -1,0 +1,41 @@
+"""Per-step token budget demo — no API key, account, or network.
+
+Run with:
+
+    python examples/step_budget.py
+
+The router sees a step at 80% token utilization, downshifts to a cheaper model,
+then the hard guard blocks a request that still cannot fit in the step.
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetGuard, ManualPrice, TokenBudgetExceeded
+
+PRICE = ManualPrice(input_cost_per_token=1e-6, output_cost_per_token=2e-6)
+
+
+def main() -> None:
+    guard = BudgetGuard(limit_usd=1.00, token_limit=1_000)
+
+    with guard.step(max_usd=0.10, max_tokens=100) as step:
+        # Work already completed in this agent step.
+        step.record("demo-model", 60, 20, price=PRICE)
+        advisory = step.advisory()
+        model = "flash-model" if advisory.near_limit else "premium-model"
+        print(
+            f"step tokens: {advisory.step_spent_tokens}/"
+            f"{advisory.step_token_limit}; router chose {model}"
+        )
+
+        try:
+            step.check(estimated_next_cost=0.001, estimated_next_tokens=25)
+        except TokenBudgetExceeded as exc:
+            print(exc)
+            print("provider was not called")
+
+    print(f"aggregate tokens remain recorded: {guard.spent_tokens}")
+
+
+if __name__ == "__main__":
+    main()

--- a/js/README.md
+++ b/js/README.md
@@ -50,6 +50,47 @@ const guard = new BudgetGuard(5.0, {
 });
 ```
 
+## Token ceilings and per-step budgets
+
+Add `tokenLimit` to enforce aggregate LLM tokens alongside dollars:
+
+```ts
+const guard = new BudgetGuard(5.0, { tokenLimit: 100_000 });
+const handle = guard.reserve(0.02, 4_096);
+const response = await callModel();
+guard.settle(response.model, response.promptTokens, response.completionTokens, {
+  reserved: handle,
+});
+```
+
+An omitted token estimate falls back to the previous LLM call's token count
+(`0` on a fresh guard). A projected crossing throws `TokenBudgetExceeded`
+before the provider runs. Tool calls consume USD, not tokens.
+
+Use `step()` for a fresh scoped sub-budget while retaining aggregate totals:
+
+```ts
+await guard.step({ maxUsd: 0.1, maxTokens: 4_000 }, async (step) => {
+  const advisory = step.advisory();
+  const model = advisory.nearLimit ? flashModel : premiumModel;
+  const handle = step.reserve(0.01, 800);
+  const response = await callModel(model);
+  step.settle(response.model, response.promptTokens, response.completionTokens, {
+    reserved: handle,
+  });
+});
+```
+
+The callback receives an explicit scoped guard, so overlapping steps stay
+isolated without Node-only async-context APIs. Pass it directly to
+`budgetGuardMiddleware(step)`. Advisory fields include aggregate token
+utilization and step USD/token headroom; `nearLimit` reflects the tightest
+configured aggregate or step ceiling. `advisory()` always returns the complete
+token/step shape; those additive fields are optional in the TypeScript interface
+only so existing aggregate-only advisory literals remain source-compatible.
+The step stays active until returned promise-like work settles, and a rejected
+callback propagates its original error.
+
 ## Context-aware budgeting
 
 `guard.advisory()` returns a soft signal you can act on before a call — `nearLimit`,

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "ai": "^4.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -26,14 +26,46 @@ export class FloeGuardError extends Error {
 export class BudgetExceeded extends FloeGuardError {
   readonly spentUsd: number;
   readonly limitUsd: number;
+  readonly scope: "aggregate" | "step";
 
-  constructor(spentUsd: number, limitUsd: number) {
+  constructor(
+    spentUsd: number,
+    limitUsd: number,
+    scope: "aggregate" | "step" = "aggregate",
+  ) {
+    const prefix = scope === "step" ? "STEP BUDGET EXCEEDED" : "BUDGET EXCEEDED";
     super(
-      `BUDGET EXCEEDED — call blocked (spent $${spentUsd.toFixed(6)} of $${limitUsd.toFixed(6)} ceiling)`,
+      `${prefix} — call blocked ` +
+        `(spent $${spentUsd.toFixed(6)} of $${limitUsd.toFixed(6)} ceiling)`,
     );
     this.name = "BudgetExceeded";
     this.spentUsd = spentUsd;
     this.limitUsd = limitUsd;
+    this.scope = scope;
+  }
+}
+
+/** Thrown before an LLM call that would cross a token ceiling. */
+export class TokenBudgetExceeded extends FloeGuardError {
+  readonly spentTokens: number;
+  readonly limitTokens: number;
+  readonly scope: "aggregate" | "step";
+
+  constructor(
+    spentTokens: number,
+    limitTokens: number,
+    scope: "aggregate" | "step" = "aggregate",
+  ) {
+    const prefix =
+      scope === "step" ? "STEP TOKEN BUDGET EXCEEDED" : "TOKEN BUDGET EXCEEDED";
+    super(
+      `${prefix} — call blocked ` +
+        `(spent ${spentTokens} of ${limitTokens} token ceiling)`,
+    );
+    this.name = "TokenBudgetExceeded";
+    this.spentTokens = spentTokens;
+    this.limitTokens = limitTokens;
+    this.scope = scope;
   }
 }
 

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -621,7 +621,14 @@ export class BudgetGuard<
       state.active = false;
       throw error;
     }
-    if (isPromiseLike(result)) {
+    let promiseLike: boolean;
+    try {
+      promiseLike = isPromiseLike(result);
+    } catch (error) {
+      state.active = false;
+      throw error;
+    }
+    if (promiseLike) {
       return Promise.resolve(result).then(
         (value) => {
           this.closeStep(state);

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -23,7 +23,11 @@
  * same epsilon handling, same fail-closed default.
  */
 
-import { BudgetExceeded, UnpriceableModelError } from "./errors.js";
+import {
+  BudgetExceeded,
+  TokenBudgetExceeded,
+  UnpriceableModelError,
+} from "./errors.js";
 import {
   type ManualPrice,
   priceTokens,
@@ -32,6 +36,47 @@ import {
 
 /** Tolerance for float rounding in the running spend total (well below $0.000001). */
 const EPS = 1e-12;
+
+interface StepState {
+  limitUsd: number | null;
+  tokenLimit: number | null;
+  spentUsd: number;
+  spentTokens: number;
+  reservedUsd: number;
+  reservedTokens: number;
+  active: boolean;
+}
+
+interface ReservationParts {
+  usd: number;
+  tokens: number;
+  step: StepState | null;
+}
+
+type BlockingLimit = {
+  metric: "usd" | "tokens";
+  scope: "aggregate" | "step";
+  spent: number;
+  limit: number;
+};
+
+export interface BudgetReservation {
+  readonly usd: number;
+  readonly tokens: number;
+  /** @internal */
+  _owner: BudgetGuard<number | undefined>;
+  /** @internal */
+  _step: StepState | null;
+  /** @internal */
+  _active: boolean;
+}
+
+export type ReservationHandle = number | BudgetReservation;
+
+export interface StepBudgetOptions {
+  maxUsd?: number;
+  maxTokens?: number;
+}
 
 /**
  * One priced spend event in the guard's per-call ledger.
@@ -61,7 +106,11 @@ export interface SpendEvent {
   readonly reserved?: number;
 }
 
-export interface BudgetGuardOptions {
+export interface BudgetGuardOptions<
+  TokenLimit extends number | undefined = number | undefined,
+> {
+  /** Optional aggregate token ceiling. */
+  tokenLimit?: TokenLimit;
   /** Per-model manual prices for models the bundled cost map cannot price. */
   priceOverrides?: Record<string, ManualPrice>;
   /**
@@ -76,6 +125,8 @@ export interface BudgetGuardOptions {
    * `BUDGET EXCEEDED — call blocked` banner to stderr.
    */
   onBlock?: (spentUsd: number, limitUsd: number) => void;
+  /** Callback invoked immediately before a token ceiling blocks a call. */
+  onTokenBlock?: (spentTokens: number, limitTokens: number) => void;
   /**
    * Utilization (basis points, 0..10000) at which {@link BudgetGuard.advisory}
    * flags `nearLimit` so an agent can taper before the hard-stop. Default 8000.
@@ -129,16 +180,35 @@ export interface BudgetAdvisory {
    * expectedCost; `advisory()` always sets it.
    */
   estCallsRemaining?: number | null;
+  /** Token and step fields are always set by advisory(); optional for additive compatibility. */
+  tokenLimit?: number | null;
+  spentTokens?: number;
+  remainingTokens?: number | null;
+  tokenUsedBps?: number | null;
+  nearTokenLimit?: boolean;
+  stepLimitUsd?: number | null;
+  stepSpentUsd?: number | null;
+  stepRemainingUsd?: number | null;
+  stepTokenLimit?: number | null;
+  stepSpentTokens?: number | null;
+  stepRemainingTokens?: number | null;
+  stepUsedBps?: number | null;
+  stepNearLimit?: boolean;
 }
 
-export class BudgetGuard {
+export class BudgetGuard<
+  TokenLimit extends number | undefined = undefined,
+> {
   readonly limitUsd: number;
+  readonly tokenLimit: number | null;
   spentUsd = 0;
+  spentTokens = 0;
   priceOverrides?: Record<string, ManualPrice>;
   failClosed: boolean;
   nearLimitBps: number;
 
   private readonly onBlock: (spentUsd: number, limitUsd: number) => void;
+  private readonly onTokenBlock: (spentTokens: number, limitTokens: number) => void;
   /**
    * Costs of the most recent priced LLM call and tool call, tracked
    * SEPARATELY: the default next-call prediction is the max of the two, so a
@@ -147,8 +217,10 @@ export class BudgetGuard {
    */
   private lastLlmCost = 0;
   private lastToolCost = 0;
+  private lastLlmTokens = 0;
   /** USD held for in-flight calls (reserved, not yet settled). Counts toward the ceiling. */
   private reserved = 0;
+  private reservedTokens = 0;
   /** Per-call ledger, oldest first; a ring buffer when maxLogEvents is set. */
   private readonly spendEvents: SpendEvent[] = [];
   private readonly maxLogEvents?: number;
@@ -163,7 +235,10 @@ export class BudgetGuard {
   /**
    * @param limitUsd the spend ceiling, in USD. `0` blocks the very first call.
    */
-  constructor(limitUsd: number, options: BudgetGuardOptions = {}) {
+  constructor(
+    limitUsd: number,
+    options: BudgetGuardOptions<TokenLimit> = {} as BudgetGuardOptions<TokenLimit>,
+  ) {
     if (!Number.isFinite(limitUsd) || limitUsd < 0) {
       // NaN/Infinity would make every check() comparison fail-open, silently
       // disabling the guard — reject them up front.
@@ -171,6 +246,7 @@ export class BudgetGuard {
         `limitUsd must be a finite, non-negative number, got ${limitUsd}`,
       );
     }
+    validateOptionalTokens("tokenLimit", options.tokenLimit);
     // `=== undefined` (not `??`) so an explicit null is rejected by validation
     // rather than silently defaulting — matches Python, which rejects None.
     const nearLimitBps = options.nearLimitBps === undefined ? 8000 : options.nearLimitBps;
@@ -188,10 +264,12 @@ export class BudgetGuard {
       );
     }
     this.limitUsd = limitUsd;
+    this.tokenLimit = options.tokenLimit ?? null;
     this.maxLogEvents = options.maxLogEvents;
     this.priceOverrides = options.priceOverrides;
     this.failClosed = options.failClosed ?? true;
     this.onBlock = options.onBlock ?? defaultOnBlock;
+    this.onTokenBlock = options.onTokenBlock ?? defaultOnTokenBlock;
     this.nearLimitBps = nearLimitBps;
   }
 
@@ -208,22 +286,8 @@ export class BudgetGuard {
    * Note: `check` is a non-binding peek. For parallel calls, use `reserve()` /
    * `settle()`, which hold the estimate across the await.
    */
-  check(estimatedNextCost?: number): void {
-    const rawEstimate =
-      estimatedNextCost === undefined ? this.defaultEstimate() : estimatedNextCost;
-    if (!Number.isFinite(rawEstimate)) {
-      // NaN/Infinity would poison the comparisons and fail-open — reject it
-      // (parity with the constructor's Number.isFinite guard).
-      throw new RangeError(
-        `estimatedNextCost must be a finite number, got ${rawEstimate}`,
-      );
-    }
-    const estimate = Math.max(0, rawEstimate);
-    const committed = this.spentUsd + this.reserved;
-    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
-      this.onBlock(this.spentUsd, this.limitUsd);
-      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
-    }
+  check(estimatedNextCost?: number, estimatedNextTokens?: number): void {
+    this.checkForStep(estimatedNextCost, estimatedNextTokens, null);
   }
 
   /**
@@ -237,22 +301,15 @@ export class BudgetGuard {
    * `estimatedCost` defaults to the costlier of the last LLM call and the last
    * tool call.
    */
-  reserve(estimatedCost?: number): number {
-    const rawEstimate = estimatedCost === undefined ? this.defaultEstimate() : estimatedCost;
-    if (!Number.isFinite(rawEstimate)) {
-      // NaN would poison this.reserved and fail-open the ceiling — reject it.
-      throw new RangeError(
-        `estimatedCost must be a finite number, got ${rawEstimate}`,
-      );
-    }
-    const estimate = Math.max(0, rawEstimate);
-    const committed = this.spentUsd + this.reserved;
-    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
-      this.onBlock(this.spentUsd, this.limitUsd);
-      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
-    }
-    this.reserved += estimate;
-    return estimate;
+  reserve(
+    estimatedCost?: number,
+  ): TokenLimit extends number ? BudgetReservation : number;
+  reserve(
+    estimatedCost: number | undefined,
+    estimatedTokens: number,
+  ): TokenLimit extends number ? BudgetReservation : number;
+  reserve(estimatedCost?: number, estimatedTokens?: number): ReservationHandle {
+    return this.reserveForStep(estimatedCost, estimatedTokens, null);
   }
 
   /**
@@ -268,13 +325,16 @@ export class BudgetGuard {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { reserved?: number; price?: ManualPrice; label?: string } = {},
+    options: { reserved?: ReservationHandle; price?: ManualPrice; label?: string } = {},
   ): number {
     const reserved = options.reserved ?? 0;
-    // A bad reserved handle would corrupt this.reserved and break the ceiling for
-    // OTHER in-flight calls (negative → phantom hold; Infinity → clears all holds).
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
+    const parts = this.reservationParts(reserved);
+    let totalTokens: number;
+    try {
+      totalTokens = actualTokenCount(promptTokens, completionTokens);
+    } catch (error) {
+      this.release(reserved);
+      throw error;
     }
     let overrides = this.priceOverrides;
     if (options.price !== undefined) {
@@ -283,15 +343,13 @@ export class BudgetGuard {
 
     const priced = resolvePrice(model, overrides);
     if (priced === null) {
+      this.consumeHandle(reserved, parts);
+      this.accrueTokens(totalTokens, parts.step);
       console.warn(
         `Cannot price model '${model}': not in the bundled cost map and no ` +
           `manual price given. The budget guard cannot enforce a ceiling on ` +
           `spend it cannot measure — pass { price } or set it in priceOverrides.`,
       );
-      // Release any held reservation on BOTH paths. Fail-closed must not leak
-      // the in-flight hold, or reserved grows permanently and remainingUsd
-      // shrinks until reserve() starts blocking everything.
-      this.release(reserved);
       if (this.failClosed) {
         throw new UnpriceableModelError(model);
       }
@@ -308,16 +366,18 @@ export class BudgetGuard {
       this.release(reserved);
       throw err;
     }
-    if (reserved) {
-      this.consumeReservation(reserved);
-    }
+    this.consumeHandle(reserved, parts);
     this.spentUsd += cost;
+    this.accrueTokens(totalTokens, parts.step);
     // Clamp a sub-epsilon float overshoot back to the limit so the running total
     // never reports as having crossed the ceiling by a rounding artifact.
     if (this.spentUsd - this.limitUsd > 0 && this.spentUsd - this.limitUsd < EPS) {
       this.spentUsd = this.limitUsd;
     }
     this.lastLlmCost = cost;
+    if (parts.step !== null) {
+      parts.step.spentUsd += cost;
+    }
     this.appendEvent({
       timestamp: Date.now() / 1000,
       kind: "llm",
@@ -328,7 +388,7 @@ export class BudgetGuard {
       ...(options.label !== undefined ? { label: options.label } : {}),
       // 0 means "no reservation" (the plain record() path) — omit rather than
       // log a meaningless zero.
-      ...(reserved ? { reserved } : {}),
+      ...(parts.usd ? { reserved: parts.usd } : {}),
     });
     return cost;
   }
@@ -370,7 +430,9 @@ export class BudgetGuard {
    * worth falling back to. Pass the returned handle to
    * {@link BudgetGuard.settleTool}, or {@link BudgetGuard.release} on failure.
    */
-  reserveTool(estimatedCost: number): number {
+  reserveTool(
+    estimatedCost: number,
+  ): TokenLimit extends number ? BudgetReservation : number {
     if (estimatedCost === undefined) {
       // reserve(undefined) would silently fall back to the last-cost prediction
       // (0 on a fresh guard) — an unguarded tool call. A missing price must
@@ -384,7 +446,12 @@ export class BudgetGuard {
         `estimatedCost must be a finite, non-negative number, got ${estimatedCost}`,
       );
     }
-    return this.reserve(estimatedCost);
+    return this.reserveForStep(
+      estimatedCost,
+      0,
+      null,
+      false,
+    ) as TokenLimit extends number ? BudgetReservation : number;
   }
 
   /**
@@ -404,21 +471,16 @@ export class BudgetGuard {
   settleTool(
     tool: string,
     costUsd: number,
-    options: { reserved?: number; label?: string } = {},
+    options: { reserved?: ReservationHandle; label?: string } = {},
   ): number {
     if (!Number.isFinite(costUsd) || costUsd < 0) {
       throw new RangeError(`costUsd must be a finite, non-negative number, got ${costUsd}`);
     }
     const reserved = options.reserved ?? 0;
-    // A bad reserved handle would corrupt the in-flight tally and break the
-    // ceiling for OTHER calls — same contract as settle().
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
-    }
-    if (reserved) {
-      this.consumeReservation(reserved);
-    }
+    const parts = this.reservationParts(reserved);
+    this.consumeHandle(reserved, parts);
     this.spentUsd += costUsd;
+    if (parts.step !== null) parts.step.spentUsd += costUsd;
     // Same sub-epsilon clamp as settle(): never report a rounding-artifact
     // crossing of the ceiling.
     if (this.spentUsd - this.limitUsd > 0 && this.spentUsd - this.limitUsd < EPS) {
@@ -434,7 +496,7 @@ export class BudgetGuard {
       completionTokens: null,
       costUsd,
       ...(options.label !== undefined ? { label: options.label } : {}),
-      ...(reserved ? { reserved } : {}),
+      ...(parts.usd ? { reserved: parts.usd } : {}),
     });
     return costUsd;
   }
@@ -455,19 +517,23 @@ export class BudgetGuard {
    * Drop an in-flight reservation without recording spend (e.g. the call failed
    * before producing usage). Safe to call with `0`.
    */
-  release(reserved: number): void {
+  release(reserved: ReservationHandle): void {
     // Validate before the zero-check so a NaN handle throws instead of being
     // silently dropped (a leak); a bad handle corrupts the in-flight tally.
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
-    }
-    if (!reserved) return;
-    this.consumeReservation(reserved);
+    const parts = this.reservationParts(reserved);
+    this.consumeHandle(reserved, parts);
   }
 
   /** USD left before the ceiling, net of in-flight reservations (never negative). */
   get remainingUsd(): number {
     return Math.max(0, this.limitUsd - this.spentUsd - this.reserved);
+  }
+
+  /** Tokens left before the aggregate ceiling, net of in-flight reservations. */
+  get remainingTokens(): number | null {
+    return this.tokenLimit === null
+      ? null
+      : Math.max(0, this.tokenLimit - this.spentTokens - this.reservedTokens);
   }
 
   /**
@@ -516,6 +582,249 @@ export class BudgetGuard {
         return `${JSON.stringify(row)}\n`;
       })
       .join("");
+  }
+
+  /**
+   * Run work through a fresh explicit per-step guard. The callback may be sync
+   * or async; overlapping steps remain isolated while sharing aggregate totals.
+   */
+  step<T>(
+    options: StepBudgetOptions,
+    callback: (step: StepBudgetGuard) => T,
+  ): T {
+    if (options.maxUsd === undefined && options.maxTokens === undefined) {
+      throw new RangeError("step requires maxUsd, maxTokens, or both");
+    }
+    if (
+      options.maxUsd !== undefined &&
+      (!Number.isFinite(options.maxUsd) || options.maxUsd < 0)
+    ) {
+      throw new RangeError(
+        `maxUsd must be a finite, non-negative number, got ${options.maxUsd}`,
+      );
+    }
+    validateOptionalTokens("maxTokens", options.maxTokens);
+    const state: StepState = {
+      limitUsd: options.maxUsd ?? null,
+      tokenLimit: options.maxTokens ?? null,
+      spentUsd: 0,
+      spentTokens: 0,
+      reservedUsd: 0,
+      reservedTokens: 0,
+      active: true,
+    };
+    const scoped = new StepBudgetGuard(this, state);
+    let result: T;
+    try {
+      result = callback(scoped);
+    } catch (error) {
+      state.active = false;
+      throw error;
+    }
+    if (isPromiseLike(result)) {
+      return Promise.resolve(result).then(
+        (value) => {
+          this.closeStep(state);
+          return value;
+        },
+        (error) => {
+          state.active = false;
+          throw error;
+        },
+      ) as T;
+    }
+    this.closeStep(state);
+    return result;
+  }
+
+  checkForStep(
+    estimatedCost: number | undefined,
+    estimatedTokens: number | undefined,
+    step: StepState | null,
+  ): void {
+    const cost = this.normalizedCostEstimate(estimatedCost);
+    const tokens = this.normalizedTokenEstimate(estimatedTokens);
+    const blocked = this.blockingLimit(cost, tokens, step);
+    if (blocked !== null) this.raiseBlock(blocked);
+  }
+
+  reserveForStep(
+    estimatedCost: number | undefined,
+    estimatedTokens: number | undefined,
+    step: StepState | null,
+    enforceTokens = true,
+  ): ReservationHandle {
+    if (step !== null && !step.active) {
+      throw new Error("step budget is no longer active");
+    }
+    const cost = this.normalizedCostEstimate(estimatedCost);
+    const tokens = this.normalizedTokenEstimate(estimatedTokens);
+    const blocked = this.blockingLimit(cost, tokens, step, enforceTokens);
+    if (blocked !== null) this.raiseBlock(blocked);
+    this.reserved += cost;
+    this.reservedTokens += tokens;
+    if (step !== null) {
+      step.reservedUsd += cost;
+      step.reservedTokens += tokens;
+    }
+    if (this.tokenLimit === null && step === null) return cost;
+    return { usd: cost, tokens, _owner: this, _step: step, _active: true };
+  }
+
+  private normalizedCostEstimate(estimate: number | undefined): number {
+    const raw = estimate === undefined ? this.defaultEstimate() : estimate;
+    if (!Number.isFinite(raw)) {
+      throw new RangeError(`estimated cost must be a finite number, got ${raw}`);
+    }
+    return Math.max(0, raw);
+  }
+
+  private normalizedTokenEstimate(estimate: number | undefined): number {
+    validateOptionalTokens("estimated tokens", estimate);
+    return estimate === undefined ? this.lastLlmTokens : estimate;
+  }
+
+  private blockingLimit(
+    cost: number,
+    tokens: number,
+    step: StepState | null,
+    enforceTokens = true,
+  ): BlockingLimit | null {
+    const committedUsd = this.spentUsd + this.reserved;
+    if (
+      committedUsd > this.limitUsd - EPS ||
+      committedUsd + cost > this.limitUsd + EPS
+    ) {
+      return {
+        metric: "usd",
+        scope: "aggregate",
+        spent: this.spentUsd,
+        limit: this.limitUsd,
+      };
+    }
+    const committedTokens = this.spentTokens + this.reservedTokens;
+    if (
+      enforceTokens &&
+      this.tokenLimit !== null &&
+      (committedTokens >= this.tokenLimit ||
+        committedTokens + tokens > this.tokenLimit)
+    ) {
+      return {
+        metric: "tokens",
+        scope: "aggregate",
+        spent: this.spentTokens,
+        limit: this.tokenLimit,
+      };
+    }
+    if (step !== null) {
+      const stepUsd = step.spentUsd + step.reservedUsd;
+      if (
+        step.limitUsd !== null &&
+        (stepUsd > step.limitUsd - EPS || stepUsd + cost > step.limitUsd + EPS)
+      ) {
+        return {
+          metric: "usd",
+          scope: "step",
+          spent: step.spentUsd,
+          limit: step.limitUsd,
+        };
+      }
+      const stepTokens = step.spentTokens + step.reservedTokens;
+      if (
+        enforceTokens &&
+        step.tokenLimit !== null &&
+        (stepTokens >= step.tokenLimit ||
+          stepTokens + tokens > step.tokenLimit)
+      ) {
+        return {
+          metric: "tokens",
+          scope: "step",
+          spent: step.spentTokens,
+          limit: step.tokenLimit,
+        };
+      }
+    }
+    return null;
+  }
+
+  private raiseBlock(blocked: BlockingLimit): never {
+    if (blocked.metric === "usd") {
+      this.onBlock(blocked.spent, blocked.limit);
+      throw new BudgetExceeded(blocked.spent, blocked.limit, blocked.scope);
+    }
+    this.onTokenBlock(blocked.spent, blocked.limit);
+    throw new TokenBudgetExceeded(
+      blocked.spent,
+      blocked.limit,
+      blocked.scope,
+    );
+  }
+
+  private reservationParts(handle: ReservationHandle): ReservationParts {
+    if (typeof handle === "number") {
+      if (!Number.isFinite(handle) || handle < 0) {
+        throw new RangeError(
+          `reserved must be a finite, non-negative number, got ${handle}`,
+        );
+      }
+      return { usd: handle, tokens: 0, step: null };
+    }
+    if (handle._owner !== this) {
+      throw new RangeError("reservation belongs to a different BudgetGuard");
+    }
+    if (!handle._active) {
+      throw new RangeError("reservation has already been settled or released");
+    }
+    if (
+      !Number.isFinite(handle.usd) ||
+      handle.usd < 0 ||
+      !Number.isInteger(handle.tokens) ||
+      handle.tokens < 0
+    ) {
+      throw new RangeError("reservation contains invalid USD or token values");
+    }
+    return { usd: handle.usd, tokens: handle.tokens, step: handle._step };
+  }
+
+  private consumeHandle(
+    handle: ReservationHandle,
+    parts: ReservationParts,
+  ): void {
+    if (
+      parts.usd > this.reserved + EPS ||
+      parts.tokens > this.reservedTokens
+    ) {
+      throw new RangeError("reservation exceeds total in-flight reservations");
+    }
+    if (
+      parts.step !== null &&
+      (parts.usd > parts.step.reservedUsd + EPS ||
+        parts.tokens > parts.step.reservedTokens)
+    ) {
+      throw new RangeError("reservation exceeds its step's in-flight totals");
+    }
+    this.consumeReservation(parts.usd);
+    this.reservedTokens -= parts.tokens;
+    if (parts.step !== null) {
+      parts.step.reservedUsd = Math.max(0, parts.step.reservedUsd - parts.usd);
+      parts.step.reservedTokens -= parts.tokens;
+    }
+    if (typeof handle !== "number") handle._active = false;
+  }
+
+  private accrueTokens(tokens: number, step: StepState | null): void {
+    this.spentTokens += tokens;
+    this.lastLlmTokens = tokens;
+    if (step !== null) step.spentTokens += tokens;
+  }
+
+  private closeStep(step: StepState): void {
+    step.active = false;
+    if (step.reservedUsd > EPS || step.reservedTokens > 0) {
+      throw new Error(
+        "step exited with an active reservation; settle or release every handle",
+      );
+    }
   }
 
   /**
@@ -568,6 +877,10 @@ export class BudgetGuard {
    * {@link BudgetGuard.check} is what enforces the ceiling.
    */
   advisory(): BudgetAdvisory {
+    return this.advisoryForStep(null);
+  }
+
+  advisoryForStep(step: StepState | null): BudgetAdvisory {
     // Floor (not round) so usedBps never over-reports utilization and nearLimit
     // flips exactly when the threshold is reached; the epsilon absorbs float noise
     // and Math.floor matches Python's int() exactly (round() would diverge).
@@ -576,6 +889,30 @@ export class BudgetGuard {
         ? 10000
         : Math.max(0, Math.min(10000, Math.floor((this.spentUsd / this.limitUsd) * 10000 + 1e-9)));
     const remainingUsd = Math.max(0, this.limitUsd - this.spentUsd);
+    const tokenUsedBps =
+      this.tokenLimit === null
+        ? null
+        : usedBasisPoints(this.spentTokens, this.tokenLimit);
+    const remainingTokens =
+      this.tokenLimit === null
+        ? null
+        : Math.max(0, this.tokenLimit - this.spentTokens);
+    const nearTokenLimit =
+      tokenUsedBps !== null && tokenUsedBps >= this.nearLimitBps;
+    const stepUsdBps =
+      step?.limitUsd != null
+        ? usedBasisPoints(step.spentUsd, step.limitUsd)
+        : null;
+    const stepTokenBps =
+      step?.tokenLimit != null
+        ? usedBasisPoints(step.spentTokens, step.tokenLimit)
+        : null;
+    const stepUsedBps =
+      step === null
+        ? null
+        : Math.max(...[stepUsdBps, stepTokenBps].filter((v): v is number => v !== null));
+    const stepNearLimit =
+      stepUsedBps !== null && stepUsedBps >= this.nearLimitBps;
     // The costlier of the last LLM and tool call — the guard's own default
     // reservation estimate; 0 before any call is recorded.
     const expectedCost = Math.max(this.lastLlmCost, this.lastToolCost);
@@ -584,7 +921,8 @@ export class BudgetGuard {
     const estCallsRemaining =
       expectedCost > 0 ? Math.floor(remainingUsd / expectedCost + 1e-9) : null;
     return {
-      nearLimit: usedBps >= this.nearLimitBps,
+      nearLimit:
+        usedBps >= this.nearLimitBps || nearTokenLimit || stepNearLimit,
       usedBps,
       // Settled budget: limit minus accrued spend, deliberately NOT net of
       // in-flight reservations. Unlike the remainingUsd getter (which subtracts
@@ -596,8 +934,147 @@ export class BudgetGuard {
       scope: "local",
       expectedCost,
       estCallsRemaining,
+      tokenLimit: this.tokenLimit,
+      spentTokens: this.spentTokens,
+      remainingTokens,
+      tokenUsedBps,
+      nearTokenLimit,
+      stepLimitUsd: step?.limitUsd ?? null,
+      stepSpentUsd: step?.spentUsd ?? null,
+      stepRemainingUsd:
+        step?.limitUsd != null
+          ? Math.max(0, step.limitUsd - step.spentUsd)
+          : null,
+      stepTokenLimit: step?.tokenLimit ?? null,
+      stepSpentTokens: step?.spentTokens ?? null,
+      stepRemainingTokens:
+        step?.tokenLimit != null
+          ? Math.max(0, step.tokenLimit - step.spentTokens)
+          : null,
+      stepUsedBps,
+      stepNearLimit,
     };
   }
+}
+
+/** Scoped view over a parent guard with independent per-step ceilings. */
+export class StepBudgetGuard {
+  constructor(
+    private readonly parent: BudgetGuard<number | undefined>,
+    private readonly state: StepState,
+  ) {}
+
+  get limitUsd(): number { return this.parent.limitUsd; }
+  get tokenLimit(): number | null { return this.parent.tokenLimit; }
+  get spentUsd(): number { return this.parent.spentUsd; }
+  get spentTokens(): number { return this.parent.spentTokens; }
+  get remainingUsd(): number { return this.parent.remainingUsd; }
+  get remainingTokens(): number | null { return this.parent.remainingTokens; }
+  get priceOverrides(): Record<string, ManualPrice> | undefined {
+    return this.parent.priceOverrides;
+  }
+  get failClosed(): boolean { return this.parent.failClosed; }
+
+  check(estimatedCost?: number, estimatedTokens?: number): void {
+    this.ensureActive();
+    this.parent.checkForStep(estimatedCost, estimatedTokens, this.state);
+  }
+
+  reserve(estimatedCost?: number, estimatedTokens?: number): ReservationHandle {
+    this.ensureActive();
+    return this.parent.reserveForStep(estimatedCost, estimatedTokens, this.state);
+  }
+
+  settle(
+    model: string,
+    promptTokens: number,
+    completionTokens: number,
+    options: { reserved?: ReservationHandle; price?: ManualPrice; label?: string } = {},
+  ): number {
+    this.ensureActive();
+    const reserved =
+      options.reserved ??
+      {
+        usd: 0,
+        tokens: 0,
+        _owner: this.parent,
+        _step: this.state,
+        _active: true,
+      };
+    return this.parent.settle(model, promptTokens, completionTokens, {
+      ...options,
+      reserved,
+    });
+  }
+
+  record(
+    model: string,
+    promptTokens: number,
+    completionTokens: number,
+    options: { price?: ManualPrice; label?: string } = {},
+  ): number {
+    return this.settle(model, promptTokens, completionTokens, options);
+  }
+
+  reserveTool(estimatedCost: number): ReservationHandle {
+    this.ensureActive();
+    return this.parent.reserveForStep(estimatedCost, 0, this.state, false);
+  }
+
+  settleTool(
+    tool: string,
+    costUsd: number,
+    options: { reserved?: ReservationHandle; label?: string } = {},
+  ): number {
+    this.ensureActive();
+    const reserved =
+      options.reserved ??
+      {
+        usd: 0,
+        tokens: 0,
+        _owner: this.parent,
+        _step: this.state,
+        _active: true,
+      };
+    return this.parent.settleTool(tool, costUsd, { ...options, reserved });
+  }
+
+  recordTool(tool: string, costUsd: number, options: { label?: string } = {}): number {
+    return this.settleTool(tool, costUsd, options);
+  }
+
+  release(reserved: ReservationHandle): void {
+    this.parent.release(reserved);
+  }
+
+  advisory(): BudgetAdvisory {
+    return this.parent.advisoryForStep(this.state);
+  }
+
+  private ensureActive(): void {
+    if (!this.state.active) throw new Error("step budget is no longer active");
+  }
+}
+
+function usedBasisPoints(used: number, limit: number): number {
+  if (limit <= 0) return 10000;
+  return Math.max(0, Math.min(10000, Math.floor((used / limit) * 10000 + 1e-9)));
+}
+
+function validateOptionalTokens(name: string, value: number | undefined): void {
+  if (
+    value !== undefined &&
+    (!Number.isInteger(value) || !Number.isFinite(value) || value < 0)
+  ) {
+    throw new RangeError(`${name} must be a non-negative integer, got ${value}`);
+  }
+}
+
+function actualTokenCount(promptTokens: number, completionTokens: number): number {
+  if (!Number.isFinite(promptTokens) || !Number.isFinite(completionTokens)) {
+    throw new RangeError("token counts must be finite numbers");
+  }
+  return Math.trunc(Math.max(0, promptTokens)) + Math.trunc(Math.max(0, completionTokens));
 }
 
 function defaultOnBlock(spentUsd: number, limitUsd: number): void {
@@ -607,4 +1084,23 @@ function defaultOnBlock(spentUsd: number, limitUsd: number): void {
       "  The next call would cross your budget; floe-guard stopped your agent " +
       "before it ran.",
   );
+}
+
+function defaultOnTokenBlock(spentTokens: number, limitTokens: number): void {
+  console.error(
+    "TOKEN BUDGET EXCEEDED — call blocked\n" +
+      `  tokens so far: ${spentTokens}  |  ceiling: ${limitTokens}\n` +
+      "  The next call would cross your token budget; floe-guard stopped your " +
+      "agent before it ran.",
+  );
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    return false;
+  }
+  return typeof (value as { then?: unknown }).then === "function";
 }

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -735,16 +735,23 @@ export class BudgetGuard<
     }
     const cost = this.normalizedCostEstimate(estimatedCost);
     const tokens = this.normalizedTokenEstimate(estimatedTokens);
-    const blocked = this.blockingLimit(cost, tokens, step, enforceTokens);
+    const reservedTokens =
+      this.tokenLimit !== null || step !== null ? tokens : 0;
+    const blocked = this.blockingLimit(
+      cost,
+      reservedTokens,
+      step,
+      enforceTokens,
+    );
     if (blocked !== null) this.raiseBlock(blocked);
     this.reserved += cost;
-    this.reservedTokens += tokens;
+    this.reservedTokens += reservedTokens;
     if (step !== null) {
       step.reservedUsd += cost;
-      step.reservedTokens += tokens;
+      step.reservedTokens += reservedTokens;
     }
     if (this.tokenLimit === null && step === null) return cost;
-    return issueReservation(this, cost, tokens, step);
+    return issueReservation(this, cost, reservedTokens, step);
   }
 
   private normalizedCostEstimate(estimate: number | undefined): number {

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -53,6 +53,11 @@ interface ReservationParts {
   step: StepState | null;
 }
 
+interface ReservationState extends ReservationParts {
+  owner: object;
+  active: boolean;
+}
+
 type BlockingLimit = {
   metric: "usd" | "tokens";
   scope: "aggregate" | "step";
@@ -60,18 +65,82 @@ type BlockingLimit = {
   limit: number;
 };
 
+declare const reservationBrand: unique symbol;
+
+/**
+ * An opaque, immutable reservation issued by {@link BudgetGuard.reserve}.
+ *
+ * Pass the original object to `settle()` or `release()` exactly once. Do not
+ * construct, clone, or copy reservation handles: the guard validates object
+ * identity against private authoritative state.
+ */
 export interface BudgetReservation {
   readonly usd: number;
   readonly tokens: number;
-  /** @internal */
-  _owner: BudgetGuard<number | undefined>;
-  /** @internal */
-  _step: StepState | null;
-  /** @internal */
-  _active: boolean;
+  /** Nominal brand: reservation handles can only be issued by this module. */
+  readonly [reservationBrand]: never;
 }
 
 export type ReservationHandle = number | BudgetReservation;
+
+/**
+ * Authoritative per-handle state. The public object is only an immutable view;
+ * accounting and lifecycle decisions never trust caller-visible properties.
+ */
+const reservationStates = new WeakMap<BudgetReservation, ReservationState>();
+
+function issueReservation(
+  owner: object,
+  usd: number,
+  tokens: number,
+  step: StepState | null,
+): BudgetReservation {
+  const handle = Object.freeze({
+    usd,
+    tokens,
+  }) as BudgetReservation;
+  reservationStates.set(handle, {
+    owner,
+    usd,
+    tokens,
+    step,
+    active: true,
+  });
+  return handle;
+}
+
+function normalizeStepHandle(
+  owner: object,
+  handle: ReservationHandle,
+  step: StepState,
+): BudgetReservation {
+  if (typeof handle === "number") {
+    if (!Number.isFinite(handle) || handle < 0) {
+      throw new RangeError(
+        `reserved must be a finite, non-negative number, got ${handle}`,
+      );
+    }
+    if (handle !== 0) {
+      throw new RangeError(
+        "scoped budget APIs require a reservation issued by this step",
+      );
+    }
+    return issueReservation(owner, 0, 0, step);
+  }
+  const state = reservationStates.get(handle);
+  if (state === undefined) {
+    throw new RangeError(
+      "invalid reservation handle; use the original object returned by reserve()",
+    );
+  }
+  if (state.owner !== owner) {
+    throw new RangeError("reservation belongs to a different BudgetGuard");
+  }
+  if (state.step !== step) {
+    throw new RangeError("reservation belongs to a different budget step");
+  }
+  return handle;
+}
 
 export interface StepBudgetOptions {
   maxUsd?: number;
@@ -675,7 +744,7 @@ export class BudgetGuard<
       step.reservedTokens += tokens;
     }
     if (this.tokenLimit === null && step === null) return cost;
-    return { usd: cost, tokens, _owner: this, _step: step, _active: true };
+    return issueReservation(this, cost, tokens, step);
   }
 
   private normalizedCostEstimate(estimate: number | undefined): number {
@@ -776,21 +845,29 @@ export class BudgetGuard<
       }
       return { usd: handle, tokens: 0, step: null };
     }
-    if (handle._owner !== this) {
+    const state = reservationStates.get(handle);
+    if (state === undefined) {
+      throw new RangeError(
+        "invalid reservation handle; use the original object returned by reserve()",
+      );
+    }
+    if (state.owner !== this) {
       throw new RangeError("reservation belongs to a different BudgetGuard");
     }
-    if (!handle._active) {
+    if (!state.active) {
       throw new RangeError("reservation has already been settled or released");
     }
     if (
       !Number.isFinite(handle.usd) ||
       handle.usd < 0 ||
       !Number.isInteger(handle.tokens) ||
-      handle.tokens < 0
+      handle.tokens < 0 ||
+      handle.usd !== state.usd ||
+      handle.tokens !== state.tokens
     ) {
       throw new RangeError("reservation contains invalid USD or token values");
     }
-    return { usd: handle.usd, tokens: handle.tokens, step: handle._step };
+    return { usd: state.usd, tokens: state.tokens, step: state.step };
   }
 
   private consumeHandle(
@@ -816,7 +893,14 @@ export class BudgetGuard<
       parts.step.reservedUsd = Math.max(0, parts.step.reservedUsd - parts.usd);
       parts.step.reservedTokens -= parts.tokens;
     }
-    if (typeof handle !== "number") handle._active = false;
+    if (typeof handle !== "number") {
+      const state = reservationStates.get(handle);
+      // reservationParts() validated issuance, ownership, and active state.
+      if (state === undefined || state.owner !== this || !state.active) {
+        throw new RangeError("invalid or already consumed reservation handle");
+      }
+      state.active = false;
+    }
   }
 
   private accrueTokens(tokens: number, step: StepState | null): void {
@@ -999,15 +1083,11 @@ export class StepBudgetGuard {
     options: { reserved?: ReservationHandle; price?: ManualPrice; label?: string } = {},
   ): number {
     this.ensureActive();
-    const reserved =
-      options.reserved ??
-      {
-        usd: 0,
-        tokens: 0,
-        _owner: this.parent,
-        _step: this.state,
-        _active: true,
-      };
+    const reserved = normalizeStepHandle(
+      this.parent,
+      options.reserved ?? 0,
+      this.state,
+    );
     return this.parent.settle(model, promptTokens, completionTokens, {
       ...options,
       reserved,
@@ -1034,15 +1114,11 @@ export class StepBudgetGuard {
     options: { reserved?: ReservationHandle; label?: string } = {},
   ): number {
     this.ensureActive();
-    const reserved =
-      options.reserved ??
-      {
-        usd: 0,
-        tokens: 0,
-        _owner: this.parent,
-        _step: this.state,
-        _active: true,
-      };
+    const reserved = normalizeStepHandle(
+      this.parent,
+      options.reserved ?? 0,
+      this.state,
+    );
     return this.parent.settleTool(tool, costUsd, { ...options, reserved });
   }
 
@@ -1051,7 +1127,7 @@ export class StepBudgetGuard {
   }
 
   release(reserved: ReservationHandle): void {
-    this.parent.release(reserved);
+    this.parent.release(normalizeStepHandle(this.parent, reserved, this.state));
   }
 
   advisory(): BudgetAdvisory {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -8,8 +8,12 @@
 
 export {
   BudgetGuard,
+  StepBudgetGuard,
   type BudgetGuardOptions,
   type BudgetAdvisory,
+  type BudgetReservation,
+  type ReservationHandle,
+  type StepBudgetOptions,
   type SpendEvent,
 } from "./guard.js";
 export {
@@ -20,6 +24,7 @@ export {
 export {
   FloeGuardError,
   BudgetExceeded,
+  TokenBudgetExceeded,
   DeadlineExceeded,
   UnpriceableModelError,
 } from "./errors.js";

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -25,7 +25,7 @@
  * The model id used for pricing comes from `model.modelId`.
  */
 
-import type { BudgetGuard } from "./guard.js";
+import type { BudgetGuard, StepBudgetGuard } from "./guard.js";
 
 /**
  * The middleware call surface shared by `ai@4` and `ai@5`. Both majors invoke
@@ -98,7 +98,9 @@ function usageTokens(
  *   middleware: budgetGuardMiddleware(guard),
  * });
  */
-export function budgetGuardMiddleware(guard: BudgetGuard): BudgetGuardMiddleware {
+export function budgetGuardMiddleware(
+  guard: BudgetGuard<number | undefined> | StepBudgetGuard,
+): BudgetGuardMiddleware {
   return {
     async wrapGenerate({ doGenerate, model }) {
       const reserved = guard.reserve(); // throws BudgetExceeded before the call runs

--- a/js/src/retry.ts
+++ b/js/src/retry.ts
@@ -1,5 +1,9 @@
-import { BudgetExceeded } from "./errors.js";
-import { type BudgetAdvisory, BudgetGuard } from "./guard.js";
+import { BudgetExceeded, TokenBudgetExceeded } from "./errors.js";
+import {
+  type BudgetAdvisory,
+  BudgetGuard,
+  type StepBudgetGuard,
+} from "./guard.js";
 
 export interface RetryPlan<T> {
   /** Operation to run for this retry attempt. */
@@ -26,7 +30,10 @@ export interface BudgetRetryOptions<T> {
 }
 
 function defaultRetryIf(error: unknown): boolean {
-  return !(error instanceof BudgetExceeded);
+  return !(
+    error instanceof BudgetExceeded ||
+    error instanceof TokenBudgetExceeded
+  );
 }
 
 /**
@@ -38,7 +45,7 @@ function defaultRetryIf(error: unknown): boolean {
  * retry so an over-budget retry is blocked before it runs.
  */
 export async function withBudgetRetry<T>(
-  guard: BudgetGuard,
+  guard: BudgetGuard<number | undefined> | StepBudgetGuard,
   call: () => T | Promise<T>,
   options: BudgetRetryOptions<T> = {},
 ): Promise<T> {
@@ -64,7 +71,7 @@ export async function withBudgetRetry<T>(
 }
 
 async function nextPlan<T>(
-  guard: BudgetGuard,
+  guard: BudgetGuard<number | undefined> | StepBudgetGuard,
   error: unknown,
   current: RetryPlan<T>,
   onDegrade: BudgetRetryOptions<T>["onDegrade"],

--- a/js/test/retry.test.ts
+++ b/js/test/retry.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { BudgetExceeded, BudgetGuard, type RetryPlan, withBudgetRetry } from "../src/index.js";
+import {
+  BudgetExceeded,
+  BudgetGuard,
+  type RetryPlan,
+  TokenBudgetExceeded,
+  withBudgetRetry,
+} from "../src/index.js";
 
 class RetryableError extends Error {}
 
@@ -91,6 +97,27 @@ describe("withBudgetRetry", () => {
         },
       ),
     ).rejects.toThrow("bad request");
+    expect(primaryCalls).toBe(1);
+  });
+
+  it("does not retry token budget errors by default", async () => {
+    const guard = new BudgetGuard(1.0, {
+      tokenLimit: 0,
+      onTokenBlock: () => undefined,
+    });
+    let primaryCalls = 0;
+
+    await expect(
+      withBudgetRetry(
+        guard,
+        () => {
+          primaryCalls += 1;
+          guard.check(0, 1);
+          return "unreachable";
+        },
+        { maxAttempts: 3 },
+      ),
+    ).rejects.toBeInstanceOf(TokenBudgetExceeded);
     expect(primaryCalls).toBe(1);
   });
 

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -103,6 +103,115 @@ describe("aggregate token ceilings", () => {
     second.release(foreign);
   });
 
+  it("returns frozen opaque handles with immutable caller-visible values", () => {
+    const guard = quiet(100);
+    const handle = guard.reserve(0.25, 20) as BudgetReservation;
+
+    expect(handle).toMatchObject({ usd: 0.25, tokens: 20 });
+    expect(Object.isFrozen(handle)).toBe(true);
+    expect("_owner" in handle).toBe(false);
+    expect("_step" in handle).toBe(false);
+    expect("_active" in handle).toBe(false);
+    expect(Reflect.set(handle as unknown as object, "usd", 9)).toBe(false);
+    expect(Reflect.set(handle as unknown as object, "tokens", 99)).toBe(false);
+    expect(() =>
+      Object.defineProperty(handle, "tokens", { value: Number.NaN }),
+    ).toThrow(TypeError);
+    expect(handle).toMatchObject({ usd: 0.25, tokens: 20 });
+
+    guard.release(handle);
+    expect(guard.remainingUsd).toBe(10);
+    expect(guard.remainingTokens).toBe(100);
+  });
+
+  it.each([
+    { usd: 0.5, tokens: 10, description: "finite oversized" },
+    { usd: -1, tokens: 10, description: "negative USD" },
+    { usd: Number.NaN, tokens: 10, description: "NaN USD" },
+    { usd: 0.1, tokens: -1, description: "negative tokens" },
+    { usd: 0.1, tokens: 1.5, description: "non-integer tokens" },
+    { usd: 0.1, tokens: Number.NaN, description: "NaN tokens" },
+  ])(
+    "rejects a forged $description handle without changing accounting",
+    ({ usd, tokens }) => {
+      const guard = quiet(100);
+      const legitimate = guard.reserve(0.2, 20);
+      const forged = { usd, tokens } as unknown as BudgetReservation;
+      const before = guard as unknown as {
+        reserved: number;
+        reservedTokens: number;
+      };
+
+      expect(() => guard.release(forged)).toThrow(/invalid reservation handle/);
+      expect(before.reserved).toBe(0.2);
+      expect(before.reservedTokens).toBe(20);
+      expect(guard.remainingUsd).toBeCloseTo(9.8);
+      expect(guard.remainingTokens).toBe(80);
+
+      guard.release(legitimate);
+      expect(before.reserved).toBe(0);
+      expect(before.reservedTokens).toBe(0);
+    },
+  );
+
+  it("rejects copied and cloned handles without consuming the original", () => {
+    const guard = quiet(100);
+    const handle = guard.reserve(0.2, 20) as BudgetReservation;
+    const spreadClone = { ...handle } as unknown as BudgetReservation;
+    const assignedClone = Object.assign({}, handle) as unknown as BudgetReservation;
+    const sameOwnerForgery = {
+      usd: 0.2,
+      tokens: 20,
+      _owner: guard,
+    } as unknown as BudgetReservation;
+
+    expect(() => guard.release(spreadClone)).toThrow(/original object/);
+    expect(() => guard.release(assignedClone)).toThrow(/original object/);
+    expect(() => guard.release(sameOwnerForgery)).toThrow(/original object/);
+    expect(guard.remainingTokens).toBe(80);
+    guard.release(handle);
+    expect(guard.remainingTokens).toBe(100);
+  });
+
+  it("cannot free concurrent holds with a forged larger handle", () => {
+    const guard = new BudgetGuard(10, {
+      tokenLimit: 400,
+      onBlock: () => {},
+      onTokenBlock: () => {},
+    });
+    const first = guard.reserve(0, 100);
+    const second = guard.reserve(0, 100);
+    const forged = { usd: 0, tokens: 300 } as unknown as BudgetReservation;
+
+    expect(() => guard.release(forged)).toThrow(/invalid reservation handle/);
+    expect(guard.remainingTokens).toBe(200);
+    expect(() => guard.reserve(0, 300)).toThrow(TokenBudgetExceeded);
+
+    guard.release(first);
+    expect(guard.remainingTokens).toBe(300);
+    guard.release(second);
+    expect(guard.remainingTokens).toBe(400);
+  });
+
+  it("allows exactly one concurrent terminal operation per handle", async () => {
+    const guard = quiet(100);
+    const contested = guard.reserve(0.2, 20);
+    const unrelated = guard.reserve(0.3, 30);
+
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() => guard.release(contested)),
+      Promise.resolve().then(() => guard.release(contested)),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(guard.remainingUsd).toBeCloseTo(9.7);
+    expect(guard.remainingTokens).toBe(70);
+
+    guard.release(unrelated);
+    expect(guard.remainingUsd).toBe(10);
+    expect(guard.remainingTokens).toBe(100);
+  });
+
   it("holds tokens synchronously across Promise fan-out", async () => {
     const guard = quiet(100);
     const launches = Array.from({ length: 5 }, async () => {
@@ -248,13 +357,54 @@ describe("per-step budgets", () => {
 
   it("detects a leaked reservation on clean exit", () => {
     const guard = quiet(100);
+    let scoped: StepBudgetGuard | undefined;
     let handle: BudgetReservation | undefined;
     expect(() =>
       guard.step({ maxTokens: 50 }, (step) => {
+        scoped = step;
         handle = step.reserve(0, 10) as BudgetReservation;
       }),
     ).toThrow(/active reservation/);
-    guard.release(handle!);
+    scoped!.release(handle!);
+    expect(guard.remainingTokens).toBe(100);
+  });
+
+  it("rejects cloned and sibling-step handles without consuming their holds", () => {
+    const guard = quiet(200);
+
+    guard.step({ maxTokens: 100 }, (firstStep) => {
+      const handle = firstStep.reserve(0.1, 20) as BudgetReservation;
+      const clone = { ...handle } as unknown as BudgetReservation;
+
+      expect(() => firstStep.release(clone)).toThrow(/original object/);
+      guard.step({ maxTokens: 100 }, (secondStep) => {
+        expect(() => secondStep.release(handle)).toThrow(/different budget step/);
+        expect(() => secondStep.release(0.1)).toThrow(/issued by this step/);
+        secondStep.release(0);
+      });
+
+      expect(guard.remainingTokens).toBe(180);
+      firstStep.release(handle);
+      expect(guard.remainingTokens).toBe(200);
+    });
+  });
+
+  it("registers scoped zero handles for record and recordTool", () => {
+    const guard = quiet(100);
+
+    guard.step({ maxUsd: 1, maxTokens: 100 }, (step) => {
+      step.record("manual", 10, 5, {
+        price: { inputCostPerToken: 0.01, outputCostPerToken: 0.02 },
+      });
+      step.recordTool("search", 0.25);
+
+      expect(step.advisory()).toMatchObject({
+        stepSpentUsd: 0.45,
+        stepSpentTokens: 15,
+      });
+    });
+    expect(guard.spentUsd).toBeCloseTo(0.45);
+    expect(guard.spentTokens).toBe(15);
   });
 
   it("does not mask a callback failure with leak detection", async () => {

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -221,6 +221,31 @@ describe("per-step budgets", () => {
     expect(guard.spentTokens).toBe(30);
   });
 
+  it("closes the step when inspecting a thenable throws", () => {
+    const guard = quiet(100);
+    let scoped: StepBudgetGuard | undefined;
+    const failure = new URIError("then getter failed");
+
+    expect(() =>
+      guard.step({ maxTokens: 50 }, (step) => {
+        scoped = step;
+        return Object.defineProperty({}, "then", {
+          get() {
+            throw failure;
+          },
+        }) as PromiseLike<never>;
+      }),
+    ).toThrow(failure);
+
+    expect(() => scoped!.reserve(0, 1)).toThrow(/no longer active/);
+    expect(() =>
+      scoped!.record("manual", 1, 0, {
+        price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+      }),
+    ).toThrow(/no longer active/);
+    expect(() => scoped!.reserveTool(0.01)).toThrow(/no longer active/);
+  });
+
   it("detects a leaked reservation on clean exit", () => {
     const guard = quiet(100);
     let handle: BudgetReservation | undefined;

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BudgetExceeded,
+  type BudgetAdvisory,
+  BudgetGuard,
+  type BudgetGuardOptions,
+  type StepBudgetGuard,
+  TokenBudgetExceeded,
+  budgetGuardMiddleware,
+  type BudgetReservation,
+} from "../src/index.js";
+
+const quiet = (tokenLimit?: number) =>
+  new BudgetGuard(10, {
+    tokenLimit,
+    onBlock: () => {},
+    onTokenBlock: () => {},
+  });
+
+describe("aggregate token ceilings", () => {
+  it("keeps aggregate-only advisory and options literals source-compatible", () => {
+    const legacyAdvisory: BudgetAdvisory = {
+      nearLimit: false,
+      usedBps: 0,
+      remainingUsd: 10,
+      limitUsd: 10,
+      spentUsd: 0,
+      scope: "local",
+    };
+    const options: BudgetGuardOptions = { tokenLimit: 100 };
+
+    expect(legacyAdvisory.nearLimit).toBe(false);
+    expect(new BudgetGuard(10, options).tokenLimit).toBe(100);
+  });
+
+  it.each([-1, 1.5, NaN, Infinity])("rejects invalid tokenLimit %s", (bad) => {
+    expect(() => quiet(bad)).toThrow(RangeError);
+  });
+
+  it("preserves numeric handles when new limits are absent", () => {
+    const guard = quiet();
+    const handle = guard.reserve(0.1);
+    expect(typeof handle).toBe("number");
+    guard.release(handle);
+    expect(guard.remainingTokens).toBeNull();
+  });
+
+  it("infers a typed handle for an explicitly token-enabled guard", () => {
+    const guard = new BudgetGuard(10, { tokenLimit: 100 });
+    const handle: BudgetReservation = guard.reserve(0);
+    expect(handle.tokens).toBe(0);
+    guard.release(handle);
+  });
+
+  it("accumulates tokens and blocks explicit and fallback estimates", () => {
+    const guard = quiet(100);
+    expect(() => guard.reserve(0, 101)).toThrow(TokenBudgetExceeded);
+    guard.record("manual", 40, 10, {
+      price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+    });
+    expect(guard.spentTokens).toBe(50);
+    const handle = guard.reserve(0);
+    expect(typeof handle).toBe("object");
+    expect((handle as unknown as BudgetReservation).tokens).toBe(50);
+    expect(() => guard.reserve(0)).toThrow(TokenBudgetExceeded);
+    guard.release(handle);
+  });
+
+  it("extends nearLimit with aggregate token utilization", () => {
+    const guard = quiet(100);
+    guard.record("manual", 80, 0, {
+      price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+    });
+    expect(guard.advisory()).toMatchObject({
+      tokenUsedBps: 8000,
+      nearTokenLimit: true,
+      nearLimit: true,
+      remainingTokens: 20,
+    });
+  });
+
+  it("accrues known tokens when unpriceable spend is fail-open", () => {
+    const guard = new BudgetGuard(10, {
+      tokenLimit: 100,
+      failClosed: false,
+      onBlock: () => {},
+      onTokenBlock: () => {},
+    });
+    guard.record("unknown-model", 10, 5);
+    expect(guard.spentTokens).toBe(15);
+    expect(guard.spentUsd).toBe(0);
+  });
+
+  it("enforces typed handle ownership and exactly-once disposal", () => {
+    const first = quiet(100);
+    const second = quiet(100);
+    const handle = first.reserve(0.1, 20);
+    first.release(handle);
+    expect(() => first.release(handle)).toThrow(/already/);
+    const foreign = second.reserve(0.1, 20);
+    expect(() => first.release(foreign)).toThrow(/different/);
+    second.release(foreign);
+  });
+
+  it("holds tokens synchronously across Promise fan-out", async () => {
+    const guard = quiet(100);
+    const launches = Array.from({ length: 5 }, async () => {
+      const handle = guard.reserve(0, 30);
+      await Promise.resolve();
+      return handle;
+    });
+    const results = await Promise.allSettled(launches);
+    expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(3);
+    expect(results.filter((r) => r.status === "rejected")).toHaveLength(2);
+    for (const result of results) {
+      if (result.status === "fulfilled") guard.release(result.value);
+    }
+    expect(guard.remainingTokens).toBe(100);
+  });
+});
+
+describe("per-step budgets", () => {
+  it("resets each step while retaining aggregate totals", async () => {
+    const guard = quiet(1_000);
+    await guard.step({ maxTokens: 100 }, async (step) => {
+      step.record("manual", 40, 10, {
+        price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+      });
+      expect(step.advisory().stepSpentTokens).toBe(50);
+    });
+    guard.step({ maxTokens: 100 }, (step) => {
+      expect(step.advisory().stepSpentTokens).toBe(0);
+      step.record("manual", 20, 10, {
+        price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+      });
+    });
+    expect(guard.spentTokens).toBe(80);
+  });
+
+  it("reports step scope for the tightest token and USD limits", () => {
+    const guard = quiet(1_000);
+    guard.step({ maxTokens: 50 }, (step) => {
+      step.record("manual", 40, 0, {
+        price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+      });
+      try {
+        step.check(0, 11);
+        throw new Error("expected token block");
+      } catch (error) {
+        expect(error).toBeInstanceOf(TokenBudgetExceeded);
+        expect((error as TokenBudgetExceeded).scope).toBe("step");
+      }
+    });
+    guard.step({ maxUsd: 0.001 }, (step) => {
+      try {
+        step.check(0.002, 0);
+        throw new Error("expected USD block");
+      } catch (error) {
+        expect(error).toBeInstanceOf(BudgetExceeded);
+        expect((error as BudgetExceeded).scope).toBe("step");
+      }
+    });
+  });
+
+  it("counts tools against step USD but not tokens", () => {
+    const guard = quiet(100);
+    guard.step({ maxUsd: 0.02, maxTokens: 0 }, (step) => {
+      const handle = step.reserveTool(0.01);
+      step.settleTool("search", 0.01, { reserved: handle });
+      expect(step.advisory().stepSpentTokens).toBe(0);
+      expect(() => step.reserveTool(0.02)).toThrow(BudgetExceeded);
+    });
+  });
+
+  it("keeps overlapping async step state isolated", async () => {
+    const guard = quiet(1_000);
+    const [first, second] = await Promise.all([
+      guard.step({ maxTokens: 100 }, async (step) => {
+        await Promise.resolve();
+        step.record("manual", 30, 0, {
+          price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+        });
+        return step.advisory().stepSpentTokens;
+      }),
+      guard.step({ maxTokens: 200 }, async (step) => {
+        step.record("manual", 70, 0, {
+          price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+        });
+        return step.advisory().stepSpentTokens;
+      }),
+    ]);
+    expect([first, second]).toEqual([30, 70]);
+    expect(guard.spentTokens).toBe(100);
+  });
+
+  it("keeps a step active until a custom thenable settles", async () => {
+    const guard = quiet(1_000);
+
+    const result = await guard.step(
+      { maxTokens: 100 },
+      (step) => {
+        const thenable: PromiseLike<string> = {
+          then(onfulfilled, onrejected) {
+            const pending = new Promise<string>((resolve) => {
+              queueMicrotask(() => {
+                step.record("manual", 30, 0, {
+                  price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+                });
+                resolve("done");
+              });
+            });
+            return pending.then(onfulfilled, onrejected);
+          },
+        };
+        return thenable;
+      },
+    );
+
+    expect(result).toBe("done");
+    expect(guard.spentTokens).toBe(30);
+  });
+
+  it("detects a leaked reservation on clean exit", () => {
+    const guard = quiet(100);
+    let handle: BudgetReservation | undefined;
+    expect(() =>
+      guard.step({ maxTokens: 50 }, (step) => {
+        handle = step.reserve(0, 10) as BudgetReservation;
+      }),
+    ).toThrow(/active reservation/);
+    guard.release(handle!);
+  });
+
+  it("does not mask a callback failure with leak detection", async () => {
+    const guard = quiet(100);
+    let handle: BudgetReservation | undefined;
+    await expect(
+      guard.step({ maxTokens: 50 }, async (step) => {
+        handle = step.reserve(0, 10) as BudgetReservation;
+        throw new URIError("provider failed");
+      }),
+    ).rejects.toThrow("provider failed");
+    guard.release(handle!);
+  });
+
+  it("does not open new reservations after a step closes", () => {
+    const guard = quiet(100);
+    let scoped: StepBudgetGuard | undefined;
+
+    guard.step({ maxTokens: 50 }, (step) => {
+      scoped = step;
+    });
+
+    expect(() => scoped!.reserve(0, 1)).toThrow(/no longer active/);
+    expect(() => scoped!.reserveTool(0.01)).toThrow(/no longer active/);
+  });
+
+  it("extends nearLimit with step utilization", () => {
+    const guard = quiet(1_000);
+    guard.step({ maxTokens: 100 }, (step) => {
+      step.record("manual", 80, 0, {
+        price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+      });
+      expect(step.advisory()).toMatchObject({
+        stepUsedBps: 8000,
+        stepNearLimit: true,
+        nearLimit: true,
+      });
+    });
+  });
+
+  it("blocks scoped middleware before the provider call", async () => {
+    const guard = quiet(1_000);
+    let called = false;
+    await guard.step({ maxTokens: 0 }, async (step) => {
+      const middleware = budgetGuardMiddleware(step);
+      await expect(
+        middleware.wrapGenerate({
+          model: { modelId: "gpt-4o" },
+          doGenerate: async () => {
+            called = true;
+            return { usage: { promptTokens: 1, completionTokens: 1 } };
+          },
+        }),
+      ).rejects.toBeInstanceOf(TokenBudgetExceeded);
+    });
+    expect(called).toBe(false);
+  });
+});

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -46,6 +46,35 @@ describe("aggregate token ceilings", () => {
     expect(guard.remainingTokens).toBeNull();
   });
 
+  it("does not leak token reservations through legacy numeric handles", () => {
+    const guard = quiet();
+    const counters = guard as unknown as {
+      reserved: number;
+      reservedTokens: number;
+    };
+    guard.record("manual", 10, 5, {
+      price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+    });
+
+    const fallback = guard.reserve(0.1);
+    expect(typeof fallback).toBe("number");
+    expect(counters.reservedTokens).toBe(0);
+    guard.release(fallback);
+    expect(counters.reserved).toBe(0);
+    expect(counters.reservedTokens).toBe(0);
+
+    const explicit = guard.reserve(0.1, 25);
+    expect(typeof explicit).toBe("number");
+    expect(counters.reservedTokens).toBe(0);
+    guard.settle("manual", 2, 3, {
+      reserved: explicit,
+      price: { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 },
+    });
+    expect(counters.reserved).toBe(0);
+    expect(counters.reservedTokens).toBe(0);
+    expect(guard.spentTokens).toBe(20);
+  });
+
   it("infers a typed handle for an explicitly token-enabled guard", () => {
     const guard = new BudgetGuard(10, { tokenLimit: 100 });
     const handle: BudgetReservation = guard.reserve(0);
@@ -63,8 +92,14 @@ describe("aggregate token ceilings", () => {
     const handle = guard.reserve(0);
     expect(typeof handle).toBe("object");
     expect((handle as unknown as BudgetReservation).tokens).toBe(50);
+    expect(
+      (guard as unknown as { reservedTokens: number }).reservedTokens,
+    ).toBe(50);
     expect(() => guard.reserve(0)).toThrow(TokenBudgetExceeded);
     guard.release(handle);
+    expect(
+      (guard as unknown as { reservedTokens: number }).reservedTokens,
+    ).toBe(0);
   });
 
   it("extends nearLimit with aggregate token utilization", () => {
@@ -245,6 +280,23 @@ describe("per-step budgets", () => {
       });
     });
     expect(guard.spentTokens).toBe(80);
+  });
+
+  it("tracks typed token reservations in USD-only steps without a parent token limit", () => {
+    const guard = quiet();
+    const counters = guard as unknown as {
+      reserved: number;
+      reservedTokens: number;
+    };
+
+    guard.step({ maxUsd: 1 }, (step) => {
+      const handle = step.reserve(0.1, 20) as BudgetReservation;
+      expect(handle.tokens).toBe(20);
+      expect(counters.reservedTokens).toBe(20);
+      step.release(handle);
+      expect(counters.reserved).toBe(0);
+      expect(counters.reservedTokens).toBe(0);
+    });
   });
 
   it("reports step scope for the tightest token and USD limits", () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.11.0"
+version = "0.12.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -19,21 +19,30 @@ from .errors import (
     DeadlineExceeded,
     FloeGuardError,
     HostedEnforcementError,
+    TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
-from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
+from .guard import (
+    BudgetAdvisory,
+    BudgetGuard,
+    BudgetReservation,
+    SpendEvent,
+    StepBudgetGuard,
+)
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.10.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.12.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
+    "BudgetReservation",
+    "StepBudgetGuard",
     "SpendEvent",
     "LatencyBudget",
     "LatencyAdvisory",
@@ -43,6 +52,7 @@ __all__ = [
     "with_budget_retry",
     "async_with_budget_retry",
     "BudgetExceeded",
+    "TokenBudgetExceeded",
     "DeadlineExceeded",
     "FloeGuardError",
     "HostedEnforcementError",

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -32,11 +32,26 @@ class BudgetExceeded(FloeGuardError):
     loop stops here rather than burning more money.
     """
 
-    def __init__(self, spent_usd: float, limit_usd: float) -> None:
+    def __init__(self, spent_usd: float, limit_usd: float, *, scope: str = "aggregate") -> None:
         self.spent_usd = spent_usd
         self.limit_usd = limit_usd
+        self.scope = scope
+        prefix = "STEP BUDGET EXCEEDED" if scope == "step" else "BUDGET EXCEEDED"
         super().__init__(
-            f"BUDGET EXCEEDED — call blocked (spent ${spent_usd:.6f} of ${limit_usd:.6f} ceiling)"
+            f"{prefix} — call blocked (spent ${spent_usd:.6f} of ${limit_usd:.6f} ceiling)"
+        )
+
+
+class TokenBudgetExceeded(FloeGuardError):
+    """Raised before an LLM call that would cross a token ceiling."""
+
+    def __init__(self, spent_tokens: int, limit_tokens: int, *, scope: str = "aggregate") -> None:
+        self.spent_tokens = spent_tokens
+        self.limit_tokens = limit_tokens
+        self.scope = scope
+        prefix = "STEP TOKEN BUDGET EXCEEDED" if scope == "step" else "TOKEN BUDGET EXCEEDED"
+        super().__init__(
+            f"{prefix} — call blocked (spent {spent_tokens} of {limit_tokens} token ceiling)"
         )
 
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -860,38 +860,53 @@ class BudgetGuard:
             raise ValueError("reservation handle has been modified")
         return state
 
-    def _scoped_reservation(
-        self, reserved: ReservationHandle, step: _StepState
-    ) -> BudgetReservation:
-        """Return a genuine handle for ``step``; numeric scoped handles must be zero."""
+    def _validate_scoped_locked(
+        self,
+        reserved: ReservationHandle,
+        step: _StepState,
+        *,
+        require_active: bool,
+    ) -> BudgetReservation | None:
+        """Validate a scoped handle. Caller must hold ``self._lock``.
+
+        Return the genuine typed handle, or ``None`` for a legal numeric zero
+        that the caller may normalize into a registered zero-valued handle.
+        """
+        if require_active and not step.active:
+            raise RuntimeError("step budget is no longer active")
         if isinstance(reserved, BudgetReservation):
-            with self._lock:
-                state = self._typed_reservation_state_locked(reserved)
-                if state.step is not step:
-                    raise ValueError("reservation belongs to a different step budget")
+            state = self._typed_reservation_state_locked(reserved)
+            if state.step is not step:
+                raise ValueError("reservation belongs to a different step budget")
             return reserved
         if not math.isfinite(reserved) or reserved < 0:
             raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
         if reserved != 0:
             raise ValueError("scoped numeric reservation handles must be zero")
-        return self._make_reservation(0.0, 0, step)
+        return None
+
+    def _scoped_reservation(
+        self,
+        reserved: ReservationHandle,
+        step: _StepState,
+        *,
+        require_active: bool,
+    ) -> BudgetReservation:
+        """Return a genuine handle for ``step``; numeric scoped handles must be zero."""
+        with self._lock:
+            normalized = self._validate_scoped_locked(
+                reserved,
+                step,
+                require_active=require_active,
+            )
+            if normalized is not None:
+                return normalized
+            return self._make_reservation_locked(0.0, 0, step)
 
     def _validate_scoped_reservation(self, reserved: ReservationHandle, step: _StepState) -> None:
         """Validate a scoped handle without creating a zero-valued replacement."""
         with self._lock:
-            if not step.active:
-                raise RuntimeError("step budget is no longer active")
-            if isinstance(reserved, BudgetReservation):
-                state = self._typed_reservation_state_locked(reserved)
-                if state.step is not step:
-                    raise ValueError("reservation belongs to a different step budget")
-                return
-            if not math.isfinite(reserved) or reserved < 0:
-                raise ValueError(
-                    f"reserved must be a finite, non-negative number, got {reserved!r}"
-                )
-            if reserved != 0:
-                raise ValueError("scoped numeric reservation handles must be zero")
+            self._validate_scoped_locked(reserved, step, require_active=True)
 
     def _consume_handle_locked(
         self,
@@ -1002,22 +1017,10 @@ class BudgetGuard:
     ) -> tuple[BudgetReservation, object]:
         """Atomically validate scope liveness, normalize its handle, and register."""
         with self._lock:
-            if not step.active:
-                raise RuntimeError("step budget is no longer active")
-            if isinstance(reserved, BudgetReservation):
-                state = self._typed_reservation_state_locked(reserved)
-                if state.step is not step:
-                    raise ValueError("reservation belongs to a different step budget")
-                normalized = reserved
-            else:
-                if not math.isfinite(reserved) or reserved < 0:
-                    raise ValueError(
-                        f"reserved must be a finite, non-negative number, got {reserved!r}"
-                    )
-                if reserved != 0:
-                    raise ValueError("scoped numeric reservation handles must be zero")
+            normalized = self._validate_scoped_locked(reserved, step, require_active=True)
+            if normalized is None:
                 normalized = self._make_reservation_locked(0.0, 0, step)
-                state = self._typed_reservation_state_locked(normalized)
+            state = self._typed_reservation_state_locked(normalized)
             key = self._stream_register_locked(state.usd, state.tokens, state.step)
         return normalized, key
 
@@ -1253,7 +1256,11 @@ class StepBudgetGuard:
         label: str | None = None,
     ) -> float:
         self._ensure_active()
-        reserved = self._parent._scoped_reservation(reserved, self._state)
+        reserved = self._parent._scoped_reservation(
+            reserved,
+            self._state,
+            require_active=True,
+        )
         return self._parent.settle(
             model,
             prompt_tokens,
@@ -1305,7 +1312,11 @@ class StepBudgetGuard:
         label: str | None = None,
     ) -> float:
         self._ensure_active()
-        reserved = self._parent._scoped_reservation(reserved, self._state)
+        reserved = self._parent._scoped_reservation(
+            reserved,
+            self._state,
+            require_active=True,
+        )
         return self._parent.settle_tool(tool, cost_usd, reserved=reserved, label=label)
 
     def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
@@ -1314,7 +1325,11 @@ class StepBudgetGuard:
         return self.settle_tool(tool, cost_usd, reserved=handle, label=label)
 
     def release(self, reserved: ReservationHandle) -> None:
-        reserved = self._parent._scoped_reservation(reserved, self._state)
+        reserved = self._parent._scoped_reservation(
+            reserved,
+            self._state,
+            require_active=False,
+        )
         self._parent.release(reserved)
 
     def advisory(self) -> BudgetAdvisory:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -36,10 +36,11 @@ import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from .errors import (
     BudgetExceeded,
+    TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
@@ -79,6 +80,44 @@ class BudgetAdvisory:
     # floor(remaining_usd / expected_cost). None when expected_cost is 0.0
     # (no call recorded yet) — unknown, not zero.
     est_calls_remaining: int | None = None
+    token_limit: int | None = None
+    spent_tokens: int = 0
+    remaining_tokens: int | None = None
+    token_used_bps: int | None = None
+    near_token_limit: bool = False
+    step_limit_usd: float | None = None
+    step_spent_usd: float | None = None
+    step_remaining_usd: float | None = None
+    step_token_limit: int | None = None
+    step_spent_tokens: int | None = None
+    step_remaining_tokens: int | None = None
+    step_used_bps: int | None = None
+    step_near_limit: bool = False
+
+
+@dataclass(eq=False)
+class _StepState:
+    limit_usd: float | None
+    token_limit: int | None
+    spent_usd: float = 0.0
+    spent_tokens: int = 0
+    reserved_usd: float = 0.0
+    reserved_tokens: int = 0
+    active: bool = True
+
+
+@dataclass(eq=False)
+class BudgetReservation:
+    """Opaque multi-dimensional reservation returned by token/step guards."""
+
+    usd: float
+    tokens: int
+    _owner: BudgetGuard
+    _step: _StepState | None = None
+    _active: bool = True
+
+
+ReservationHandle = float | BudgetReservation
 
 
 @dataclass(frozen=True)
@@ -133,6 +172,8 @@ class BudgetGuard:
 
     Args:
         limit_usd: the spend ceiling, in USD. ``0`` blocks the very first call.
+        token_limit: optional aggregate LLM-token ceiling. Tool calls consume
+            USD only. ``0`` blocks the first LLM call.
         price_overrides: per-model manual prices for models the bundled cost map
             cannot price (e.g. a brand-new or self-hosted model).
         fail_closed: when ``True`` (default), recording an unpriceable model
@@ -143,6 +184,9 @@ class BudgetGuard:
         on_block: optional callback invoked with ``(spent_usd, limit_usd)`` right
             before :class:`BudgetExceeded` is raised. Defaults to printing the
             ``BUDGET EXCEEDED — call blocked`` banner to stderr.
+        on_token_block: token counterpart invoked with
+            ``(spent_tokens, token_limit)`` before
+            :class:`~floe_guard.TokenBudgetExceeded`.
         near_limit_bps: utilization (basis points, 0..10000) at which
             :meth:`advisory` flags ``near_limit`` so an agent can taper before the
             hard-stop. Defaults to ``8000`` (80%).
@@ -160,9 +204,11 @@ class BudgetGuard:
         self,
         limit_usd: float,
         *,
+        token_limit: int | None = None,
         price_overrides: dict[str, ManualPrice] | None = None,
         fail_closed: bool = True,
         on_block: Callable[[float, float], None] | None = None,
+        on_token_block: Callable[[int, int], None] | None = None,
         near_limit_bps: int = 8000,
         max_log_events: int | None = None,
     ) -> None:
@@ -180,20 +226,26 @@ class BudgetGuard:
         ):
             raise ValueError(f"near_limit_bps must be an int in 0..10000, got {near_limit_bps!r}")
         self.limit_usd = float(limit_usd)
+        _validate_optional_tokens("token_limit", token_limit)
+        self.token_limit = token_limit
         self.price_overrides = price_overrides
         self.fail_closed = fail_closed
         self._on_block = on_block or _default_on_block
+        self._on_token_block = on_token_block or _default_on_token_block
         self.near_limit_bps = near_limit_bps
         self.spent_usd = 0.0
+        self.spent_tokens = 0
         # Costs of the most recent priced LLM call and tool call, tracked
         # SEPARATELY: the default next-call prediction is the max of the two, so
         # a cheap tool call can't shrink the estimate right before an expensive
         # LLM call (or vice versa) — conservative beats one-call-too-late.
         self._last_llm_cost = 0.0
         self._last_tool_cost = 0.0
+        self._last_llm_tokens = 0
         # USD held for calls that are in flight (reserved but not yet settled).
         # Counted against the ceiling so concurrent callers can't overshoot.
         self._reserved = 0.0
+        self._reserved_tokens = 0
         # Same int-not-bool contract as near_limit_bps (parity with TS Number.isInteger).
         if max_log_events is not None and (
             isinstance(max_log_events, bool)
@@ -208,7 +260,7 @@ class BudgetGuard:
         # Active streams' (accrued_usd, reserved_usd), keyed by registry token —
         # see _stream_register(). Lets parallel streams count each other's
         # in-flight accrual against the ceiling before anything settles.
-        self._stream_costs: dict[object, tuple[float, float]] = {}
+        self._stream_costs: dict[object, tuple[float, int, float, int, _StepState | None]] = {}
         # Per-tool running totals (settle_tool/record_tool) — the tool side of
         # the one shared ceiling, exposed via the tool_costs property.
         self._tool_costs: dict[str, float] = {}
@@ -216,7 +268,12 @@ class BudgetGuard:
 
     # ── enforcement ───────────────────────────────────────────────────────────
 
-    def check(self, estimated_next_cost: float | None = None) -> None:
+    def check(
+        self,
+        estimated_next_cost: float | None = None,
+        *,
+        estimated_next_tokens: int | None = None,
+    ) -> None:
         """Raise :class:`BudgetExceeded` if the next call would cross the ceiling.
 
         Call this immediately before each LLM request. The "next call" is
@@ -230,9 +287,7 @@ class BudgetGuard:
         Note: ``check`` is a non-binding peek. For parallel calls, use
         :meth:`reserve` / :meth:`settle`, which hold the estimate atomically.
         """
-        self._validate_estimate(estimated_next_cost)
-        if self._would_cross(estimated_next_cost):
-            self._block()
+        self._check(estimated_next_cost, estimated_next_tokens, step=None)
 
     def estimate_call(
         self,
@@ -264,7 +319,12 @@ class BudgetGuard:
             return None
         return price_tokens(priced, prompt_tokens, max_completion_tokens)
 
-    def reserve(self, estimated_cost: float | None = None) -> float:
+    def reserve(
+        self,
+        estimated_cost: float | None = None,
+        *,
+        estimated_tokens: int | None = None,
+    ) -> ReservationHandle:
         """Atomically check the ceiling AND hold the estimated cost in-flight.
 
         This is the concurrency-safe enforcement path. Each parallel caller
@@ -277,22 +337,7 @@ class BudgetGuard:
         fails. ``estimated_cost`` defaults to the costlier of the last LLM call
         and the last tool call.
         """
-        self._validate_estimate(estimated_cost)
-        with self._lock:
-            estimate = (
-                self._default_estimate_locked()
-                if estimated_cost is None
-                else max(0.0, estimated_cost)
-            )
-            committed = self.spent_usd + self._reserved
-            if committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS:
-                spent, limit = self.spent_usd, self.limit_usd
-            else:
-                self._reserved += estimate
-                return estimate
-        # Blocked — notify and raise outside the lock.
-        self._on_block(spent, limit)
-        raise BudgetExceeded(spent, limit)
+        return self._reserve(estimated_cost, estimated_tokens, step=None)
 
     def settle(
         self,
@@ -300,7 +345,7 @@ class BudgetGuard:
         prompt_tokens: int,
         completion_tokens: int,
         *,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         price: ManualPrice | None = None,
         cache_creation_input_tokens: int = 0,
         cache_creation_input_tokens_1h: int = 0,
@@ -317,12 +362,26 @@ class BudgetGuard:
         agent or task name); the warn-and-skip path accrues nothing and logs
         nothing, so the ledger stays in lockstep with ``spent_usd``.
         """
-        # A bad reserved handle would corrupt _reserved and break the ceiling for
-        # OTHER in-flight calls (negative → phantom hold; inf → clears all holds).
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
+        try:
+            total_tokens = sum(
+                max(0, int(value))
+                for value in (
+                    prompt_tokens,
+                    completion_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_input_tokens_1h,
+                    cache_read_input_tokens,
+                )
+            )
+        except (TypeError, ValueError, OverflowError):
+            self.release(reserved)
+            raise
         priced = self._resolve(model, price)
         if priced is None:
+            with self._lock:
+                self._consume_handle_locked(reserved, reserved_usd, reserved_tokens, step)
+                self._accrue_tokens_locked(total_tokens, step)
             warnings.warn(
                 f"Cannot price model {model!r}: not in the bundled cost map and no "
                 f"manual price given. The budget guard cannot enforce a ceiling on "
@@ -331,10 +390,6 @@ class BudgetGuard:
                 UnpriceableModelWarning,
                 stacklevel=2,
             )
-            # Release any held reservation on BOTH paths. Fail-closed must not
-            # leak the in-flight hold, or _reserved grows permanently and
-            # remaining_usd shrinks until reserve() starts blocking everything.
-            self.release(reserved)
             if self.fail_closed:
                 raise UnpriceableModelError(model)
             return 0.0
@@ -356,14 +411,16 @@ class BudgetGuard:
             self.release(reserved)
             raise
         with self._lock:
-            if reserved:
-                self._consume_reservation_locked(reserved)
+            self._consume_handle_locked(reserved, reserved_usd, reserved_tokens, step)
             self.spent_usd += cost
+            self._accrue_tokens_locked(total_tokens, step)
             # Clamp a sub-epsilon float overshoot back to the limit so the running
             # total never reports as having crossed the ceiling by a rounding artifact.
             if 0.0 < self.spent_usd - self.limit_usd < _EPS:
                 self.spent_usd = self.limit_usd
             self._last_llm_cost = cost
+            if step is not None:
+                step.spent_usd += cost
             self._spend_log.append(
                 SpendEvent(
                     timestamp=time.time(),
@@ -375,7 +432,7 @@ class BudgetGuard:
                     label=label,
                     # 0.0 means "no reservation" (the plain record() path) — omit
                     # rather than log a meaningless zero.
-                    reserved=reserved if reserved else None,
+                    reserved=reserved_usd if reserved_usd else None,
                 )
             )
         return cost
@@ -410,7 +467,7 @@ class BudgetGuard:
             label=label,
         )
 
-    def reserve_tool(self, estimated_cost: float) -> float:
+    def reserve_tool(self, estimated_cost: float) -> ReservationHandle:
         """Atomically check the ceiling AND hold a tool call's cost in-flight.
 
         The tool-spend counterpart of :meth:`reserve` — and STRONGER than the
@@ -437,14 +494,14 @@ class BudgetGuard:
             raise ValueError(
                 f"estimated_cost must be a finite, non-negative number, got {estimated_cost!r}"
             )
-        return self.reserve(estimated_cost)
+        return self._reserve(estimated_cost, 0, step=None, enforce_tokens=False)
 
     def settle_tool(
         self,
         tool: str,
         cost_usd: float,
         *,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         label: str | None = None,
     ) -> float:
         """Release a reservation and record a tool call's actual cost.
@@ -461,17 +518,15 @@ class BudgetGuard:
         """
         if not math.isfinite(cost_usd) or cost_usd < 0:
             raise ValueError(f"cost_usd must be a finite, non-negative number, got {cost_usd!r}")
-        # A bad reserved handle would corrupt _reserved and break the ceiling for
-        # OTHER in-flight calls — same contract as settle().
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
         # int (and bool) are valid inputs; coerce so the logged event and the
         # return value are always float, like every other cost in the guard.
         cost_usd = float(cost_usd)
         with self._lock:
-            if reserved:
-                self._consume_reservation_locked(reserved)
+            self._consume_handle_locked(reserved, reserved_usd, reserved_tokens, step)
             self.spent_usd += cost_usd
+            if step is not None:
+                step.spent_usd += cost_usd
             # Same sub-epsilon clamp as settle(): never report a rounding-artifact
             # crossing of the ceiling.
             if 0.0 < self.spent_usd - self.limit_usd < _EPS:
@@ -487,7 +542,7 @@ class BudgetGuard:
                     completion_tokens=None,
                     cost_usd=cost_usd,
                     label=label,
-                    reserved=reserved if reserved else None,
+                    reserved=reserved_usd if reserved_usd else None,
                 )
             )
         return cost_usd
@@ -502,24 +557,33 @@ class BudgetGuard:
         """
         return self.settle_tool(tool, cost_usd, reserved=0.0, label=label)
 
-    def release(self, reserved: float) -> None:
+    def release(self, reserved: ReservationHandle) -> None:
         """Drop an in-flight reservation without recording spend (e.g. the call
         failed before producing usage). Safe to call with ``0``."""
         # Validate before the zero-check so a NaN handle raises instead of being
         # silently dropped (which would leak the hold). A bad handle here corrupts
         # _reserved for other in-flight calls.
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
-        if not reserved:
+        reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
+        if not reserved_usd and not reserved_tokens:
+            if isinstance(reserved, BudgetReservation):
+                reserved._active = False
             return
         with self._lock:
-            self._consume_reservation_locked(reserved)
+            self._consume_handle_locked(reserved, reserved_usd, reserved_tokens, step)
 
     @property
     def remaining_usd(self) -> float:
         """USD left before the ceiling, net of in-flight reservations (never negative)."""
         with self._lock:
             return max(0.0, self.limit_usd - self.spent_usd - self._reserved)
+
+    @property
+    def remaining_tokens(self) -> int | None:
+        """Tokens left before the aggregate ceiling, net of reservations."""
+        if self.token_limit is None:
+            return None
+        with self._lock:
+            return max(0, self.token_limit - self.spent_tokens - self._reserved_tokens)
 
     @property
     def tool_costs(self) -> dict[str, float]:
@@ -562,47 +626,219 @@ class BudgetGuard:
         )
 
     def advisory(self) -> BudgetAdvisory:
-        """Context-aware spend advisory for this budget — see :class:`BudgetAdvisory`.
+        """Return aggregate USD/token headroom and the overall taper signal."""
+        return self._advisory(step=None)
 
-        ``near_limit`` flips once utilization reaches ``near_limit_bps`` (default
-        80%), so an agent can taper *before* the hard-stop. Advisory only: read it
-        to adapt; :meth:`check` is what enforces the ceiling.
-        """
-        if self.limit_usd <= 0.0:
-            used_bps = 10000
-        else:
-            # Floor (not round) so used_bps never over-reports utilization and
-            # near_limit flips exactly when the threshold is reached, not a hair
-            # early. The tiny epsilon absorbs float noise (0.7*10000 = 6999.9999…),
-            # and floor matches JS Math.floor exactly — round() would diverge
-            # (Python banker's rounding vs JS ties-up).
-            used_bps = max(0, min(10000, int(self.spent_usd / self.limit_usd * 10000 + 1e-9)))
+    def step(
+        self, *, max_usd: float | None = None, max_tokens: int | None = None
+    ) -> StepBudgetGuard:
+        """Create an explicit scoped guard with fresh per-step ceilings."""
+        return StepBudgetGuard(self, max_usd=max_usd, max_tokens=max_tokens)
+
+    def _advisory(self, step: _StepState | None) -> BudgetAdvisory:
+        used_bps = _used_bps(self.spent_usd, self.limit_usd)
         remaining = max(0.0, self.limit_usd - self.spent_usd)
-        # Lock-free read of the last-cost fields, consistent with reading
-        # spent_usd above: the estimate is the costlier of the last LLM and tool
-        # call (the guard's own default reservation), 0.0 before any call.
-        expected_cost = max(self._last_llm_cost, self._last_tool_cost)
-        # +1e-9 absorbs float noise so e.g. 0.6/0.2 floors to 3 not 2 (same
-        # epsilon rationale as used_bps above, and keeps JS Math.floor parity).
-        est_calls_remaining = (
-            int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
+        token_used_bps = (
+            _used_bps(self.spent_tokens, self.token_limit) if self.token_limit is not None else None
         )
+        remaining_tokens = (
+            max(0, self.token_limit - self.spent_tokens) if self.token_limit is not None else None
+        )
+        near_token_limit = token_used_bps is not None and token_used_bps >= self.near_limit_bps
+        step_usd_bps = (
+            _used_bps(step.spent_usd, step.limit_usd)
+            if step is not None and step.limit_usd is not None
+            else None
+        )
+        step_token_bps = (
+            _used_bps(step.spent_tokens, step.token_limit)
+            if step is not None and step.token_limit is not None
+            else None
+        )
+        step_used_bps = (
+            max(v for v in (step_usd_bps, step_token_bps) if v is not None)
+            if step is not None
+            else None
+        )
+        step_near_limit = step_used_bps is not None and step_used_bps >= self.near_limit_bps
+        expected_cost = max(self._last_llm_cost, self._last_tool_cost)
+        est_calls_remaining = int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
         return BudgetAdvisory(
-            near_limit=used_bps >= self.near_limit_bps,
+            near_limit=(used_bps >= self.near_limit_bps or near_token_limit or step_near_limit),
             used_bps=used_bps,
-            # Settled budget: limit minus accrued spend, deliberately NOT net of
-            # in-flight reservations. This differs from the remaining_usd property
-            # (which subtracts _reserved): the advisory is a soft utilization signal
-            # about money already spent, while the property reports what a new call
-            # can still claim.
             remaining_usd=remaining,
             limit_usd=self.limit_usd,
             spent_usd=self.spent_usd,
             expected_cost=expected_cost,
             est_calls_remaining=est_calls_remaining,
+            token_limit=self.token_limit,
+            spent_tokens=self.spent_tokens,
+            remaining_tokens=remaining_tokens,
+            token_used_bps=token_used_bps,
+            near_token_limit=near_token_limit,
+            step_limit_usd=step.limit_usd if step is not None else None,
+            step_spent_usd=step.spent_usd if step is not None else None,
+            step_remaining_usd=(
+                max(0.0, step.limit_usd - step.spent_usd)
+                if step is not None and step.limit_usd is not None
+                else None
+            ),
+            step_token_limit=step.token_limit if step is not None else None,
+            step_spent_tokens=step.spent_tokens if step is not None else None,
+            step_remaining_tokens=(
+                max(0, step.token_limit - step.spent_tokens)
+                if step is not None and step.token_limit is not None
+                else None
+            ),
+            step_used_bps=step_used_bps,
+            step_near_limit=step_near_limit,
         )
 
     # ── internals ──────────────────────────────────────────────────────────────
+
+    def _check(
+        self,
+        estimated_cost: float | None,
+        estimated_tokens: int | None,
+        *,
+        step: _StepState | None,
+    ) -> None:
+        self._validate_estimate(estimated_cost)
+        _validate_optional_tokens("estimated tokens", estimated_tokens)
+        with self._lock:
+            cost = (
+                self._default_estimate_locked()
+                if estimated_cost is None
+                else max(0.0, estimated_cost)
+            )
+            tokens = self._last_llm_tokens if estimated_tokens is None else estimated_tokens
+            blocked = self._blocking_limit_locked(cost, tokens, step)
+        if blocked is not None:
+            self._raise_block(blocked)
+
+    def _reserve(
+        self,
+        estimated_cost: float | None,
+        estimated_tokens: int | None,
+        *,
+        step: _StepState | None,
+        enforce_tokens: bool = True,
+    ) -> ReservationHandle:
+        self._validate_estimate(estimated_cost)
+        _validate_optional_tokens("estimated tokens", estimated_tokens)
+        if step is not None and not step.active:
+            raise RuntimeError("step budget is no longer active")
+        with self._lock:
+            cost = (
+                self._default_estimate_locked()
+                if estimated_cost is None
+                else max(0.0, estimated_cost)
+            )
+            tokens = self._last_llm_tokens if estimated_tokens is None else estimated_tokens
+            blocked = self._blocking_limit_locked(cost, tokens, step, enforce_tokens=enforce_tokens)
+            if blocked is None:
+                self._reserved += cost
+                self._reserved_tokens += tokens
+                if step is not None:
+                    step.reserved_usd += cost
+                    step.reserved_tokens += tokens
+                if self.token_limit is None and step is None:
+                    return cost
+                return BudgetReservation(cost, tokens, self, step)
+        self._raise_block(blocked)
+        raise AssertionError("unreachable")
+
+    def _blocking_limit_locked(
+        self,
+        cost: float,
+        tokens: int,
+        step: _StepState | None,
+        *,
+        enforce_tokens: bool = True,
+    ) -> tuple[str, str, float | int, float | int] | None:
+        committed_usd = self.spent_usd + self._reserved
+        if committed_usd > self.limit_usd - _EPS or committed_usd + cost > self.limit_usd + _EPS:
+            return ("usd", "aggregate", self.spent_usd, self.limit_usd)
+        committed_tokens = self.spent_tokens + self._reserved_tokens
+        if (
+            enforce_tokens
+            and self.token_limit is not None
+            and (
+                committed_tokens >= self.token_limit or committed_tokens + tokens > self.token_limit
+            )
+        ):
+            return ("tokens", "aggregate", self.spent_tokens, self.token_limit)
+        if step is not None:
+            committed_step_usd = step.spent_usd + step.reserved_usd
+            if step.limit_usd is not None and (
+                committed_step_usd > step.limit_usd - _EPS
+                or committed_step_usd + cost > step.limit_usd + _EPS
+            ):
+                return ("usd", "step", step.spent_usd, step.limit_usd)
+            committed_step_tokens = step.spent_tokens + step.reserved_tokens
+            if (
+                enforce_tokens
+                and step.token_limit is not None
+                and (
+                    committed_step_tokens >= step.token_limit
+                    or committed_step_tokens + tokens > step.token_limit
+                )
+            ):
+                return ("tokens", "step", step.spent_tokens, step.token_limit)
+        return None
+
+    def _raise_block(self, blocked: tuple[str, str, float | int, float | int]) -> None:
+        metric, scope, spent, limit = blocked
+        if metric == "usd":
+            self._on_block(float(spent), float(limit))
+            raise BudgetExceeded(float(spent), float(limit), scope=scope)
+        self._on_token_block(int(spent), int(limit))
+        raise TokenBudgetExceeded(int(spent), int(limit), scope=scope)
+
+    def _reservation_parts(
+        self, reserved: ReservationHandle
+    ) -> tuple[float, int, _StepState | None]:
+        if isinstance(reserved, BudgetReservation):
+            if reserved._owner is not self:
+                raise ValueError("reservation belongs to a different BudgetGuard")
+            if not reserved._active:
+                raise ValueError("reservation has already been settled or released")
+            return reserved.usd, reserved.tokens, reserved._step
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        return float(reserved), 0, None
+
+    def _consume_handle_locked(
+        self,
+        handle: ReservationHandle,
+        reserved_usd: float,
+        reserved_tokens: int,
+        step: _StepState | None,
+    ) -> None:
+        if not reserved_usd and not reserved_tokens:
+            if isinstance(handle, BudgetReservation):
+                handle._active = False
+            return
+        if reserved_usd > self._reserved + _EPS:
+            raise ValueError("reserved USD handle exceeds total in-flight reservations")
+        if reserved_tokens > self._reserved_tokens:
+            raise ValueError("reserved token handle exceeds total in-flight reservations")
+        if step is not None:
+            if reserved_usd > step.reserved_usd + _EPS or reserved_tokens > step.reserved_tokens:
+                raise ValueError("reservation exceeds its step's in-flight totals")
+        self._consume_reservation_locked(reserved_usd)
+        self._reserved_tokens -= reserved_tokens
+        if step is not None:
+            step.reserved_usd = max(0.0, step.reserved_usd - reserved_usd)
+            step.reserved_tokens -= reserved_tokens
+        if isinstance(handle, BudgetReservation):
+            handle._active = False
+
+    def _accrue_tokens_locked(self, total_tokens: int, step: _StepState | None) -> None:
+        self.spent_tokens += total_tokens
+        self._last_llm_tokens = total_tokens
+        if step is not None:
+            step.spent_tokens += total_tokens
 
     def _default_estimate_locked(self) -> float:
         """The default next-call prediction when the caller supplies no
@@ -638,14 +874,21 @@ class BudgetGuard:
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
 
-    def _stream_register(self, reserved: float) -> object:
+    def _stream_register(self, reserved: ReservationHandle) -> object:
         """Register an active stream (see :class:`~floe_guard.stream.StreamGuard`)
         and return its registry key. Active streams' accrued-but-unsettled costs
         count against the ceiling for each OTHER stream, so parallel unreserved
         streams share the budget instead of each spending the full ceiling."""
+        reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
         key = object()
         with self._lock:
-            self._stream_costs[key] = (0.0, max(0.0, reserved))
+            self._stream_costs[key] = (
+                0.0,
+                0,
+                reserved_usd,
+                reserved_tokens,
+                step,
+            )
         return key
 
     def _stream_unregister(self, key: object) -> None:
@@ -654,7 +897,9 @@ class BudgetGuard:
         with self._lock:
             self._stream_costs.pop(key, None)
 
-    def _stream_would_cross(self, key: object, cumulative_call_cost: float) -> bool:
+    def _stream_would_cross(
+        self, key: object, cumulative_call_cost: float, cumulative_tokens: int
+    ) -> tuple[str, str, float | int, float | int] | None:
         """Atomically record stream ``key``'s cumulative cost so far and answer:
         would it cross the ceiling? Counted against the limit: settled spend,
         other calls' reservations (this stream's own hold is excluded — its real
@@ -663,15 +908,71 @@ class BudgetGuard:
         inside ``_reserved``). Used by :class:`~floe_guard.stream.StreamGuard`.
         """
         with self._lock:
-            own_reserved = self._stream_costs.get(key, (0.0, 0.0))[1]
-            self._stream_costs[key] = (cumulative_call_cost, own_reserved)
-            other_overage = sum(
-                max(0.0, accrued - held)
-                for k, (accrued, held) in self._stream_costs.items()
+            _, _, own_usd, own_tokens, step = self._stream_costs.get(key, (0.0, 0, 0.0, 0, None))
+            self._stream_costs[key] = (
+                cumulative_call_cost,
+                cumulative_tokens,
+                own_usd,
+                own_tokens,
+                step,
+            )
+            other_usd_overage = sum(
+                max(0.0, accrued_usd - held_usd)
+                for k, (accrued_usd, _, held_usd, _, _) in self._stream_costs.items()
                 if k is not key
             )
-            others = self.spent_usd + max(0.0, self._reserved - own_reserved) + other_overage
-            return others + cumulative_call_cost > self.limit_usd + _EPS
+            other_token_overage = sum(
+                max(0, accrued_tokens - held_tokens)
+                for k, (_, accrued_tokens, _, held_tokens, _) in self._stream_costs.items()
+                if k is not key
+            )
+            aggregate_usd = self.spent_usd + max(0.0, self._reserved - own_usd) + other_usd_overage
+            if aggregate_usd + cumulative_call_cost > self.limit_usd + _EPS:
+                return ("usd", "aggregate", self.spent_usd, self.limit_usd)
+            aggregate_tokens = (
+                self.spent_tokens + max(0, self._reserved_tokens - own_tokens) + other_token_overage
+            )
+            if (
+                self.token_limit is not None
+                and aggregate_tokens + cumulative_tokens > self.token_limit
+            ):
+                return ("tokens", "aggregate", self.spent_tokens, self.token_limit)
+            if step is not None:
+                same_step_usd_overage = sum(
+                    max(0.0, accrued_usd - held_usd)
+                    for k, (accrued_usd, _, held_usd, _, other_step) in self._stream_costs.items()
+                    if k is not key and other_step is step
+                )
+                step_usd = (
+                    step.spent_usd + max(0.0, step.reserved_usd - own_usd) + same_step_usd_overage
+                )
+                if (
+                    step.limit_usd is not None
+                    and step_usd + cumulative_call_cost > step.limit_usd + _EPS
+                ):
+                    return ("usd", "step", step.spent_usd, step.limit_usd)
+                same_step_token_overage = sum(
+                    max(0, accrued_tokens - held_tokens)
+                    for k, (
+                        _,
+                        accrued_tokens,
+                        _,
+                        held_tokens,
+                        other_step,
+                    ) in self._stream_costs.items()
+                    if k is not key and other_step is step
+                )
+                step_tokens = (
+                    step.spent_tokens
+                    + max(0, step.reserved_tokens - own_tokens)
+                    + same_step_token_overage
+                )
+                if (
+                    step.token_limit is not None
+                    and step_tokens + cumulative_tokens > step.token_limit
+                ):
+                    return ("tokens", "step", step.spent_tokens, step.token_limit)
+            return None
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:
         with self._lock:
@@ -694,11 +995,173 @@ class BudgetGuard:
         return resolve_price(model, overrides)
 
 
+class StepBudgetGuard:
+    """A scoped guard that enforces fresh per-step limits plus its parent limits."""
+
+    def __init__(
+        self,
+        parent: BudgetGuard,
+        *,
+        max_usd: float | None,
+        max_tokens: int | None,
+    ) -> None:
+        if max_usd is None and max_tokens is None:
+            raise ValueError("step requires max_usd, max_tokens, or both")
+        if max_usd is not None and (not math.isfinite(max_usd) or max_usd < 0):
+            raise ValueError(f"max_usd must be a finite, non-negative number, got {max_usd!r}")
+        _validate_optional_tokens("max_tokens", max_tokens)
+        self._parent = parent
+        self._state = _StepState(
+            limit_usd=float(max_usd) if max_usd is not None else None,
+            token_limit=max_tokens,
+        )
+
+    def __enter__(self) -> StepBudgetGuard:
+        if not self._state.active:
+            raise RuntimeError("step budget cannot be re-entered")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._state.active = False
+        if exc_type is None and (
+            self._state.reserved_usd > _EPS or self._state.reserved_tokens > 0
+        ):
+            raise RuntimeError(
+                "step exited with an active reservation; settle or release every handle"
+            )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._parent, name)
+
+    def check(
+        self,
+        estimated_next_cost: float | None = None,
+        *,
+        estimated_next_tokens: int | None = None,
+    ) -> None:
+        self._ensure_active()
+        self._parent._check(estimated_next_cost, estimated_next_tokens, step=self._state)
+
+    def reserve(
+        self,
+        estimated_cost: float | None = None,
+        *,
+        estimated_tokens: int | None = None,
+    ) -> ReservationHandle:
+        self._ensure_active()
+        return self._parent._reserve(estimated_cost, estimated_tokens, step=self._state)
+
+    def settle(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        reserved: ReservationHandle = 0.0,
+        price: ManualPrice | None = None,
+        cache_creation_input_tokens: int = 0,
+        cache_creation_input_tokens_1h: int = 0,
+        cache_read_input_tokens: int = 0,
+        label: str | None = None,
+    ) -> float:
+        self._ensure_active()
+        if not isinstance(reserved, BudgetReservation):
+            reserved = BudgetReservation(float(reserved), 0, self._parent, self._state)
+        return self._parent.settle(
+            model,
+            prompt_tokens,
+            completion_tokens,
+            reserved=reserved,
+            price=price,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_creation_input_tokens_1h=cache_creation_input_tokens_1h,
+            cache_read_input_tokens=cache_read_input_tokens,
+            label=label,
+        )
+
+    def record(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        *,
+        price: ManualPrice | None = None,
+        cache_creation_input_tokens: int = 0,
+        cache_creation_input_tokens_1h: int = 0,
+        cache_read_input_tokens: int = 0,
+        label: str | None = None,
+    ) -> float:
+        handle = BudgetReservation(0.0, 0, self._parent, self._state)
+        return self.settle(
+            model,
+            prompt_tokens,
+            completion_tokens,
+            reserved=handle,
+            price=price,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cache_creation_input_tokens_1h=cache_creation_input_tokens_1h,
+            cache_read_input_tokens=cache_read_input_tokens,
+            label=label,
+        )
+
+    def reserve_tool(self, estimated_cost: float) -> ReservationHandle:
+        self._ensure_active()
+        return self._parent._reserve(estimated_cost, 0, step=self._state, enforce_tokens=False)
+
+    def settle_tool(
+        self,
+        tool: str,
+        cost_usd: float,
+        *,
+        reserved: ReservationHandle = 0.0,
+        label: str | None = None,
+    ) -> float:
+        self._ensure_active()
+        if not isinstance(reserved, BudgetReservation):
+            reserved = BudgetReservation(float(reserved), 0, self._parent, self._state)
+        return self._parent.settle_tool(tool, cost_usd, reserved=reserved, label=label)
+
+    def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
+        handle = BudgetReservation(0.0, 0, self._parent, self._state)
+        return self._parent.settle_tool(tool, cost_usd, reserved=handle, label=label)
+
+    def release(self, reserved: ReservationHandle) -> None:
+        self._parent.release(reserved)
+
+    def advisory(self) -> BudgetAdvisory:
+        return self._parent._advisory(self._state)
+
+    def _ensure_active(self) -> None:
+        if not self._state.active:
+            raise RuntimeError("step budget is no longer active")
+
+
+def _validate_optional_tokens(name: str, value: int | None) -> None:
+    if value is not None and (isinstance(value, bool) or not isinstance(value, int) or value < 0):
+        raise ValueError(f"{name} must be None or a non-negative int, got {value!r}")
+
+
+def _used_bps(used: float | int, limit: float | int) -> int:
+    if limit <= 0:
+        return 10000
+    return max(0, min(10000, int(used / limit * 10000 + 1e-9)))
+
+
 def _default_on_block(spent_usd: float, limit_usd: float) -> None:
     print(
         "BUDGET EXCEEDED — call blocked\n"
         f"  spent so far: ${spent_usd:.6f}  |  ceiling: ${limit_usd:.6f}\n"
         "  The next call would cross your budget; floe-guard stopped your agent "
         "before it ran.",
+        file=sys.stderr,
+    )
+
+
+def _default_on_token_block(spent_tokens: int, limit_tokens: int) -> None:
+    print(
+        "TOKEN BUDGET EXCEEDED — call blocked\n"
+        f"  tokens so far: {spent_tokens}  |  ceiling: {limit_tokens}\n"
+        "  The next call would cross your token budget; floe-guard stopped your "
+        "agent before it ran.",
         file=sys.stderr,
     )

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -751,16 +751,22 @@ class BudgetGuard:
                 else max(0.0, estimated_cost)
             )
             tokens = self._last_llm_tokens if estimated_tokens is None else estimated_tokens
-            blocked = self._blocking_limit_locked(cost, tokens, step, enforce_tokens=enforce_tokens)
+            reserved_tokens = tokens if self.token_limit is not None or step is not None else 0
+            blocked = self._blocking_limit_locked(
+                cost,
+                reserved_tokens,
+                step,
+                enforce_tokens=enforce_tokens,
+            )
             if blocked is None:
                 self._reserved += cost
-                self._reserved_tokens += tokens
+                self._reserved_tokens += reserved_tokens
                 if step is not None:
                     step.reserved_usd += cost
-                    step.reserved_tokens += tokens
+                    step.reserved_tokens += reserved_tokens
                 if self.token_limit is None and step is None:
                     return cost
-                return self._make_reservation_locked(cost, tokens, step)
+                return self._make_reservation_locked(cost, reserved_tokens, step)
         self._raise_block(blocked)
         raise AssertionError("unreachable")
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -37,7 +37,7 @@ import weakref
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal
 
 from .errors import (
     BudgetExceeded,
@@ -276,7 +276,7 @@ class BudgetGuard:
         # Per-call ledger; deque(maxlen=None) is unbounded, otherwise a ring buffer.
         self._spend_log: deque[SpendEvent] = deque(maxlen=max_log_events)
         # Active streams' (accrued_usd, reserved_usd), keyed by registry token —
-        # see _stream_register(). Lets parallel streams count each other's
+        # see _stream_prepare(). Lets parallel streams count each other's
         # in-flight accrual against the ceiling before anything settles.
         self._stream_costs: dict[object, tuple[float, int, float, int, _StepState | None]] = {}
         # Per-tool running totals (settle_tool/record_tool) — the tool side of
@@ -742,9 +742,9 @@ class BudgetGuard:
     ) -> ReservationHandle:
         self._validate_estimate(estimated_cost)
         _validate_optional_tokens("estimated tokens", estimated_tokens)
-        if step is not None and not step.active:
-            raise RuntimeError("step budget is no longer active")
         with self._lock:
+            if step is not None and not step.active:
+                raise RuntimeError("step budget is no longer active")
             cost = (
                 self._default_estimate_locked()
                 if estimated_cost is None
@@ -876,6 +876,23 @@ class BudgetGuard:
             raise ValueError("scoped numeric reservation handles must be zero")
         return self._make_reservation(0.0, 0, step)
 
+    def _validate_scoped_reservation(self, reserved: ReservationHandle, step: _StepState) -> None:
+        """Validate a scoped handle without creating a zero-valued replacement."""
+        with self._lock:
+            if not step.active:
+                raise RuntimeError("step budget is no longer active")
+            if isinstance(reserved, BudgetReservation):
+                state = self._typed_reservation_state_locked(reserved)
+                if state.step is not step:
+                    raise ValueError("reservation belongs to a different step budget")
+                return
+            if not math.isfinite(reserved) or reserved < 0:
+                raise ValueError(
+                    f"reserved must be a finite, non-negative number, got {reserved!r}"
+                )
+            if reserved != 0:
+                raise ValueError("scoped numeric reservation handles must be zero")
+
     def _consume_handle_locked(
         self,
         handle: ReservationHandle,
@@ -949,22 +966,60 @@ class BudgetGuard:
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
 
-    def _stream_register(self, reserved: ReservationHandle) -> object:
+    def _stream_register_locked(
+        self,
+        reserved_usd: float,
+        reserved_tokens: int,
+        step: _StepState | None,
+    ) -> object:
+        """Register a stream after its handle is validated. Caller holds ``_lock``."""
+        key = object()
+        self._stream_costs[key] = (
+            0.0,
+            0,
+            reserved_usd,
+            reserved_tokens,
+            step,
+        )
+        return key
+
+    def _stream_validate_reservation(self, reserved: ReservationHandle) -> None:
+        """Reject malformed handles before stream construction does any setup."""
+        self._reservation_parts(reserved)
+
+    def _stream_prepare(self, reserved: ReservationHandle) -> tuple[ReservationHandle, object]:
         """Register an active stream (see :class:`~floe_guard.stream.StreamGuard`)
         and return its registry key. Active streams' accrued-but-unsettled costs
         count against the ceiling for each OTHER stream, so parallel unreserved
         streams share the budget instead of each spending the full ceiling."""
         reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
-        key = object()
         with self._lock:
-            self._stream_costs[key] = (
-                0.0,
-                0,
-                reserved_usd,
-                reserved_tokens,
-                step,
-            )
-        return key
+            key = self._stream_register_locked(reserved_usd, reserved_tokens, step)
+        return reserved, key
+
+    def _stream_prepare_scoped(
+        self, reserved: ReservationHandle, step: _StepState
+    ) -> tuple[BudgetReservation, object]:
+        """Atomically validate scope liveness, normalize its handle, and register."""
+        with self._lock:
+            if not step.active:
+                raise RuntimeError("step budget is no longer active")
+            if isinstance(reserved, BudgetReservation):
+                state = self._typed_reservation_state_locked(reserved)
+                if state.step is not step:
+                    raise ValueError("reservation belongs to a different step budget")
+                normalized = reserved
+            else:
+                if not math.isfinite(reserved) or reserved < 0:
+                    raise ValueError(
+                        f"reserved must be a finite, non-negative number, got {reserved!r}"
+                    )
+                if reserved != 0:
+                    raise ValueError("scoped numeric reservation handles must be zero")
+                normalized = self._make_reservation_locked(0.0, 0, step)
+                state = self._typed_reservation_state_locked(normalized)
+            key = self._stream_register_locked(state.usd, state.tokens, state.step)
+        return normalized, key
 
     def _stream_unregister(self, key: object) -> None:
         """Drop a stream's registry entry once its cost is settled (settle()
@@ -991,16 +1046,29 @@ class BudgetGuard:
                 own_tokens,
                 step,
             )
-            other_usd_overage = sum(
-                max(0.0, accrued_usd - held_usd)
-                for k, (accrued_usd, _, held_usd, _, _) in self._stream_costs.items()
-                if k is not key
-            )
-            other_token_overage = sum(
-                max(0, accrued_tokens - held_tokens)
-                for k, (_, accrued_tokens, _, held_tokens, _) in self._stream_costs.items()
-                if k is not key
-            )
+            other_usd_overage = 0.0
+            other_token_overage = 0
+            same_step_usd_overage = 0.0
+            same_step_token_overage = 0
+            for (
+                other_key,
+                (
+                    accrued_usd,
+                    accrued_tokens,
+                    held_usd,
+                    held_tokens,
+                    other_step,
+                ),
+            ) in self._stream_costs.items():
+                if other_key is key:
+                    continue
+                usd_overage = max(0.0, accrued_usd - held_usd)
+                token_overage = max(0, accrued_tokens - held_tokens)
+                other_usd_overage += usd_overage
+                other_token_overage += token_overage
+                if step is not None and other_step is step:
+                    same_step_usd_overage += usd_overage
+                    same_step_token_overage += token_overage
             aggregate_usd = self.spent_usd + max(0.0, self._reserved - own_usd) + other_usd_overage
             if aggregate_usd + cumulative_call_cost > self.limit_usd + _EPS:
                 return ("usd", "aggregate", self.spent_usd, self.limit_usd)
@@ -1013,11 +1081,6 @@ class BudgetGuard:
             ):
                 return ("tokens", "aggregate", self.spent_tokens, self.token_limit)
             if step is not None:
-                same_step_usd_overage = sum(
-                    max(0.0, accrued_usd - held_usd)
-                    for k, (accrued_usd, _, held_usd, _, other_step) in self._stream_costs.items()
-                    if k is not key and other_step is step
-                )
                 step_usd = (
                     step.spent_usd + max(0.0, step.reserved_usd - own_usd) + same_step_usd_overage
                 )
@@ -1026,17 +1089,6 @@ class BudgetGuard:
                     and step_usd + cumulative_call_cost > step.limit_usd + _EPS
                 ):
                     return ("usd", "step", step.spent_usd, step.limit_usd)
-                same_step_token_overage = sum(
-                    max(0, accrued_tokens - held_tokens)
-                    for k, (
-                        _,
-                        accrued_tokens,
-                        _,
-                        held_tokens,
-                        other_step,
-                    ) in self._stream_costs.items()
-                    if k is not key and other_step is step
-                )
                 step_tokens = (
                     step.spent_tokens
                     + max(0, step.reserved_tokens - own_tokens)
@@ -1099,16 +1151,75 @@ class StepBudgetGuard:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
-        self._state.active = False
-        if exc_type is None and (
-            self._state.reserved_usd > _EPS or self._state.reserved_tokens > 0
-        ):
+        with self._parent._lock:
+            self._state.active = False
+            leaked = self._state.reserved_usd > _EPS or self._state.reserved_tokens > 0
+        if exc_type is None and leaked:
             raise RuntimeError(
                 "step exited with an active reservation; settle or release every handle"
             )
 
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._parent, name)
+    @property
+    def limit_usd(self) -> float:
+        return self._parent.limit_usd
+
+    @property
+    def token_limit(self) -> int | None:
+        return self._parent.token_limit
+
+    @property
+    def spent_usd(self) -> float:
+        return self._parent.spent_usd
+
+    @property
+    def spent_tokens(self) -> int:
+        return self._parent.spent_tokens
+
+    @property
+    def remaining_usd(self) -> float:
+        return self._parent.remaining_usd
+
+    @property
+    def remaining_tokens(self) -> int | None:
+        return self._parent.remaining_tokens
+
+    @property
+    def price_overrides(self) -> dict[str, ManualPrice] | None:
+        return self._parent.price_overrides
+
+    @property
+    def fail_closed(self) -> bool:
+        return self._parent.fail_closed
+
+    @property
+    def near_limit_bps(self) -> int:
+        return self._parent.near_limit_bps
+
+    @property
+    def tool_costs(self) -> dict[str, float]:
+        return self._parent.tool_costs
+
+    @property
+    def spend_log(self) -> list[SpendEvent]:
+        return self._parent.spend_log
+
+    def estimate_call(
+        self,
+        model: str,
+        prompt_tokens: int,
+        max_completion_tokens: int = 0,
+        *,
+        price: ManualPrice | None = None,
+    ) -> float | None:
+        return self._parent.estimate_call(
+            model,
+            prompt_tokens,
+            max_completion_tokens,
+            price=price,
+        )
+
+    def export_log(self) -> str:
+        return self._parent.export_log()
 
     def check(
         self,
@@ -1208,6 +1319,26 @@ class StepBudgetGuard:
 
     def advisory(self) -> BudgetAdvisory:
         return self._parent._advisory(self._state)
+
+    def _stream_validate_reservation(self, reserved: ReservationHandle) -> None:
+        self._parent._validate_scoped_reservation(reserved, self._state)
+
+    def _stream_prepare(self, reserved: ReservationHandle) -> tuple[BudgetReservation, object]:
+        return self._parent._stream_prepare_scoped(reserved, self._state)
+
+    def _stream_would_cross(
+        self, key: object, cumulative_call_cost: float, cumulative_tokens: int
+    ) -> tuple[str, str, float | int, float | int] | None:
+        return self._parent._stream_would_cross(key, cumulative_call_cost, cumulative_tokens)
+
+    def _stream_unregister(self, key: object) -> None:
+        self._parent._stream_unregister(key)
+
+    def _resolve(self, model: str, price: ManualPrice | None):
+        return self._parent._resolve(model, price)
+
+    def _raise_block(self, blocked: tuple[str, str, float | int, float | int]) -> None:
+        self._parent._raise_block(blocked)
 
     def _ensure_active(self) -> None:
         if not self._state.active:

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -1015,10 +1015,12 @@ class StepBudgetGuard:
             limit_usd=float(max_usd) if max_usd is not None else None,
             token_limit=max_tokens,
         )
+        self._entered = False
 
     def __enter__(self) -> StepBudgetGuard:
-        if not self._state.active:
+        if self._entered or not self._state.active:
             raise RuntimeError("step budget cannot be re-entered")
+        self._entered = True
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
@@ -1122,8 +1124,7 @@ class StepBudgetGuard:
         return self._parent.settle_tool(tool, cost_usd, reserved=reserved, label=label)
 
     def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
-        handle = BudgetReservation(0.0, 0, self._parent, self._state)
-        return self._parent.settle_tool(tool, cost_usd, reserved=handle, label=label)
+        return self.settle_tool(tool, cost_usd, label=label)
 
     def release(self, reserved: ReservationHandle) -> None:
         self._parent.release(reserved)

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -33,6 +33,7 @@ import sys
 import threading
 import time
 import warnings
+import weakref
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -106,15 +107,25 @@ class _StepState:
     active: bool = True
 
 
-@dataclass(eq=False)
+@dataclass(frozen=True, eq=False)
 class BudgetReservation:
-    """Opaque multi-dimensional reservation returned by token/step guards."""
+    """Opaque immutable reservation returned by token/step guards.
+
+    Read ``usd`` and ``tokens`` for diagnostics, but do not construct, copy, or
+    modify handles. Only the issuing guard's private registry is authoritative.
+    """
 
     usd: float
     tokens: int
     _owner: BudgetGuard
-    _step: _StepState | None = None
-    _active: bool = True
+
+
+@dataclass(frozen=True)
+class _ReservationState:
+    issued: weakref.ReferenceType[BudgetReservation]
+    usd: float
+    tokens: int
+    step: _StepState | None
 
 
 ReservationHandle = float | BudgetReservation
@@ -246,6 +257,13 @@ class BudgetGuard:
         # Counted against the ceiling so concurrent callers can't overshoot.
         self._reserved = 0.0
         self._reserved_tokens = 0
+        # Typed handles are immutable caller-visible identities. Accounting and
+        # lifecycle state live here so forged, copied, or modified handles can
+        # never release another caller's hold.
+        self._reservations: weakref.WeakKeyDictionary[BudgetReservation, _ReservationState] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._consumed_reservations: weakref.WeakSet[BudgetReservation] = weakref.WeakSet()
         # Same int-not-bool contract as near_limit_bps (parity with TS Number.isInteger).
         if max_log_events is not None and (
             isinstance(max_log_events, bool)
@@ -564,9 +582,7 @@ class BudgetGuard:
         # silently dropped (which would leak the hold). A bad handle here corrupts
         # _reserved for other in-flight calls.
         reserved_usd, reserved_tokens, step = self._reservation_parts(reserved)
-        if not reserved_usd and not reserved_tokens:
-            if isinstance(reserved, BudgetReservation):
-                reserved._active = False
+        if not isinstance(reserved, BudgetReservation) and not reserved_usd:
             return
         with self._lock:
             self._consume_handle_locked(reserved, reserved_usd, reserved_tokens, step)
@@ -744,7 +760,7 @@ class BudgetGuard:
                     step.reserved_tokens += tokens
                 if self.token_limit is None and step is None:
                     return cost
-                return BudgetReservation(cost, tokens, self, step)
+                return self._make_reservation_locked(cost, tokens, step)
         self._raise_block(blocked)
         raise AssertionError("unreachable")
 
@@ -799,14 +815,66 @@ class BudgetGuard:
         self, reserved: ReservationHandle
     ) -> tuple[float, int, _StepState | None]:
         if isinstance(reserved, BudgetReservation):
-            if reserved._owner is not self:
-                raise ValueError("reservation belongs to a different BudgetGuard")
-            if not reserved._active:
-                raise ValueError("reservation has already been settled or released")
-            return reserved.usd, reserved.tokens, reserved._step
+            with self._lock:
+                state = self._typed_reservation_state_locked(reserved)
+                return state.usd, state.tokens, state.step
         if not math.isfinite(reserved) or reserved < 0:
             raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
         return float(reserved), 0, None
+
+    def _make_reservation_locked(
+        self, usd: float, tokens: int, step: _StepState | None
+    ) -> BudgetReservation:
+        """Create and register a typed handle. Caller must hold ``self._lock``."""
+        handle = BudgetReservation(usd, tokens, self)
+        self._reservations[handle] = _ReservationState(weakref.ref(handle), usd, tokens, step)
+        return handle
+
+    def _make_reservation(
+        self, usd: float, tokens: int, step: _StepState | None
+    ) -> BudgetReservation:
+        """Create a registered zero/default handle for a scoped post-hoc record."""
+        with self._lock:
+            return self._make_reservation_locked(usd, tokens, step)
+
+    def _typed_reservation_state_locked(self, handle: BudgetReservation) -> _ReservationState:
+        """Validate a typed handle without mutating accounting state."""
+        if handle._owner is not self:
+            raise ValueError("reservation belongs to a different BudgetGuard")
+        if handle in self._consumed_reservations:
+            raise ValueError("reservation has already been settled or released")
+        state = self._reservations.get(handle)
+        if state is None or state.issued() is not handle:
+            raise ValueError("reservation handle was not issued by this BudgetGuard")
+        if (
+            not math.isfinite(handle.usd)
+            or handle.usd < 0
+            or isinstance(handle.tokens, bool)
+            or not isinstance(handle.tokens, int)
+            or handle.tokens < 0
+            or type(handle.usd) is not type(state.usd)
+            or type(handle.tokens) is not type(state.tokens)
+            or handle.usd != state.usd
+            or handle.tokens != state.tokens
+        ):
+            raise ValueError("reservation handle has been modified")
+        return state
+
+    def _scoped_reservation(
+        self, reserved: ReservationHandle, step: _StepState
+    ) -> BudgetReservation:
+        """Return a genuine handle for ``step``; numeric scoped handles must be zero."""
+        if isinstance(reserved, BudgetReservation):
+            with self._lock:
+                state = self._typed_reservation_state_locked(reserved)
+                if state.step is not step:
+                    raise ValueError("reservation belongs to a different step budget")
+            return reserved
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        if reserved != 0:
+            raise ValueError("scoped numeric reservation handles must be zero")
+        return self._make_reservation(0.0, 0, step)
 
     def _consume_handle_locked(
         self,
@@ -815,9 +883,15 @@ class BudgetGuard:
         reserved_tokens: int,
         step: _StepState | None,
     ) -> None:
-        if not reserved_usd and not reserved_tokens:
-            if isinstance(handle, BudgetReservation):
-                handle._active = False
+        if isinstance(handle, BudgetReservation):
+            state = self._typed_reservation_state_locked(handle)
+            if (
+                reserved_usd != state.usd
+                or reserved_tokens != state.tokens
+                or step is not state.step
+            ):
+                raise ValueError("reservation handle state changed during settlement")
+        elif not reserved_usd and not reserved_tokens:
             return
         if reserved_usd > self._reserved + _EPS:
             raise ValueError("reserved USD handle exceeds total in-flight reservations")
@@ -832,7 +906,8 @@ class BudgetGuard:
             step.reserved_usd = max(0.0, step.reserved_usd - reserved_usd)
             step.reserved_tokens -= reserved_tokens
         if isinstance(handle, BudgetReservation):
-            handle._active = False
+            del self._reservations[handle]
+            self._consumed_reservations.add(handle)
 
     def _accrue_tokens_locked(self, total_tokens: int, step: _StepState | None) -> None:
         self.spent_tokens += total_tokens
@@ -1067,8 +1142,7 @@ class StepBudgetGuard:
         label: str | None = None,
     ) -> float:
         self._ensure_active()
-        if not isinstance(reserved, BudgetReservation):
-            reserved = BudgetReservation(float(reserved), 0, self._parent, self._state)
+        reserved = self._parent._scoped_reservation(reserved, self._state)
         return self._parent.settle(
             model,
             prompt_tokens,
@@ -1093,7 +1167,8 @@ class StepBudgetGuard:
         cache_read_input_tokens: int = 0,
         label: str | None = None,
     ) -> float:
-        handle = BudgetReservation(0.0, 0, self._parent, self._state)
+        self._ensure_active()
+        handle = self._parent._make_reservation(0.0, 0, self._state)
         return self.settle(
             model,
             prompt_tokens,
@@ -1119,14 +1194,16 @@ class StepBudgetGuard:
         label: str | None = None,
     ) -> float:
         self._ensure_active()
-        if not isinstance(reserved, BudgetReservation):
-            reserved = BudgetReservation(float(reserved), 0, self._parent, self._state)
+        reserved = self._parent._scoped_reservation(reserved, self._state)
         return self._parent.settle_tool(tool, cost_usd, reserved=reserved, label=label)
 
     def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
-        return self.settle_tool(tool, cost_usd, label=label)
+        self._ensure_active()
+        handle = self._parent._make_reservation(0.0, 0, self._state)
+        return self.settle_tool(tool, cost_usd, reserved=handle, label=label)
 
     def release(self, reserved: ReservationHandle) -> None:
+        reserved = self._parent._scoped_reservation(reserved, self._state)
         self._parent.release(reserved)
 
     def advisory(self) -> BudgetAdvisory:

--- a/src/floe_guard/integrations/langchain.py
+++ b/src/floe_guard/integrations/langchain.py
@@ -63,6 +63,18 @@ def _estimate_start(guard: BudgetGuard, serialized: Any, texts: list[str]) -> fl
     return guard.estimate_call(str(model), prompt_tokens, max_out)
 
 
+def _estimate_start_tokens(serialized: Any, texts: list[str]) -> int | None:
+    model_kwargs = serialized.get("kwargs") if isinstance(serialized, dict) else None
+    if not isinstance(model_kwargs, dict):
+        return None
+    prompt_tokens = sum(approx_tokens(t) for t in texts if isinstance(t, str))
+    max_out = model_kwargs.get("max_tokens") or model_kwargs.get("max_completion_tokens") or 0
+    try:
+        return prompt_tokens + max(0, int(max_out))
+    except (TypeError, ValueError):
+        return prompt_tokens
+
+
 def _chat_texts(messages: Any) -> list[str]:
     """Flatten LangChain's batched chat messages to their text contents."""
     texts: list[str] = []
@@ -153,10 +165,17 @@ def budget_guard_callback_handler(guard: BudgetGuard) -> Any:
             # Request-sized when derivable (see _estimate_start); check(None)
             # falls back to the last-cost prediction.
             texts = [p for p in (prompts or []) if isinstance(p, str)]
-            self.guard.check(_estimate_start(self.guard, serialized, texts))
+            self.guard.check(
+                _estimate_start(self.guard, serialized, texts),
+                estimated_next_tokens=_estimate_start_tokens(serialized, texts),
+            )
 
         def on_chat_model_start(self, serialized: Any, messages: Any, **kwargs: Any) -> None:
-            self.guard.check(_estimate_start(self.guard, serialized, _chat_texts(messages)))
+            texts = _chat_texts(messages)
+            self.guard.check(
+                _estimate_start(self.guard, serialized, texts),
+                estimated_next_tokens=_estimate_start_tokens(serialized, texts),
+            )
 
         def on_llm_end(self, response: Any, **kwargs: Any) -> None:
             _record_result(self.guard, response)

--- a/src/floe_guard/integrations/langchain.py
+++ b/src/floe_guard/integrations/langchain.py
@@ -69,10 +69,10 @@ def _estimate_start(
 
 
 def _estimate_start_tokens(serialized: Any, texts: list[str]) -> int | None:
+    prompt_tokens = sum(approx_tokens(t) for t in texts if isinstance(t, str))
     model_kwargs = serialized.get("kwargs") if isinstance(serialized, dict) else None
     if not isinstance(model_kwargs, dict):
-        return None
-    prompt_tokens = sum(approx_tokens(t) for t in texts if isinstance(t, str))
+        return prompt_tokens or None
     max_out = model_kwargs.get("max_tokens") or model_kwargs.get("max_completion_tokens") or 0
     try:
         return prompt_tokens + max(0, int(max_out))

--- a/src/floe_guard/integrations/langchain.py
+++ b/src/floe_guard/integrations/langchain.py
@@ -1,10 +1,11 @@
 """LangChain adapter (optional extra: ``pip install floe-guard[langchain]``).
 
 :func:`budget_guard_callback_handler` builds a LangChain callback handler you pass
-to any LLM or chat model. It checks the budget *before* the call
+to any LLM or chat model. It reserves the budget *before* the call
 (``on_llm_start`` / ``on_chat_model_start``) — raising
-:class:`~floe_guard.BudgetExceeded` aborts the call so it never runs — and records
-spend *after* the response (``on_llm_end``).
+:class:`~floe_guard.BudgetExceeded` or
+:class:`~floe_guard.TokenBudgetExceeded` aborts the call so it never runs — and
+settles spend *after* the response (``on_llm_end``).
 
     from langchain_openai import ChatOpenAI
     from floe_guard import BudgetGuard
@@ -20,9 +21,11 @@ the other adapters, so token usage is priced via the bundled cost map.
 
 from __future__ import annotations
 
+import threading
 from typing import Any
+from uuid import UUID
 
-from ..guard import BudgetGuard
+from ..guard import BudgetGuard, ReservationHandle, StepBudgetGuard
 from ..stream import approx_tokens
 
 
@@ -37,16 +40,18 @@ def _require_langchain() -> Any:
     return langchain_core
 
 
-def _estimate_start(guard: BudgetGuard, serialized: Any, texts: list[str]) -> float | None:
-    """Request-sized cost estimate for the pre-call check.
+def _estimate_start(
+    guard: BudgetGuard | StepBudgetGuard, serialized: Any, texts: list[str]
+) -> float | None:
+    """Request-sized cost estimate for the pre-call reservation.
 
-    ``check()`` defaults to predicting from the LAST call's cost — blind on the
+    ``reserve()`` defaults to predicting from the LAST call's cost — blind on the
     first call and wrong for a much larger one. Size the prediction to the
     request instead: model id and ``max_tokens`` from the serialized model
     config, prompt tokens via the ~4 chars/token heuristic (langchain-core has
     no tokenizer; a rough request-sized figure still beats a stale or zero
     baseline). Returns ``None`` when the model is unknown/unpriceable —
-    ``check(None)`` keeps the old behaviour.
+    ``reserve(None)`` keeps the old behaviour.
     """
     model_kwargs = serialized.get("kwargs") if isinstance(serialized, dict) else None
     if not isinstance(model_kwargs, dict):
@@ -124,29 +129,39 @@ def _usage_from_result(response: Any) -> tuple[int, int]:
     return prompt, completion
 
 
-def _record_result(guard: BudgetGuard, response: Any) -> None:
-    model = _model_from_result(response)
-    prompt_tokens, completion_tokens = _usage_from_result(response)
+def _record_result(
+    guard: BudgetGuard | StepBudgetGuard,
+    response: Any,
+    *,
+    reserved: ReservationHandle = 0.0,
+) -> None:
+    try:
+        model = _model_from_result(response)
+        prompt_tokens, completion_tokens = _usage_from_result(response)
+    except (TypeError, ValueError, OverflowError):
+        guard.release(reserved)
+        raise
     if prompt_tokens <= 0 and completion_tokens <= 0:
-        # No tokens were spent — nothing to meter.
+        # No tokens were spent — nothing to meter, so free the in-flight hold.
+        guard.release(reserved)
         return
-    # There IS spend to account for. Route it through record() even when the model
+    # There IS spend to account for. Route it through settle() even when the model
     # id is missing, so the guard's configured policy applies (fail-closed → warn +
     # raise; fail-open → warn + skip). Silently skipping here would let a real,
     # completed call go unmetered and skew the next check().
-    guard.record(model, prompt_tokens, completion_tokens)
+    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
-def budget_guard_callback_handler(guard: BudgetGuard) -> Any:
+def budget_guard_callback_handler(guard: BudgetGuard | StepBudgetGuard) -> Any:
     """Build a LangChain callback handler that enforces ``guard`` on every call.
 
     Pass it to any LLM or chat model::
 
         llm = ChatOpenAI(model="gpt-4o", callbacks=[budget_guard_callback_handler(guard)])
 
-    ``on_llm_start``/``on_chat_model_start`` run ``guard.check()`` (raising
-    :class:`~floe_guard.BudgetExceeded` to abort), and ``on_llm_end`` records the
-    response's token cost.
+    ``on_llm_start``/``on_chat_model_start`` reserve each call by ``run_id``.
+    ``on_llm_end`` settles the matching hold and ``on_llm_error`` releases it,
+    so parallel calls cannot race through the same aggregate or step ceiling.
     """
     _require_langchain()
     from langchain_core.callbacks import BaseCallbackHandler
@@ -160,25 +175,44 @@ def budget_guard_callback_handler(guard: BudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
+            self._reservations: dict[UUID, ReservationHandle] = {}
+            self._reservation_lock = threading.Lock()
 
-        def on_llm_start(self, serialized: Any, prompts: Any, **kwargs: Any) -> None:
-            # Request-sized when derivable (see _estimate_start); check(None)
-            # falls back to the last-cost prediction.
+        def _hold(self, run_id: UUID, serialized: Any, texts: list[str]) -> None:
+            reserved = self.guard.reserve(
+                _estimate_start(self.guard, serialized, texts),
+                estimated_tokens=_estimate_start_tokens(serialized, texts),
+            )
+            with self._reservation_lock:
+                if run_id in self._reservations:
+                    duplicate = True
+                else:
+                    self._reservations[run_id] = reserved
+                    duplicate = False
+            if duplicate:
+                self.guard.release(reserved)
+                raise RuntimeError(f"duplicate LangChain run_id {run_id}")
+
+        def _pop(self, run_id: UUID) -> ReservationHandle:
+            with self._reservation_lock:
+                return self._reservations.pop(run_id, 0.0)
+
+        def on_llm_start(
+            self, serialized: Any, prompts: Any, *, run_id: UUID, **kwargs: Any
+        ) -> None:
             texts = [p for p in (prompts or []) if isinstance(p, str)]
-            self.guard.check(
-                _estimate_start(self.guard, serialized, texts),
-                estimated_next_tokens=_estimate_start_tokens(serialized, texts),
-            )
+            self._hold(run_id, serialized, texts)
 
-        def on_chat_model_start(self, serialized: Any, messages: Any, **kwargs: Any) -> None:
-            texts = _chat_texts(messages)
-            self.guard.check(
-                _estimate_start(self.guard, serialized, texts),
-                estimated_next_tokens=_estimate_start_tokens(serialized, texts),
-            )
+        def on_chat_model_start(
+            self, serialized: Any, messages: Any, *, run_id: UUID, **kwargs: Any
+        ) -> None:
+            self._hold(run_id, serialized, _chat_texts(messages))
 
-        def on_llm_end(self, response: Any, **kwargs: Any) -> None:
-            _record_result(self.guard, response)
+        def on_llm_end(self, response: Any, *, run_id: UUID, **kwargs: Any) -> None:
+            _record_result(self.guard, response, reserved=self._pop(run_id))
+
+        def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
+            self.guard.release(self._pop(run_id))
 
     return BudgetGuardCallbackHandler()
 

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -174,7 +174,8 @@ def guarded_node(
     Works as a decorator (``@guarded_node(guard)``) or a plain wrapper
     (``guarded_node(guard, fn)``); sync and async nodes are both supported.
 
-    Raises :class:`~floe_guard.BudgetExceeded` before the node runs if the
+    Raises :class:`~floe_guard.BudgetExceeded` or
+    :class:`~floe_guard.TokenBudgetExceeded` before the node runs if the
     reservation would cross the ceiling — the branch never executes. On
     success, the node's ``usage_key`` entry is settled against the reservation
     and the guard's :class:`~floe_guard.BudgetAdvisory` is written to
@@ -188,6 +189,11 @@ def guarded_node(
     guard no call has been recorded yet, so that default is ``0`` — when the
     very first graph step is already a parallel fan-out, pass an explicit
     ``estimated_cost`` per node so each branch holds a realistic slice.
+
+    ``estimated_tokens`` similarly sizes the token reservation and defaults to
+    the last settled LLM token count. That default is ``0`` on a cold guard, so
+    pass an explicit value for first-step or parallel fan-out nodes when a token
+    ceiling is configured.
     """
     _require_langgraph()
 

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -60,7 +60,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Annotated, Any
 
-from ..guard import BudgetAdvisory, BudgetGuard
+from ..guard import BudgetAdvisory, BudgetGuard, ReservationHandle, StepBudgetGuard
 
 
 def _require_langgraph() -> None:
@@ -118,7 +118,13 @@ def _usage_from_update(update: Any, usage_key: str) -> tuple[str, int, int] | No
     return model, prompt_tokens, completion_tokens
 
 
-def _settle_update(guard: BudgetGuard, update: Any, usage_key: str, *, reserved: float) -> None:
+def _settle_update(
+    guard: BudgetGuard | StepBudgetGuard,
+    update: Any,
+    usage_key: str,
+    *,
+    reserved: ReservationHandle,
+) -> None:
     try:
         usage = _usage_from_update(update, usage_key)
     except (TypeError, ValueError, OverflowError):
@@ -147,7 +153,11 @@ def _settle_update(guard: BudgetGuard, update: Any, usage_key: str, *, reserved:
     guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
-def _inject_advisory(guard: BudgetGuard, update: Any, advisory_key: str | None) -> Any:
+def _inject_advisory(
+    guard: BudgetGuard | StepBudgetGuard,
+    update: Any,
+    advisory_key: str | None,
+) -> Any:
     if advisory_key is None:
         return update
     if update is None:
@@ -161,7 +171,7 @@ def _inject_advisory(guard: BudgetGuard, update: Any, advisory_key: str | None) 
 
 
 def guarded_node(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     node: Callable[..., Any] | None = None,
     *,
     usage_key: str = "usage",

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -86,7 +86,12 @@ def latest_advisory(
         return current
     if current is None:
         return update
-    return update if update.used_bps >= current.used_bps else current
+    # Aggregate settled totals are monotone even when a step budget resets.
+    # Compare both dimensions so a token-only update is not discarded merely
+    # because its USD utilization is unchanged.
+    current_progress = (current.spent_usd, current.spent_tokens)
+    update_progress = (update.spent_usd, update.spent_tokens)
+    return update if update_progress >= current_progress else current
 
 
 # Declare this on your graph state to receive the advisory after each guarded
@@ -162,6 +167,7 @@ def guarded_node(
     usage_key: str = "usage",
     advisory_key: str | None = "budget",
     estimated_cost: float | None = None,
+    estimated_tokens: int | None = None,
 ) -> Callable[..., Any]:
     """Wrap a LangGraph node with a budget reservation, accrual, and advisory.
 
@@ -190,7 +196,7 @@ def guarded_node(
 
             @wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                reserved = guard.reserve(estimated_cost)
+                reserved = guard.reserve(estimated_cost, estimated_tokens=estimated_tokens)
                 try:
                     update = await fn(*args, **kwargs)
                 except BaseException:
@@ -203,7 +209,7 @@ def guarded_node(
 
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            reserved = guard.reserve(estimated_cost)
+            reserved = guard.reserve(estimated_cost, estimated_tokens=estimated_tokens)
             try:
                 update = fn(*args, **kwargs)
             except BaseException:

--- a/src/floe_guard/integrations/langgraph.py
+++ b/src/floe_guard/integrations/langgraph.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from dataclasses import replace
 from functools import wraps
 from typing import Annotated, Any
 
@@ -76,22 +77,39 @@ def _require_langgraph() -> None:
 def latest_advisory(
     current: BudgetAdvisory | None, update: BudgetAdvisory | None
 ) -> BudgetAdvisory | None:
-    """Reducer for the budget channel: keep the advisory reflecting the most spend.
+    """Reducer for the budget channel: keep the freshest spend in each dimension.
 
     Parallel branches finish in nondeterministic order, so "last write wins"
-    does not mean "latest spend wins". ``used_bps`` is monotone in the guard's
-    running total, so the higher reading is always the fresher truth.
+    does not mean "latest spend wins". Aggregate USD and token totals are each
+    monotone, so merge them independently when updates are incomparable.
     """
     if update is None:
         return current
     if current is None:
         return update
-    # Aggregate settled totals are monotone even when a step budget resets.
-    # Compare both dimensions so a token-only update is not discarded merely
-    # because its USD utilization is unchanged.
-    current_progress = (current.spent_usd, current.spent_tokens)
-    update_progress = (update.spent_usd, update.spent_tokens)
-    return update if update_progress >= current_progress else current
+    if update.spent_usd >= current.spent_usd and update.spent_tokens >= current.spent_tokens:
+        return update
+    if current.spent_usd >= update.spent_usd and current.spent_tokens >= update.spent_tokens:
+        return current
+
+    usd = update if update.spent_usd > current.spent_usd else current
+    tokens = update if update.spent_tokens > current.spent_tokens else current
+    # Keep each total and its derived headroom fields from the same snapshot.
+    return replace(
+        usd,
+        near_limit=current.near_limit or update.near_limit,
+        used_bps=usd.used_bps,
+        remaining_usd=usd.remaining_usd,
+        limit_usd=usd.limit_usd,
+        spent_usd=usd.spent_usd,
+        expected_cost=usd.expected_cost,
+        est_calls_remaining=usd.est_calls_remaining,
+        token_limit=tokens.token_limit,
+        spent_tokens=tokens.spent_tokens,
+        remaining_tokens=tokens.remaining_tokens,
+        token_used_bps=tokens.token_used_bps,
+        near_token_limit=tokens.near_token_limit,
+    )
 
 
 # Declare this on your graph state to receive the advisory after each guarded

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -34,8 +34,8 @@ import logging
 import threading
 from typing import Any
 
-from ..errors import BudgetExceeded, UnpriceableModelError
-from ..guard import BudgetGuard
+from ..errors import BudgetExceeded, TokenBudgetExceeded, UnpriceableModelError
+from ..guard import BudgetGuard, ReservationHandle, StepBudgetGuard
 
 _logger = logging.getLogger("floe_guard")
 
@@ -73,7 +73,9 @@ def _usage_from(response: Any) -> tuple[int, int]:
     return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
 
 
-def _estimate_request(litellm: Any, guard: BudgetGuard, kwargs: Any) -> float | None:
+def _estimate_request(
+    litellm: Any, guard: BudgetGuard | StepBudgetGuard, kwargs: Any
+) -> float | None:
     """Request-sized cost estimate for the pre-call reservation.
 
     Prices the ACTUAL incoming request — prompt tokens via litellm's offline
@@ -108,8 +110,28 @@ def _estimate_request(litellm: Any, guard: BudgetGuard, kwargs: Any) -> float | 
     return guard.estimate_call(str(model), prompt_tokens, max_out)
 
 
+def _estimate_request_tokens(litellm: Any, kwargs: Any) -> int | None:
+    if not isinstance(kwargs, dict) or not kwargs.get("model"):
+        return None
+    try:
+        prompt_tokens = int(
+            litellm.token_counter(model=kwargs["model"], messages=kwargs.get("messages") or [])
+        )
+    except Exception:
+        return None
+    max_out = kwargs.get("max_completion_tokens") or kwargs.get("max_tokens") or 0
+    try:
+        return prompt_tokens + max(0, int(max_out))
+    except (TypeError, ValueError):
+        return prompt_tokens
+
+
 def _record_response(
-    guard: BudgetGuard, kwargs: Any, response: Any, *, reserved: float = 0.0
+    guard: BudgetGuard | StepBudgetGuard,
+    kwargs: Any,
+    response: Any,
+    *,
+    reserved: ReservationHandle = 0.0,
 ) -> None:
     # LiteLLM hooks pass kwargs as Any; normalize so a None/non-dict can't crash
     # the metering callback on .get() (matches the _key() fallback).
@@ -129,7 +151,7 @@ def _record_response(
     guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
 
 
-def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
+def guarded_completion(guard: BudgetGuard | StepBudgetGuard, **kwargs: Any) -> Any:
     """``litellm.completion`` with a pre-call budget reservation and post-call accrual.
 
     Raises :class:`~floe_guard.BudgetExceeded` before the call if the budget
@@ -138,7 +160,10 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
     can be, so even a FIRST call that alone would cross the cap is blocked.
     """
     litellm = _require_litellm()
-    reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
+    reserved = guard.reserve(
+        _estimate_request(litellm, guard, kwargs),
+        estimated_tokens=_estimate_request_tokens(litellm, kwargs),
+    )
     try:
         response = litellm.completion(**kwargs)
     except BaseException:
@@ -148,10 +173,13 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
     return response
 
 
-async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
+async def guarded_acompletion(guard: BudgetGuard | StepBudgetGuard, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`."""
     litellm = _require_litellm()
-    reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
+    reserved = guard.reserve(
+        _estimate_request(litellm, guard, kwargs),
+        estimated_tokens=_estimate_request_tokens(litellm, kwargs),
+    )
     try:
         response = await litellm.acompletion(**kwargs)
     except BaseException:
@@ -161,7 +189,7 @@ async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
     return response
 
 
-def budget_guard_callback(guard: BudgetGuard) -> Any:
+def budget_guard_callback(guard: BudgetGuard | StepBudgetGuard) -> Any:
     """Build a LiteLLM ``CustomLogger`` that enforces ``guard`` on every call.
 
     Register it globally::
@@ -170,7 +198,8 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         litellm.callbacks = [budget_guard_callback(guard)]
 
     ``log_pre_api_call`` reserves the call's budget (raising
-    :class:`~floe_guard.BudgetExceeded` to abort), ``log_success_event`` settles
+    :class:`~floe_guard.BudgetExceeded` or
+    :class:`~floe_guard.TokenBudgetExceeded` to abort), ``log_success_event`` settles
     the response's actual token cost, and ``log_failure_event`` releases the
     reservation. Reservations are keyed per call, so parallel crew calls each
     hold their own slice of the ceiling instead of racing one shared total.
@@ -189,13 +218,13 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
-            # The first enforcement violation (BudgetExceeded or fail-closed
+            # The first enforcement violation (USD/token budget or fail-closed
             # UnpriceableModelError). Survives LiteLLM swallowing the raise, so a
             # call-path owner can re-raise it outside the callback machinery.
             # Latches until reset() — a config change on the guard alone does
             # not clear it.
             self.tripped: Exception | None = None
-            self._reservations: dict[Any, float] = {}
+            self._reservations: dict[Any, ReservationHandle] = {}
             self._rlock = threading.Lock()
 
         @staticmethod
@@ -229,14 +258,17 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
             try:
                 # Request-sized when possible (see _estimate_request); raises
                 # BudgetExceeded -> aborts the call.
-                reserved = self.guard.reserve(_estimate_request(litellm, self.guard, kwargs))
-            except BudgetExceeded as exc:
+                reserved = self.guard.reserve(
+                    _estimate_request(litellm, self.guard, kwargs),
+                    estimated_tokens=_estimate_request_tokens(litellm, kwargs),
+                )
+            except (BudgetExceeded, TokenBudgetExceeded) as exc:
                 self._trip(exc)
                 raise
             with self._rlock:
                 self._reservations[self._key(kwargs)] = reserved
 
-        def _pop(self, kwargs: Any) -> float:
+        def _pop(self, kwargs: Any) -> ReservationHandle:
             with self._rlock:
                 return self._reservations.pop(self._key(kwargs), 0.0)
 

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -199,9 +199,10 @@ def budget_guard_callback(guard: BudgetGuard | StepBudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
-            # The first enforcement violation (USD/token budget or fail-closed
-            # UnpriceableModelError). Survives LiteLLM swallowing the raise, so a
-            # call-path owner can re-raise it outside the callback machinery.
+            # The first enforcement or reservation-lifecycle violation
+            # (USD/token budget, fail-closed pricing, or duplicate call id).
+            # Survives LiteLLM swallowing the raise, so a call-path owner can
+            # re-raise it outside the callback machinery.
             # Latches until reset() — a config change on the guard alone does
             # not clear it.
             self.tripped: Exception | None = None
@@ -253,7 +254,9 @@ def budget_guard_callback(guard: BudgetGuard | StepBudgetGuard) -> Any:
                     duplicate = False
             if duplicate:
                 self.guard.release(reserved)
-                raise RuntimeError(f"duplicate LiteLLM call id {key}")
+                exc = RuntimeError(f"duplicate LiteLLM call id {key}")
+                self._trip(exc)
+                raise exc
 
         def _pop(self, kwargs: Any) -> ReservationHandle:
             with self._rlock:

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -75,25 +75,26 @@ def _usage_from(response: Any) -> tuple[int, int]:
 
 def _estimate_request(
     litellm: Any, guard: BudgetGuard | StepBudgetGuard, kwargs: Any
-) -> float | None:
-    """Request-sized cost estimate for the pre-call reservation.
+) -> tuple[float | None, int | None]:
+    """Request-sized USD and token estimates for the pre-call reservation.
 
     Prices the ACTUAL incoming request — prompt tokens via litellm's offline
     ``token_counter`` plus the ``max_tokens`` output cap — so a first call, or
     one much larger than the last, reserves its true worst-case size instead of
-    the last call's cost (which is 0 on call one). Returns ``None`` when
-    anything needed is unavailable (no model, counter failure, unpriceable
-    model); ``reserve(None)`` falls back to the last-cost prediction, so this
-    only ever tightens enforcement, never breaks a call path.
+    the last call's cost (which is 0 on call one). Returns ``(None, None)`` for
+    both estimates when request sizing is unavailable (no model or counter
+    failure). An unpriceable model still returns its token estimate, so a token
+    ceiling remains enforceable while the USD estimate uses the last-call
+    fallback.
 
     Without ``max_tokens`` on the request the output side is unpredictable and
     estimates prompt-only — set a cap for full pre-call sizing.
     """
     if not isinstance(kwargs, dict):
-        return None
+        return None, None
     model = kwargs.get("model")
     if not model:
-        return None
+        return None, None
     try:
         prompt_tokens = int(
             litellm.token_counter(model=model, messages=kwargs.get("messages") or [])
@@ -101,29 +102,13 @@ def _estimate_request(
     except Exception:
         # token_counter can fail on unknown models/shapes — degrade to the
         # guard's default prediction rather than blocking the call path.
-        return None
+        return None, None
     max_out = kwargs.get("max_completion_tokens") or kwargs.get("max_tokens") or 0
     try:
         max_out = max(0, int(max_out))
     except (TypeError, ValueError):
         max_out = 0
-    return guard.estimate_call(str(model), prompt_tokens, max_out)
-
-
-def _estimate_request_tokens(litellm: Any, kwargs: Any) -> int | None:
-    if not isinstance(kwargs, dict) or not kwargs.get("model"):
-        return None
-    try:
-        prompt_tokens = int(
-            litellm.token_counter(model=kwargs["model"], messages=kwargs.get("messages") or [])
-        )
-    except Exception:
-        return None
-    max_out = kwargs.get("max_completion_tokens") or kwargs.get("max_tokens") or 0
-    try:
-        return prompt_tokens + max(0, int(max_out))
-    except (TypeError, ValueError):
-        return prompt_tokens
+    return guard.estimate_call(str(model), prompt_tokens, max_out), prompt_tokens + max_out
 
 
 def _record_response(
@@ -160,10 +145,8 @@ def guarded_completion(guard: BudgetGuard | StepBudgetGuard, **kwargs: Any) -> A
     can be, so even a FIRST call that alone would cross the cap is blocked.
     """
     litellm = _require_litellm()
-    reserved = guard.reserve(
-        _estimate_request(litellm, guard, kwargs),
-        estimated_tokens=_estimate_request_tokens(litellm, kwargs),
-    )
+    estimated_cost, estimated_tokens = _estimate_request(litellm, guard, kwargs)
+    reserved = guard.reserve(estimated_cost, estimated_tokens=estimated_tokens)
     try:
         response = litellm.completion(**kwargs)
     except BaseException:
@@ -176,10 +159,8 @@ def guarded_completion(guard: BudgetGuard | StepBudgetGuard, **kwargs: Any) -> A
 async def guarded_acompletion(guard: BudgetGuard | StepBudgetGuard, **kwargs: Any) -> Any:
     """Async counterpart of :func:`guarded_completion`."""
     litellm = _require_litellm()
-    reserved = guard.reserve(
-        _estimate_request(litellm, guard, kwargs),
-        estimated_tokens=_estimate_request_tokens(litellm, kwargs),
-    )
+    estimated_cost, estimated_tokens = _estimate_request(litellm, guard, kwargs)
+    reserved = guard.reserve(estimated_cost, estimated_tokens=estimated_tokens)
     try:
         response = await litellm.acompletion(**kwargs)
     except BaseException:
@@ -258,10 +239,8 @@ def budget_guard_callback(guard: BudgetGuard | StepBudgetGuard) -> Any:
             try:
                 # Request-sized when possible (see _estimate_request); raises
                 # BudgetExceeded -> aborts the call.
-                reserved = self.guard.reserve(
-                    _estimate_request(litellm, self.guard, kwargs),
-                    estimated_tokens=_estimate_request_tokens(litellm, kwargs),
-                )
+                estimated_cost, estimated_tokens = _estimate_request(litellm, self.guard, kwargs)
+                reserved = self.guard.reserve(estimated_cost, estimated_tokens=estimated_tokens)
             except (BudgetExceeded, TokenBudgetExceeded) as exc:
                 self._trip(exc)
                 raise

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -244,8 +244,16 @@ def budget_guard_callback(guard: BudgetGuard | StepBudgetGuard) -> Any:
             except (BudgetExceeded, TokenBudgetExceeded) as exc:
                 self._trip(exc)
                 raise
+            key = self._key(kwargs)
             with self._rlock:
-                self._reservations[self._key(kwargs)] = reserved
+                if key in self._reservations:
+                    duplicate = True
+                else:
+                    self._reservations[key] = reserved
+                    duplicate = False
+            if duplicate:
+                self.guard.release(reserved)
+                raise RuntimeError(f"duplicate LiteLLM call id {key}")
 
         def _pop(self, kwargs: Any) -> ReservationHandle:
             with self._rlock:

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -35,8 +35,8 @@ from dataclasses import dataclass
 
 from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
 
-from ..errors import BudgetExceeded
-from ..guard import BudgetGuard
+from ..errors import BudgetExceeded, TokenBudgetExceeded
+from ..guard import BudgetGuard, ReservationHandle, StepBudgetGuard
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +45,13 @@ logger = logging.getLogger(__name__)
 class _TurnSlot:
     """One llm_node invocation awaiting (or already past) its LLMMetrics event.
 
-    ``open`` means the USD amount is still held on the BudgetGuard. Early
+    ``open`` means the USD/token reservation is still held on the BudgetGuard. Early
     release (next turn, exception, close) clears the guard hold but leaves the
     slot in the FIFO queue so a delayed metrics event settles against this
     turn's slot (with ``amount`` 0) instead of stealing a later turn's hold.
     """
 
-    amount: float
+    amount: ReservationHandle
     open: bool = True
 
 
@@ -64,9 +64,10 @@ class LiveKitBudgetGuard:
             no model name). Must be priceable via the cost map or the guard's
             ``price_overrides``.
         on_budget_exceeded: optional async callback invoked with the
-            ``BudgetExceeded`` when a turn is blocked, so a bot can speak a
-            graceful "wrapping up" line before the turn ends silently. If
-            omitted, the ``BudgetExceeded`` propagates out of ``llm_node``.
+            ``BudgetExceeded`` or ``TokenBudgetExceeded`` when a turn is
+            blocked, so a bot can speak a graceful "wrapping up" line before
+            the turn ends silently. If omitted, the budget exception
+            propagates out of ``llm_node``.
         stt_usd_per_second: if set, meter ``STTMetrics.audio_duration`` via
             ``record_tool`` (per-second). Omit to keep the token-only contract.
         tts_usd_per_1k_chars: if set, meter ``TTSMetrics.characters_count`` via
@@ -75,9 +76,10 @@ class LiveKitBudgetGuard:
 
     def __init__(
         self,
-        guard: BudgetGuard,
+        guard: BudgetGuard | StepBudgetGuard,
         model: str,
-        on_budget_exceeded: Callable[[BudgetExceeded], Awaitable[None]] | None = None,
+        on_budget_exceeded: Callable[[BudgetExceeded | TokenBudgetExceeded], Awaitable[None]]
+        | None = None,
         *,
         stt_usd_per_second: float | None = None,
         tts_usd_per_1k_chars: float | None = None,
@@ -87,7 +89,7 @@ class LiveKitBudgetGuard:
         self._on_budget_exceeded = on_budget_exceeded
         self._stt_usd_per_second = stt_usd_per_second
         self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
-        self._reserved: float = 0.0
+        self._reserved: ReservationHandle = 0.0
         self._pending = False
         self._active: _TurnSlot | None = None
         # FIFO of turns that may still emit LLMMetrics (including early-released).
@@ -108,7 +110,7 @@ class LiveKitBudgetGuard:
                 self._early_release_active()
             try:
                 amount = self._guard.reserve()
-            except BudgetExceeded as exc:
+            except (BudgetExceeded, TokenBudgetExceeded) as exc:
                 self._clear_active()
                 logger.warning("floe-guard blocked a turn: %s", exc)
                 if self._on_budget_exceeded is None:

--- a/src/floe_guard/integrations/pipecat.py
+++ b/src/floe_guard/integrations/pipecat.py
@@ -56,8 +56,8 @@ from pipecat.frames.frames import (
 from pipecat.metrics.metrics import LLMUsageMetricsData
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
-from ..errors import BudgetExceeded
-from ..guard import BudgetGuard
+from ..errors import BudgetExceeded, TokenBudgetExceeded
+from ..guard import BudgetGuard, ReservationHandle, StepBudgetGuard
 from ..pricing import resolve_price
 
 logger = logging.getLogger(__name__)
@@ -105,11 +105,12 @@ class FloeBudgetGuardProcessor(FrameProcessor):
             cost map doesn't fail-close a call that would otherwise price
             cleanly.
         on_budget_exceeded: optional async callback invoked with the
-            ``BudgetExceeded`` exception when a turn is blocked, so the
-            caller can push a graceful "wrapping up" TTS frame before the
-            pipeline ends. If omitted, a fatal ``ErrorFrame`` is pushed
-            instead, which terminates the pipeline -- this is the "hard
-            stop" default that matches every other floe-guard adapter.
+            ``BudgetExceeded`` or ``TokenBudgetExceeded`` exception when a
+            turn is blocked, so the caller can push a graceful "wrapping up"
+            TTS frame before the pipeline ends. If omitted, a fatal
+            ``ErrorFrame`` is pushed instead, which terminates the pipeline --
+            this is the "hard stop" default that matches every other
+            floe-guard adapter.
             (A bare raise here would *not* achieve that: Pipecat's
             FrameProcessor catches exceptions raised inside process_frame()
             and downgrades them to a non-fatal, merely-logged ErrorFrame.)
@@ -117,16 +118,17 @@ class FloeBudgetGuardProcessor(FrameProcessor):
 
     def __init__(
         self,
-        guard: BudgetGuard,
+        guard: BudgetGuard | StepBudgetGuard,
         model: str,
-        on_budget_exceeded: Callable[[BudgetExceeded], Awaitable[None]] | None = None,
+        on_budget_exceeded: Callable[[BudgetExceeded | TokenBudgetExceeded], Awaitable[None]]
+        | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self._guard = guard
         self._model = model
         self._on_budget_exceeded = on_budget_exceeded
-        self._reserved: float = 0.0
+        self._reserved: ReservationHandle = 0.0
         self._pending = False
 
     def _settle_model(self, reported_model: str | None) -> str:
@@ -160,7 +162,7 @@ class FloeBudgetGuardProcessor(FrameProcessor):
             try:
                 self._reserved = self._guard.reserve()
                 self._pending = True
-            except BudgetExceeded as exc:
+            except (BudgetExceeded, TokenBudgetExceeded) as exc:
                 logger.warning("floe-guard blocked a turn: %s", exc)
                 self._pending = False
                 if self._on_budget_exceeded is not None:

--- a/src/floe_guard/integrations/pipecat.py
+++ b/src/floe_guard/integrations/pipecat.py
@@ -7,12 +7,12 @@ and turns fire continuously for the life of a call. So the enforcement
 surface here is a ``FrameProcessor`` placed directly after the LLM service,
 not a function wrapper around a single call.
 
-The contract matches the OpenAI/Anthropic adapters: ``reserve()`` when a turn
-starts (before TTS/audio spend piles on top of a call that would already
-cross the ceiling), ``settle(model, prompt_tokens, completion_tokens,
+The processor sees ``LLMFullResponseStartFrame`` only after the LLM request has
+started. It can therefore stop downstream TTS and terminate the pipeline, but
+it cannot prevent the current provider charge. It ``reserve()``s at that
+post-LLM boundary, ``settle(model, prompt_tokens, completion_tokens,
 reserved=...)`` once real usage is reported, and ``release(reserved)`` if a
-turn ends without ever reporting usage (e.g. an interrupted turn) so the
-reservation doesn't leak against the ceiling forever.
+turn ends without reporting usage so the reservation does not leak forever.
 
     from pipecat.pipeline.pipeline import Pipeline
     from pipecat.pipeline.task import PipelineTask, PipelineParams
@@ -108,9 +108,9 @@ class FloeBudgetGuardProcessor(FrameProcessor):
             ``BudgetExceeded`` or ``TokenBudgetExceeded`` exception when a
             turn is blocked, so the caller can push a graceful "wrapping up"
             TTS frame before the pipeline ends. If omitted, a fatal
-            ``ErrorFrame`` is pushed instead, which terminates the pipeline --
-            this is the "hard stop" default that matches every other
-            floe-guard adapter.
+            ``ErrorFrame`` is pushed instead, which terminates downstream
+            pipeline work. Because this processor sits after the LLM, it
+            cannot prevent the current provider request.
             (A bare raise here would *not* achieve that: Pipecat's
             FrameProcessor catches exceptions raised inside process_frame()
             and downgrades them to a non-fatal, merely-logged ErrorFrame.)
@@ -174,11 +174,10 @@ class FloeBudgetGuardProcessor(FrameProcessor):
                     # stopping the pipeline (confirmed empirically -- see
                     # push_error_frame in frame_processor.py). Simply raising
                     # here would just log a warning and let the pipeline
-                    # keep running, silently defeating floe-guard's whole
-                    # point of being a *hard* stop. Push a fatal ErrorFrame
-                    # ourselves instead, which does actually terminate the
-                    # pipeline, so the default (no-callback) behavior is a
-                    # real hard stop rather than a swallowed log line.
+                    # keep running, silently defeating floe-guard's downstream
+                    # stop. Push a fatal ErrorFrame ourselves instead, which
+                    # terminates the pipeline rather than reducing the block to
+                    # a swallowed log line.
                     await self.push_error(str(exc), exception=exc, fatal=True)
                 return  # don't forward the frame for a call that was blocked
 

--- a/src/floe_guard/retry.py
+++ b/src/floe_guard/retry.py
@@ -13,8 +13,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
-from .errors import BudgetExceeded
-from .guard import BudgetAdvisory, BudgetGuard
+from .errors import BudgetExceeded, TokenBudgetExceeded
+from .guard import BudgetAdvisory, BudgetGuard, StepBudgetGuard
 
 T = TypeVar("T")
 
@@ -42,21 +42,17 @@ AsyncDegradeCallback = Callable[
 
 
 def _default_retry_if(exc: Exception) -> bool:
-    return not isinstance(exc, BudgetExceeded)
+    return not isinstance(exc, (BudgetExceeded, TokenBudgetExceeded))
 
 
 def _validate_max_attempts(max_attempts: int) -> None:
     # Same int-not-bool contract as BudgetGuard.near_limit_bps.
-    if (
-        isinstance(max_attempts, bool)
-        or not isinstance(max_attempts, int)
-        or max_attempts < 1
-    ):
+    if isinstance(max_attempts, bool) or not isinstance(max_attempts, int) or max_attempts < 1:
         raise ValueError(f"max_attempts must be an int >= 1, got {max_attempts!r}")
 
 
 def with_budget_retry(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     call: Callable[[], T],
     *,
     estimated_cost: float | None = None,
@@ -96,7 +92,7 @@ def with_budget_retry(
 
 
 async def async_with_budget_retry(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     call: Callable[[], Awaitable[T]],
     *,
     estimated_cost: float | None = None,
@@ -122,7 +118,7 @@ async def async_with_budget_retry(
 
 
 def _next_plan(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     exc: Exception,
     current: RetryPlan[T],
     on_degrade: DegradeCallback[T] | None,
@@ -138,7 +134,7 @@ def _next_plan(
 
 
 async def _next_async_plan(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     exc: Exception,
     current: RetryPlan[Awaitable[T]],
     on_degrade: AsyncDegradeCallback[T] | None,

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -77,11 +77,10 @@ class StreamGuard:
     ) -> None:
         # Same contract as settle(): a bad handle would corrupt the guard's
         # in-flight tally. Reject it before the stream starts, not at settle time.
-        guard._reservation_parts(reserved)
+        guard._stream_validate_reservation(reserved)
         self._guard = guard
         self._model = model
         self._prompt_tokens = max(0, int(prompt_tokens))
-        self._reserved = reserved
         self._price = price
         self._label = label
         self._count = count_tokens or approx_tokens
@@ -108,7 +107,7 @@ class StreamGuard:
         # Registered AFTER the fail-closed raise so a refused stream leaves no
         # entry; _settle() unregisters, so entries live exactly as long as the
         # stream. Parallel streams see each other's accrual through this.
-        self._key = guard._stream_register(self._reserved)
+        self._reserved, self._key = guard._stream_prepare(reserved)
 
     def feed_text(self, delta: str) -> None:
         """Meter one text delta (token count via the heuristic/``count_tokens``).

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -25,13 +25,12 @@ See ``examples/streaming_guard.py`` for a runnable demo (no API key).
 
 from __future__ import annotations
 
-import math
 import warnings
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 from .errors import UnpriceableModelError, UnpriceableModelWarning
-from .guard import BudgetGuard
+from .guard import BudgetGuard, ReservationHandle, StepBudgetGuard
 from .pricing import ManualPrice, price_tokens
 
 
@@ -67,23 +66,22 @@ class StreamGuard:
 
     def __init__(
         self,
-        guard: BudgetGuard,
+        guard: BudgetGuard | StepBudgetGuard,
         model: str,
         *,
         prompt_tokens: int = 0,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         price: ManualPrice | None = None,
         label: str | None = None,
         count_tokens: Callable[[str], int] | None = None,
     ) -> None:
         # Same contract as settle(): a bad handle would corrupt the guard's
         # in-flight tally. Reject it before the stream starts, not at settle time.
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        guard._reservation_parts(reserved)
         self._guard = guard
         self._model = model
         self._prompt_tokens = max(0, int(prompt_tokens))
-        self._reserved = float(reserved)
+        self._reserved = reserved
         self._price = price
         self._label = label
         self._count = count_tokens or approx_tokens
@@ -129,12 +127,14 @@ class StreamGuard:
         if self._priced is None:
             return  # fail-open + unpriceable: nothing to price chunks with
         cumulative = price_tokens(self._priced, self._prompt_tokens, self._completion_tokens)
-        if self._guard._stream_would_cross(self._key, cumulative):
+        total_tokens = self._prompt_tokens + self._completion_tokens
+        blocked = self._guard._stream_would_cross(self._key, cumulative, total_tokens)
+        if blocked is not None:
             # The tokens in this chunk were already generated (and billed) —
             # settle them before raising so spent_usd reflects reality. The
             # overshoot is at most this one chunk, not the rest of the stream.
             self._settle()
-            self._guard._block()
+            self._guard._raise_block(blocked)
 
     def finish(
         self,
@@ -189,13 +189,13 @@ class StreamGuard:
 
 
 def guard_stream(
-    guard: BudgetGuard,
+    guard: BudgetGuard | StepBudgetGuard,
     model: str,
     chunks: Iterable[Any],
     *,
     get_text: Callable[[Any], str] | None = None,
     prompt_tokens: int = 0,
-    reserved: float = 0.0,
+    reserved: ReservationHandle = 0.0,
     price: ManualPrice | None = None,
     label: str | None = None,
     count_tokens: Callable[[str], int] | None = None,

--- a/tests/test_budget_retry.py
+++ b/tests/test_budget_retry.py
@@ -10,6 +10,7 @@ from floe_guard import (
     BudgetExceeded,
     BudgetGuard,
     RetryPlan,
+    TokenBudgetExceeded,
     async_with_budget_retry,
     with_budget_retry,
 )
@@ -117,6 +118,37 @@ def test_keyboard_interrupt_is_not_retried() -> None:
 
     with pytest.raises(KeyboardInterrupt):
         with_budget_retry(guard, primary, estimated_cost=0.01, max_attempts=3)
+
+    assert calls == {"primary": 1}
+
+
+def test_token_budget_error_is_not_retried_by_default() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0, on_token_block=lambda *_: None)
+    calls = {"primary": 0}
+
+    def primary() -> str:
+        calls["primary"] += 1
+        guard.check(estimated_next_tokens=1)
+        return "unreachable"
+
+    with pytest.raises(TokenBudgetExceeded):
+        with_budget_retry(guard, primary, max_attempts=3)
+
+    assert calls == {"primary": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_token_budget_error_is_not_retried_by_default() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0, on_token_block=lambda *_: None)
+    calls = {"primary": 0}
+
+    async def primary() -> str:
+        calls["primary"] += 1
+        guard.check(estimated_next_tokens=1)
+        return "unreachable"
+
+    with pytest.raises(TokenBudgetExceeded):
+        await async_with_budget_retry(guard, primary, max_attempts=3)
 
     assert calls == {"primary": 1}
 

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -22,6 +22,7 @@ litellm = pytest.importorskip("litellm")
 from floe_guard import (  # noqa: E402
     BudgetExceeded,
     BudgetGuard,
+    TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
@@ -94,9 +95,9 @@ def test_unpriceable_model_hard_stops_next_call_despite_swallowed_settle(
 
     assert guard.spent_usd == 0.0  # the completed call itself went unmetered
     assert isinstance(cb.tripped, UnpriceableModelError)
-    assert any(
-        r.name == "floe_guard" and r.levelname == "ERROR" for r in caplog.records
-    ), "the swallowed violation must be loud on the logging channel"
+    assert any(r.name == "floe_guard" and r.levelname == "ERROR" for r in caplog.records), (
+        "the swallowed violation must be loud on the logging channel"
+    )
     with pytest.raises(UnpriceableModelError):
         llm.call("next step")
 
@@ -110,8 +111,13 @@ def test_ceiling_hard_stops_next_call_despite_swallowed_pre_call_block() -> None
     (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
 
     # One completed call accrues past the ceiling (settle never blocks; check does).
-    _swallow(cb.log_success_event, {"litellm_call_id": "c1", "model": "gpt-4o"},
-             _response("gpt-4o"), None, None)
+    _swallow(
+        cb.log_success_event,
+        {"litellm_call_id": "c1", "model": "gpt-4o"},
+        _response("gpt-4o"),
+        None,
+        None,
+    )
     assert guard.spent_usd > guard.limit_usd
 
     # The swallowed pre-call block of the runaway's next attempt.
@@ -119,6 +125,23 @@ def test_ceiling_hard_stops_next_call_despite_swallowed_pre_call_block() -> None
     assert isinstance(cb.tripped, BudgetExceeded)
 
     with pytest.raises(BudgetExceeded):
+        llm.call("next step")
+
+
+def test_token_ceiling_hard_stops_after_litellm_swallows_callback_error() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+
+    _swallow(
+        cb.log_pre_api_call,
+        "gpt-4o",
+        [],
+        {"litellm_call_id": "token-block", "model": "gpt-4o", "messages": []},
+    )
+
+    assert isinstance(cb.tripped, TokenBudgetExceeded)
+    with pytest.raises(TokenBudgetExceeded):
         llm.call("next step")
 
 

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -26,6 +26,7 @@ from floe_guard import (
     UnpriceableModelWarning,
 )
 from floe_guard.integrations.langchain import (
+    _estimate_start_tokens,
     _model_from_result,
     _record_result,
     _usage_from_result,
@@ -58,6 +59,22 @@ def _openai_result(prompt: int, completion: int, model: str = "gpt-4o") -> _Resu
             "token_usage": {"prompt_tokens": prompt, "completion_tokens": completion},
         }
     )
+
+
+def test_start_token_estimate_keeps_known_prompt_without_model_kwargs() -> None:
+    assert _estimate_start_tokens({}, ["abcdefgh"]) == 2
+    assert _estimate_start_tokens(None, ["abcdefgh"]) == 2
+    assert _estimate_start_tokens({"kwargs": "invalid"}, ["abcdefgh"]) == 2
+
+
+def test_start_token_estimate_without_known_tokens_remains_unknown() -> None:
+    assert _estimate_start_tokens({}, []) is None
+    assert _estimate_start_tokens({}, [object()]) is None  # type: ignore[list-item]
+
+
+def test_start_token_estimate_adds_valid_output_cap() -> None:
+    serialized = {"kwargs": {"max_completion_tokens": 7}}
+    assert _estimate_start_tokens(serialized, ["abcdefgh"]) == 9
 
 
 def test_model_from_result_reads_llm_output() -> None:

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -12,11 +12,19 @@ before the call runs.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
+from uuid import UUID, uuid4
 
 import pytest
 
-from floe_guard import BudgetExceeded, BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    TokenBudgetExceeded,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
 from floe_guard.integrations.langchain import (
     _model_from_result,
     _record_result,
@@ -113,9 +121,10 @@ def test_handler_allows_under_budget_and_records() -> None:
     pytest.importorskip("langchain_core")
     guard = BudgetGuard(limit_usd=1.0)
     handler = budget_guard_callback_handler(guard)
+    run_id = uuid4()
 
-    handler.on_llm_start({}, ["hello"])  # under budget — no raise
-    handler.on_llm_end(_openai_result(1_000, 1_000))
+    handler.on_llm_start({}, ["hello"], run_id=run_id)  # under budget — no raise
+    handler.on_llm_end(_openai_result(1_000, 1_000), run_id=run_id)
     assert guard.spent_usd == pytest.approx(0.0125)
 
 
@@ -126,9 +135,158 @@ def test_handler_blocks_before_crossing() -> None:
     guard = BudgetGuard(limit_usd=0.02)
     handler = budget_guard_callback_handler(guard)
 
-    handler.on_llm_start({}, ["hello"])
-    handler.on_llm_end(_openai_result(1_000, 1_000))
+    first_run = uuid4()
+    handler.on_llm_start({}, ["hello"], run_id=first_run)
+    handler.on_llm_end(_openai_result(1_000, 1_000), run_id=first_run)
     assert guard.spent_usd == pytest.approx(0.0125)
 
     with pytest.raises(BudgetExceeded):
-        handler.on_llm_start({}, ["hello"])
+        handler.on_llm_start({}, ["hello"], run_id=uuid4())
+
+
+def test_parallel_handler_starts_reserve_token_ceiling_atomically() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(
+        limit_usd=1.0,
+        token_limit=100,
+        on_token_block=lambda *_: None,
+    )
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 60}}
+    run_ids = [uuid4(), uuid4()]
+
+    def start(run_id: UUID) -> tuple[UUID, str]:
+        try:
+            handler.on_llm_start(serialized, [""], run_id=run_id)
+        except TokenBudgetExceeded:
+            return run_id, "blocked"
+        return run_id, "held"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, run_ids))
+
+    assert sorted(result for _, result in results) == ["blocked", "held"]
+    held_run = next(run_id for run_id, result in results if result == "held")
+    handler.on_llm_error(RuntimeError("provider failed"), run_id=held_run)
+    assert guard.remaining_tokens == 100
+
+
+def test_parallel_handler_starts_reserve_usd_ceiling_atomically() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=0.001, on_block=lambda *_: None)
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 60}}
+    run_ids = [uuid4(), uuid4()]
+
+    def start(run_id: UUID) -> tuple[UUID, str]:
+        try:
+            handler.on_llm_start(serialized, [""], run_id=run_id)
+        except BudgetExceeded:
+            return run_id, "blocked"
+        return run_id, "held"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, run_ids))
+
+    assert sorted(result for _, result in results) == ["blocked", "held"]
+    held_run = next(run_id for run_id, result in results if result == "held")
+    handler.on_llm_error(RuntimeError("provider failed"), run_id=held_run)
+    assert guard.remaining_usd == pytest.approx(guard.limit_usd)
+
+
+def test_parallel_handler_runs_settle_their_own_reservations() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=200)
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 60}}
+    runs = [(uuid4(), _openai_result(20, 10)), (uuid4(), _openai_result(25, 15))]
+
+    for run_id, _ in runs:
+        handler.on_llm_start(serialized, [""], run_id=run_id)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(
+            pool.map(
+                lambda item: handler.on_llm_end(item[1], run_id=item[0]),
+                runs,
+            )
+        )
+
+    assert guard.spent_tokens == 70
+    assert guard.remaining_tokens == 130
+
+
+def test_handler_releases_usage_less_and_failed_runs() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100)
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 40}}
+
+    usage_less_run = uuid4()
+    handler.on_llm_start(serialized, [""], run_id=usage_less_run)
+    handler.on_llm_end(_Result(llm_output={"model_name": "gpt-4o"}), run_id=usage_less_run)
+    assert guard.remaining_tokens == 100
+
+    failed_run = uuid4()
+    handler.on_llm_start(serialized, [""], run_id=failed_run)
+    handler.on_llm_error(RuntimeError("provider failed"), run_id=failed_run)
+    assert guard.remaining_tokens == 100
+
+
+def test_handler_releases_reservation_when_usage_is_malformed() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100)
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 40}}
+    run_id = uuid4()
+    malformed = _Result(
+        llm_output={
+            "model_name": "gpt-4o",
+            "token_usage": {"prompt_tokens": "bad", "completion_tokens": 1},
+        }
+    )
+
+    handler.on_llm_start(serialized, [""], run_id=run_id)
+    with pytest.raises(ValueError):
+        handler.on_llm_end(malformed, run_id=run_id)
+    assert guard.remaining_tokens == 100
+
+
+def test_handler_rejects_duplicate_active_run_without_leaking() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100)
+    handler = budget_guard_callback_handler(guard)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 40}}
+    run_id = uuid4()
+
+    handler.on_llm_start(serialized, [""], run_id=run_id)
+    with pytest.raises(RuntimeError, match="duplicate LangChain run_id"):
+        handler.on_llm_start(serialized, [""], run_id=run_id)
+    assert guard.remaining_tokens == 60
+
+    handler.on_llm_error(RuntimeError("provider failed"), run_id=run_id)
+    assert guard.remaining_tokens == 100
+
+
+def test_handler_enforces_scoped_step_ceiling() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=1_000, on_token_block=lambda *_: None)
+    serialized = {"kwargs": {"model_name": "gpt-4o", "max_tokens": 51}}
+
+    with guard.step(max_tokens=50) as step:
+        handler = budget_guard_callback_handler(step)
+        with pytest.raises(TokenBudgetExceeded, match=r"STEP TOKEN BUDGET EXCEEDED"):
+            handler.on_llm_start(serialized, [""], run_id=uuid4())
+        assert step.advisory().step_remaining_tokens == 50
+
+
+def test_handler_end_or_error_without_start_uses_unreserved_path() -> None:
+    pytest.importorskip("langchain_core")
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100)
+    handler = budget_guard_callback_handler(guard)
+
+    handler.on_llm_end(_openai_result(5, 7), run_id=uuid4())
+    handler.on_llm_error(RuntimeError("provider failed"), run_id=uuid4())
+
+    assert guard.spent_tokens == 12
+    assert guard.remaining_tokens == 88

--- a/tests/test_langchain_groq_adapter.py
+++ b/tests/test_langchain_groq_adapter.py
@@ -12,6 +12,7 @@ Handler tests require ``langchain_core`` and are skipped without it.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from uuid import uuid4
 
 import pytest
 
@@ -24,6 +25,7 @@ from floe_guard.integrations.langchain import (
 )
 
 # Minimal stubs that mirror ChatGroq's LLMResult shape
+
 
 @dataclass
 class _Msg:
@@ -52,9 +54,7 @@ def _groq_result(
     """
     return _Result(
         llm_output={"model": model},
-        generations=[
-            [_Gen(_Msg({"input_tokens": input_tokens, "output_tokens": output_tokens}))]
-        ],
+        generations=[[_Gen(_Msg({"input_tokens": input_tokens, "output_tokens": output_tokens}))]],
     )
 
 
@@ -84,7 +84,6 @@ def test_zero_usage_groq_result_is_noop() -> None:
     assert guard.spent_usd == 0.0
 
 
-
 # Full handler lifecycle — requires langchain_core
 
 
@@ -92,9 +91,10 @@ def test_handler_allows_groq_call_under_budget_and_records() -> None:
     pytest.importorskip("langchain_core")
     guard = BudgetGuard(limit_usd=1.0)
     handler = budget_guard_callback_handler(guard)
+    run_id = uuid4()
 
-    handler.on_chat_model_start({}, [[]])  # under budget — no raise
-    handler.on_llm_end(_groq_result(1_000, 1_000))
+    handler.on_chat_model_start({}, [[]], run_id=run_id)  # under budget — no raise
+    handler.on_llm_end(_groq_result(1_000, 1_000), run_id=run_id)
     assert guard.spent_usd > 0.0
 
 
@@ -104,10 +104,11 @@ def test_handler_blocks_groq_call_before_crossing() -> None:
     handler = budget_guard_callback_handler(guard)
 
     # First call goes through and primes _last_cost.
-    handler.on_chat_model_start({}, [[]])
-    handler.on_llm_end(_groq_result(1_000, 1_000))
+    first_run = uuid4()
+    handler.on_chat_model_start({}, [[]], run_id=first_run)
+    handler.on_llm_end(_groq_result(1_000, 1_000), run_id=first_run)
     assert guard.spent_usd > 0.0
 
     # Second call's projected cost would cross the ceiling.
     with pytest.raises(BudgetExceeded):
-        handler.on_chat_model_start({}, [[]])
+        handler.on_chat_model_start({}, [[]], run_id=uuid4())

--- a/tests/test_langgraph_adapter.py
+++ b/tests/test_langgraph_adapter.py
@@ -291,3 +291,72 @@ def test_latest_advisory_prefers_higher_utilization() -> None:
     assert latest_advisory(late, early) is late
     assert latest_advisory(None, early) is early
     assert latest_advisory(late, None) is late
+
+
+def test_latest_advisory_merges_cross_dimension_progress() -> None:
+    usd_fresh = BudgetAdvisory(
+        near_limit=False,
+        used_bps=7000,
+        remaining_usd=0.30,
+        limit_usd=1.0,
+        spent_usd=0.70,
+        expected_cost=0.10,
+        est_calls_remaining=3,
+        token_limit=1_000,
+        spent_tokens=100,
+        remaining_tokens=900,
+        token_used_bps=1000,
+        step_limit_usd=1.0,
+        step_spent_usd=0.70,
+        step_remaining_usd=0.30,
+        step_token_limit=1_000,
+        step_spent_tokens=100,
+        step_remaining_tokens=900,
+        step_used_bps=7000,
+    )
+    token_fresh = BudgetAdvisory(
+        near_limit=True,
+        used_bps=4000,
+        remaining_usd=0.60,
+        limit_usd=1.0,
+        spent_usd=0.40,
+        expected_cost=0.05,
+        est_calls_remaining=12,
+        token_limit=1_000,
+        spent_tokens=900,
+        remaining_tokens=100,
+        token_used_bps=9000,
+        near_token_limit=True,
+        step_limit_usd=1.0,
+        step_spent_usd=0.40,
+        step_remaining_usd=0.60,
+        step_token_limit=1_000,
+        step_spent_tokens=900,
+        step_remaining_tokens=100,
+        step_used_bps=9000,
+        step_near_limit=True,
+    )
+
+    expected = BudgetAdvisory(
+        near_limit=True,
+        used_bps=7000,
+        remaining_usd=0.30,
+        limit_usd=1.0,
+        spent_usd=0.70,
+        expected_cost=0.10,
+        est_calls_remaining=3,
+        token_limit=1_000,
+        spent_tokens=900,
+        remaining_tokens=100,
+        token_used_bps=9000,
+        near_token_limit=True,
+        step_limit_usd=1.0,
+        step_spent_usd=0.70,
+        step_remaining_usd=0.30,
+        step_token_limit=1_000,
+        step_spent_tokens=100,
+        step_remaining_tokens=900,
+        step_used_bps=7000,
+    )
+    assert latest_advisory(usd_fresh, token_fresh) == expected
+    assert latest_advisory(token_fresh, usd_fresh) == expected

--- a/tests/test_langgraph_adapter.py
+++ b/tests/test_langgraph_adapter.py
@@ -171,6 +171,33 @@ def test_node_error_releases_reservation() -> None:
     assert guard.spent_usd == pytest.approx(0.0125)  # only the warm call
 
 
+def test_step_scoped_node_settles_and_updates_advisory() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100)
+    with guard.step(max_usd=0.1, max_tokens=20) as step:
+
+        @guarded_node(step, estimated_cost=0.001, estimated_tokens=10)
+        def worker(state: dict) -> dict:
+            return {
+                "result": "ok",
+                "usage": {
+                    "model": MODEL,
+                    "prompt_tokens": 4,
+                    "completion_tokens": 6,
+                },
+            }
+
+        result = worker({})
+        assert result["result"] == "ok"
+        advisory = result["budget"]
+        assert isinstance(advisory, BudgetAdvisory)
+        assert advisory.step_spent_tokens == 10
+        assert advisory.step_remaining_tokens == 10
+        assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+        assert guard._reserved_tokens == 0
+
+    assert guard.spent_tokens == 10
+
+
 def test_malformed_usage_releases_hold_and_raises() -> None:
     # A malformed usage payload must not leak the reservation: the hold is
     # released before the error propagates, the same fail-safe as settle()'s

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -159,8 +159,9 @@ def test_callback_duplicate_call_id_preserves_original_reservation(
 
     callback.log_pre_api_call("gpt-4o", [], kwargs)
     assert guard.remaining_tokens == 60
-    with pytest.raises(RuntimeError, match="duplicate LiteLLM call id"):
+    with pytest.raises(RuntimeError, match="duplicate LiteLLM call id") as caught:
         callback.log_pre_api_call("gpt-4o", [], kwargs)
+    assert callback.tripped is caught.value
     assert guard.remaining_tokens == 60
     assert guard._reserved_tokens == 40
 

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -39,6 +39,20 @@ class _ObjResponse:
     usage: _Usage
 
 
+def _install_fake_litellm(monkeypatch: pytest.MonkeyPatch, *, tokens: int) -> None:
+    class CustomLogger:
+        pass
+
+    litellm = types.ModuleType("litellm")
+    litellm.token_counter = lambda **_: tokens  # type: ignore[attr-defined]
+    integrations = types.ModuleType("litellm.integrations")
+    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+    custom_logger.CustomLogger = CustomLogger  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations)
+    monkeypatch.setitem(sys.modules, "litellm.integrations.custom_logger", custom_logger)
+
+
 def test_model_from_object_response_without_kwargs_model() -> None:
     resp = _ObjResponse(model="gpt-4o", usage=_Usage(1, 1))
     assert _model_from({}, resp) == "gpt-4o"
@@ -122,18 +136,7 @@ def test_callback_latches_token_block_when_hook_exception_is_swallowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The callback latch is the hard-stop bridge when LiteLLM eats hook errors."""
-
-    class CustomLogger:
-        pass
-
-    litellm = types.ModuleType("litellm")
-    litellm.token_counter = lambda **_: 0  # type: ignore[attr-defined]
-    integrations = types.ModuleType("litellm.integrations")
-    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
-    custom_logger.CustomLogger = CustomLogger  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "litellm", litellm)
-    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations)
-    monkeypatch.setitem(sys.modules, "litellm.integrations.custom_logger", custom_logger)
+    _install_fake_litellm(monkeypatch, tokens=0)
 
     guard = BudgetGuard(limit_usd=1.0, token_limit=0, on_token_block=lambda *_: None)
     callback = budget_guard_callback(guard)
@@ -143,3 +146,33 @@ def test_callback_latches_token_block_when_hook_exception_is_swallowed(
         callback.log_pre_api_call("gpt-4o", [], kwargs)
 
     assert isinstance(callback.tripped, TokenBudgetExceeded)
+
+
+@pytest.mark.parametrize("terminal", ["failure", "success"])
+def test_callback_duplicate_call_id_preserves_original_reservation(
+    monkeypatch: pytest.MonkeyPatch, terminal: str
+) -> None:
+    _install_fake_litellm(monkeypatch, tokens=40)
+    guard = BudgetGuard(limit_usd=1.0, token_limit=100, on_token_block=lambda *_: None)
+    callback = budget_guard_callback(guard)
+    kwargs = {"litellm_call_id": "duplicate", "model": "gpt-4o", "messages": []}
+
+    callback.log_pre_api_call("gpt-4o", [], kwargs)
+    assert guard.remaining_tokens == 60
+    with pytest.raises(RuntimeError, match="duplicate LiteLLM call id"):
+        callback.log_pre_api_call("gpt-4o", [], kwargs)
+    assert guard.remaining_tokens == 60
+    assert guard._reserved_tokens == 40
+
+    if terminal == "failure":
+        callback.log_failure_event(kwargs, None, None, None)
+        assert guard.remaining_tokens == 100
+    else:
+        response = {
+            "model": "gpt-4o",
+            "usage": {"prompt_tokens": 20, "completion_tokens": 20},
+        }
+        callback.log_success_event(kwargs, response, None, None)
+        assert guard.remaining_tokens == 60
+        assert guard.spent_tokens == 40
+    assert guard._reserved_tokens == 0

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -7,12 +7,24 @@ even in CI without the optional extra.
 
 from __future__ import annotations
 
+import sys
+import types
 from dataclasses import dataclass
 
 import pytest
 
-from floe_guard import BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
-from floe_guard.integrations.litellm import _model_from, _record_response, _usage_from
+from floe_guard import (
+    BudgetGuard,
+    TokenBudgetExceeded,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+from floe_guard.integrations.litellm import (
+    _model_from,
+    _record_response,
+    _usage_from,
+    budget_guard_callback,
+)
 
 
 @dataclass
@@ -104,3 +116,30 @@ def test_record_response_tolerates_non_dict_kwargs() -> None:
     resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
     _record_response(guard, None, resp)  # type: ignore[arg-type]
     assert guard.spent_usd > 0
+
+
+def test_callback_latches_token_block_when_hook_exception_is_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The callback latch is the hard-stop bridge when LiteLLM eats hook errors."""
+
+    class CustomLogger:
+        pass
+
+    litellm = types.ModuleType("litellm")
+    litellm.token_counter = lambda **_: 0  # type: ignore[attr-defined]
+    integrations = types.ModuleType("litellm.integrations")
+    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+    custom_logger.CustomLogger = CustomLogger  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations)
+    monkeypatch.setitem(sys.modules, "litellm.integrations.custom_logger", custom_logger)
+
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0, on_token_block=lambda *_: None)
+    callback = budget_guard_callback(guard)
+    kwargs = {"litellm_call_id": "token-block", "model": "gpt-4o", "messages": []}
+
+    with pytest.raises(TokenBudgetExceeded):
+        callback.log_pre_api_call("gpt-4o", [], kwargs)
+
+    assert isinstance(callback.tripped, TokenBudgetExceeded)

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -20,7 +20,7 @@ pytest.importorskip("livekit.agents")
 from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics  # noqa: E402
 
 from floe_guard import BudgetGuard  # noqa: E402
-from floe_guard.errors import BudgetExceeded  # noqa: E402
+from floe_guard.errors import BudgetExceeded, TokenBudgetExceeded  # noqa: E402
 from floe_guard.integrations.livekit import LiveKitBudgetGuard  # noqa: E402
 
 
@@ -115,6 +115,29 @@ async def test_blocked_turn_raises_without_callback():
     session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
 
     with pytest.raises(BudgetExceeded):
+        await _drive_turn(agent)
+
+
+@pytest.mark.asyncio
+async def test_token_block_uses_callback_before_entering_llm_node() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    called = {}
+
+    async def handle(exc):
+        called["exc"] = exc
+
+    _, agent, _ = _attached(guard, on_budget_exceeded=handle)
+
+    assert await _drive_turn(agent) == []
+    assert isinstance(called.get("exc"), TokenBudgetExceeded)
+
+
+@pytest.mark.asyncio
+async def test_token_block_raises_before_entering_llm_node_without_callback() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    _, agent, _ = _attached(guard)
+
+    with pytest.raises(TokenBudgetExceeded):
         await _drive_turn(agent)
 
 

--- a/tests/test_pipecat_integration.py
+++ b/tests/test_pipecat_integration.py
@@ -37,10 +37,23 @@ from pipecat.metrics.metrics import LLMTokenUsage, LLMUsageMetricsData  # noqa: 
 from pipecat.pipeline.pipeline import Pipeline  # noqa: E402
 from pipecat.pipeline.runner import PipelineRunner  # noqa: E402
 from pipecat.pipeline.task import PipelineParams, PipelineTask  # noqa: E402
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor  # noqa: E402
 
 from floe_guard import BudgetGuard  # noqa: E402
 from floe_guard.errors import BudgetExceeded, TokenBudgetExceeded  # noqa: E402
 from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor  # noqa: E402
+
+
+class _FrameProbe(FrameProcessor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.start_frames = 0
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, LLMFullResponseStartFrame):
+            self.start_frames += 1
+        await self.push_frame(frame, direction)
 
 
 def _metrics_frame(prompt_tokens, completion_tokens, model="gpt-4o") -> MetricsFrame:
@@ -128,6 +141,39 @@ async def test_token_block_uses_callback_before_forwarding_start_frame() -> None
 
     assert isinstance(called.get("exc"), TokenBudgetExceeded)
     assert not processor._pending
+
+
+@pytest.mark.asyncio
+async def test_block_stops_downstream_after_upstream_llm_frame_exists() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    upstream = _FrameProbe()
+    downstream = _FrameProbe()
+    called = {}
+
+    async def handle_exceeded(exc):
+        called["exc"] = exc
+
+    processor = FloeBudgetGuardProcessor(
+        guard,
+        model="gpt-4o",
+        on_budget_exceeded=handle_exceeded,
+    )
+    pipeline = Pipeline([upstream, processor, downstream])
+    task = PipelineTask(
+        pipeline, params=PipelineParams(enable_metrics=True, enable_usage_metrics=True)
+    )
+    runner = PipelineRunner()
+
+    async def drive():
+        await task.queue_frame(LLMFullResponseStartFrame())
+        await asyncio.sleep(0.05)
+        await task.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(task), drive())
+
+    assert upstream.start_frames == 1
+    assert downstream.start_frames == 0
+    assert isinstance(called.get("exc"), TokenBudgetExceeded)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipecat_integration.py
+++ b/tests/test_pipecat_integration.py
@@ -39,7 +39,7 @@ from pipecat.pipeline.runner import PipelineRunner  # noqa: E402
 from pipecat.pipeline.task import PipelineParams, PipelineTask  # noqa: E402
 
 from floe_guard import BudgetGuard  # noqa: E402
-from floe_guard.errors import BudgetExceeded  # noqa: E402
+from floe_guard.errors import BudgetExceeded, TokenBudgetExceeded  # noqa: E402
 from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor  # noqa: E402
 
 
@@ -108,6 +108,26 @@ async def test_on_budget_exceeded_callback_used_instead_of_raising():
 
     assert "exc" in called
     assert isinstance(called["exc"], BudgetExceeded)
+
+
+@pytest.mark.asyncio
+async def test_token_block_uses_callback_before_forwarding_start_frame() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    called = {}
+
+    async def handle_exceeded(exc):
+        called["exc"] = exc
+
+    processor = FloeBudgetGuardProcessor(
+        guard,
+        model="gpt-4o",
+        on_budget_exceeded=handle_exceeded,
+    )
+
+    await _run_frames(processor, [LLMFullResponseStartFrame()])
+
+    assert isinstance(called.get("exc"), TokenBudgetExceeded)
+    assert not processor._pending
 
 
 @pytest.mark.asyncio
@@ -197,6 +217,35 @@ async def test_pushes_fatal_error_when_ceiling_crossed_without_callback():
     await asyncio.gather(runner.run(task), drive())
 
     assert len(captured_errors) == 1
+    assert captured_errors[0].fatal is True
+
+
+@pytest.mark.asyncio
+async def test_token_block_pushes_fatal_error_without_callback() -> None:
+    guard = BudgetGuard(limit_usd=1.0, token_limit=0)
+    processor = FloeBudgetGuardProcessor(guard, model="gpt-4o")
+
+    pipeline = Pipeline([processor])
+    task = PipelineTask(
+        pipeline, params=PipelineParams(enable_metrics=True, enable_usage_metrics=True)
+    )
+    runner = PipelineRunner()
+    captured_errors = []
+
+    @task.event_handler("on_pipeline_error")
+    async def _on_pipeline_error(task, frame):
+        captured_errors.append(frame)
+
+    async def drive():
+        await task.queue_frame(LLMFullResponseStartFrame())
+        await asyncio.sleep(0.05)
+        if not task.has_finished():
+            await task.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(task), drive())
+
+    assert len(captured_errors) == 1
+    assert isinstance(captured_errors[0].exception, TokenBudgetExceeded)
     assert captured_errors[0].fatal is True
 
 

--- a/tests/test_stream_guard.py
+++ b/tests/test_stream_guard.py
@@ -81,8 +81,10 @@ class _FakeLiteLLM:
     def __init__(self, tokens: int = 1_000, raise_on_count: bool = False) -> None:
         self._tokens = tokens
         self._raise = raise_on_count
+        self.calls = 0
 
     def token_counter(self, model: str, messages: Any) -> int:
+        self.calls += 1
         if self._raise:
             raise RuntimeError("unknown model")
         return self._tokens
@@ -91,20 +93,26 @@ class _FakeLiteLLM:
 def test_litellm_estimate_prices_model_prompt_and_cap() -> None:
     guard = BudgetGuard(limit_usd=1.00)
     kwargs = {"model": MODEL, "messages": [{"role": "user", "content": "hi"}], "max_tokens": 2_000}
-    est = _estimate_request(_FakeLiteLLM(tokens=1_000), guard, kwargs)
-    assert est == pytest.approx(0.0025 + 0.02)
+    litellm = _FakeLiteLLM(tokens=1_000)
+    estimated_cost, estimated_tokens = _estimate_request(litellm, guard, kwargs)
+    assert estimated_cost == pytest.approx(0.0025 + 0.02)
+    assert estimated_tokens == 3_000
+    assert litellm.calls == 1
 
 
 def test_litellm_estimate_degrades_to_none() -> None:
     guard = BudgetGuard(limit_usd=1.00)
-    assert _estimate_request(_FakeLiteLLM(), guard, {"messages": []}) is None  # no model
-    assert _estimate_request(_FakeLiteLLM(), guard, None) is None  # non-dict kwargs
+    assert _estimate_request(_FakeLiteLLM(), guard, {"messages": []}) == (None, None)
+    assert _estimate_request(_FakeLiteLLM(), guard, None) == (None, None)
     assert (  # token_counter failure
-        _estimate_request(_FakeLiteLLM(raise_on_count=True), guard, {"model": MODEL}) is None
+        _estimate_request(_FakeLiteLLM(raise_on_count=True), guard, {"model": MODEL})
+        == (None, None)
     )
-    assert (  # unpriceable model
-        _estimate_request(_FakeLiteLLM(), guard, {"model": "model-that-does-not-exist"}) is None
-    )
+    assert _estimate_request(
+        _FakeLiteLLM(tokens=25),
+        guard,
+        {"model": "model-that-does-not-exist", "max_tokens": 10},
+    ) == (None, 35)
 
 
 def test_langchain_estimate_uses_serialized_config_and_text_heuristic() -> None:

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import copy
 import threading
+from dataclasses import FrozenInstanceError
 
 import pytest
 
@@ -108,6 +110,163 @@ def test_typed_handle_is_exactly_once_and_guard_owned() -> None:
     second.release(foreign)
 
 
+def test_typed_handle_is_immutable() -> None:
+    guard = quiet_guard(token_limit=100)
+    other = quiet_guard(token_limit=100)
+    handle = guard.reserve(0.1, estimated_tokens=20)
+    assert isinstance(handle, BudgetReservation)
+    assert handle.usd == 0.1
+    assert handle.tokens == 20
+
+    with pytest.raises(FrozenInstanceError):
+        handle.usd = 0.2  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        handle.tokens = 30  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        handle._owner = other  # type: ignore[misc]
+
+    guard.release(handle)
+
+
+@pytest.mark.parametrize(
+    ("field", "bad"),
+    [
+        ("usd", 0.4),
+        ("usd", -0.1),
+        ("usd", float("nan")),
+        ("tokens", 40),
+        ("tokens", -1),
+        ("tokens", 1.5),
+        ("tokens", float("nan")),
+    ],
+)
+def test_forced_typed_handle_mutation_cannot_change_accounting(field: str, bad: object) -> None:
+    guard = quiet_guard(token_limit=100)
+    handle = guard.reserve(0.2, estimated_tokens=20)
+    assert isinstance(handle, BudgetReservation)
+    original = getattr(handle, field)
+
+    object.__setattr__(handle, field, bad)
+    with pytest.raises(ValueError, match="modified"):
+        guard.release(handle)
+    assert guard._reserved == 0.2
+    assert guard._reserved_tokens == 20
+
+    object.__setattr__(handle, field, original)
+    guard.release(handle)
+    assert guard._reserved == 0.0
+    assert guard._reserved_tokens == 0
+
+
+def test_equal_value_type_change_is_still_rejected_as_handle_mutation() -> None:
+    guard = quiet_guard(token_limit=100)
+    handle = guard.reserve(1.0, estimated_tokens=20)
+    assert isinstance(handle, BudgetReservation)
+
+    object.__setattr__(handle, "usd", True)
+    with pytest.raises(ValueError, match="modified"):
+        guard.release(handle)
+    assert guard._reserved == 1.0
+    assert guard._reserved_tokens == 20
+
+    object.__setattr__(handle, "usd", 1.0)
+    guard.release(handle)
+
+
+def test_forged_and_copied_typed_handles_are_rejected_without_mutation() -> None:
+    guard = quiet_guard(token_limit=100)
+    issued = guard.reserve(0.2, estimated_tokens=20)
+    assert isinstance(issued, BudgetReservation)
+    forged = BudgetReservation(issued.usd, issued.tokens, guard)
+    copied = copy.copy(issued)
+
+    for invalid in (forged, copied):
+        with pytest.raises(ValueError, match="not issued"):
+            guard.release(invalid)
+        assert guard._reserved == 0.2
+        assert guard._reserved_tokens == 20
+
+    guard.release(issued)
+
+
+def test_equality_forgery_cannot_alias_an_issued_handle() -> None:
+    guard = quiet_guard(token_limit=100)
+    issued = guard.reserve(0.2, estimated_tokens=20)
+    assert isinstance(issued, BudgetReservation)
+
+    class EqualForgery(BudgetReservation):
+        def __hash__(self) -> int:
+            return hash(issued)
+
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    forged = EqualForgery(issued.usd, issued.tokens, guard)
+    with pytest.raises(ValueError, match="not issued"):
+        guard.release(forged)
+    assert guard._reserved == 0.2
+    assert guard._reserved_tokens == 20
+
+    guard.release(issued)
+
+
+def test_modified_handle_cannot_free_an_unrelated_token_hold() -> None:
+    guard = quiet_guard(token_limit=300)
+    first = guard.reserve(0.2, estimated_tokens=100)
+    second = guard.reserve(0.2, estimated_tokens=100)
+    assert isinstance(first, BudgetReservation)
+    assert isinstance(second, BudgetReservation)
+
+    object.__setattr__(first, "tokens", 200)
+    with pytest.raises(ValueError, match="modified"):
+        guard.release(first)
+    assert guard._reserved == 0.4
+    assert guard._reserved_tokens == 200
+    with pytest.raises(TokenBudgetExceeded):
+        guard.reserve(0.1, estimated_tokens=101)
+
+    object.__setattr__(first, "tokens", 100)
+    guard.release(first)
+    assert guard._reserved_tokens == 100
+    guard.release(second)
+    assert guard._reserved == 0.0
+    assert guard._reserved_tokens == 0
+
+
+def test_concurrent_terminal_operations_consume_typed_handle_once() -> None:
+    guard = quiet_guard(token_limit=100)
+    target = guard.reserve(0.2, estimated_tokens=20)
+    unrelated = guard.reserve(0.3, estimated_tokens=30)
+    assert isinstance(target, BudgetReservation)
+    assert isinstance(unrelated, BudgetReservation)
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def release_target() -> None:
+        barrier.wait()
+        try:
+            guard.release(target)
+        except ValueError as exc:
+            outcome = str(exc)
+        else:
+            outcome = "released"
+        with lock:
+            outcomes.append(outcome)
+
+    threads = [threading.Thread(target=release_target) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert outcomes.count("released") == 1
+    assert sum("already" in outcome for outcome in outcomes) == 1
+    assert guard._reserved == 0.3
+    assert guard._reserved_tokens == 30
+    guard.release(unrelated)
+
+
 def test_concurrent_token_reservations_hold_the_ceiling() -> None:
     guard = quiet_guard(token_limit=100)
     barrier = threading.Barrier(5)
@@ -187,6 +346,41 @@ def test_overlapping_steps_keep_state_isolated() -> None:
         assert step_a.advisory().step_spent_tokens == 30
         assert step_b.advisory().step_spent_tokens == 70
     assert guard.spent_tokens == 100
+
+
+def test_scoped_guard_rejects_sibling_and_nonzero_numeric_handles() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    first = guard.step(max_tokens=100)
+    second = guard.step(max_tokens=100)
+    with first as step_a, second as step_b:
+        handle_a = step_a.reserve(0.1, estimated_tokens=20)
+        handle_b = step_b.reserve(0.2, estimated_tokens=30)
+        assert isinstance(handle_a, BudgetReservation)
+        assert isinstance(handle_b, BudgetReservation)
+
+        with pytest.raises(ValueError, match="different step"):
+            step_b.settle("manual", 1, 0, reserved=handle_a, price=PRICE)
+        with pytest.raises(ValueError, match="different step"):
+            step_b.release(handle_a)
+        with pytest.raises(ValueError, match="must be zero"):
+            step_a.settle("manual", 1, 0, reserved=0.1, price=PRICE)
+        assert guard._reserved == pytest.approx(0.3)
+        assert guard._reserved_tokens == 50
+
+        step_a.release(handle_a)
+        step_b.release(handle_b)
+
+
+def test_scoped_record_paths_use_registered_zero_handles() -> None:
+    guard = quiet_guard(token_limit=100)
+    with guard.step(max_usd=1.0, max_tokens=50) as step:
+        step.record("manual", 10, 5, price=PRICE)
+        step.record_tool("search", 0.25)
+        advisory = step.advisory()
+        assert advisory.step_spent_tokens == 15
+        assert advisory.step_spent_usd == pytest.approx(0.25002)
+    assert guard.spent_tokens == 15
+    assert guard.spent_usd == pytest.approx(0.25002)
 
 
 def test_clean_step_exit_detects_leaked_reservation() -> None:

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -65,9 +65,12 @@ def test_explicit_and_last_call_estimates_block_before_call() -> None:
     with pytest.raises(TokenBudgetExceeded):
         guard.reserve(0.0, estimated_tokens=101)
     guard.record("manual", 40, 10, price=PRICE)
-    assert guard.reserve(0.0).tokens == 50
+    held = guard.reserve(0.0)
+    assert isinstance(held, BudgetReservation)
+    assert held.tokens == 50
     with pytest.raises(TokenBudgetExceeded):
         guard.reserve(0.0)
+    guard.release(held)
 
 
 def test_aggregate_token_advisory_flips_overall_near_limit() -> None:
@@ -419,6 +422,71 @@ def test_step_cannot_open_new_reservations_after_exit() -> None:
         scoped.reserve_tool(0.01)
 
 
+def test_step_exit_and_reserve_share_one_lifecycle_boundary() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_tokens=50)
+    scoped.__enter__()
+    reached_reserve = threading.Event()
+    original_ensure_active = scoped._ensure_active
+
+    def signal_before_reserve() -> None:
+        original_ensure_active()
+        reached_reserve.set()
+
+    scoped._ensure_active = signal_before_reserve  # type: ignore[method-assign]
+    reserve_result: list[BudgetReservation] = []
+    reserve_errors: list[BaseException] = []
+    exit_errors: list[BaseException] = []
+
+    def reserve() -> None:
+        try:
+            handle = scoped.reserve(0.0, estimated_tokens=10)
+            assert isinstance(handle, BudgetReservation)
+            reserve_result.append(handle)
+        except BaseException as exc:
+            reserve_errors.append(exc)
+
+    def exit_step() -> None:
+        try:
+            scoped.__exit__(None, None, None)
+        except BaseException as exc:
+            exit_errors.append(exc)
+
+    guard._lock.acquire()
+    reserve_thread = threading.Thread(target=reserve)
+    reserve_thread.start()
+    assert reached_reserve.wait(timeout=1)
+    exit_thread = threading.Thread(target=exit_step)
+    exit_thread.start()
+    guard._lock.release()
+    reserve_thread.join()
+    exit_thread.join()
+
+    if reserve_result:
+        assert len(exit_errors) == 1
+        assert "active reservation" in str(exit_errors[0])
+        guard.release(reserve_result[0])
+    else:
+        assert len(reserve_errors) == 1
+        assert "no longer active" in str(reserve_errors[0])
+        assert exit_errors == []
+    assert guard.remaining_tokens == 100
+
+
+def test_step_exposes_only_deliberate_parent_surface() -> None:
+    guard = quiet_guard(token_limit=100)
+    with guard.step(max_tokens=50) as step:
+        assert step.limit_usd == guard.limit_usd
+        assert step.token_limit == guard.token_limit
+        assert step.remaining_tokens == guard.remaining_tokens
+        assert step.estimate_call("manual", 1, price=PRICE) == pytest.approx(1e-6)
+        assert step.export_log() == guard.export_log()
+        with pytest.raises(AttributeError):
+            step.step(max_tokens=1)  # type: ignore[attr-defined]
+        with pytest.raises(AttributeError):
+            step.unknown_parent_method()  # type: ignore[attr-defined]
+
+
 def test_step_record_tool_rejects_spend_after_exit() -> None:
     guard = quiet_guard(token_limit=100)
     scoped = guard.step(max_usd=0.05)
@@ -473,6 +541,77 @@ def test_stream_hard_stops_on_token_ceiling_and_settles_partial_usage() -> None:
             stream.feed_tokens(3)
             stream.feed_tokens(1)
     assert guard.spent_tokens == 6
+
+
+def test_scoped_stream_rejects_wrong_handles_before_registration() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    first = guard.step(max_tokens=100)
+    second = guard.step(max_tokens=100)
+    with first as step_a, second as step_b:
+        handle = step_a.reserve(0.0, estimated_tokens=10)
+        assert isinstance(handle, BudgetReservation)
+        baseline_streams = len(guard._stream_costs)
+        with pytest.raises(ValueError, match="different step"):
+            StreamGuard(step_b, "manual", reserved=handle, price=PRICE)
+        with pytest.raises(ValueError, match="must be zero"):
+            StreamGuard(step_b, "manual", reserved=0.1, price=PRICE)
+        assert len(guard._stream_costs) == baseline_streams
+        assert guard._reserved_tokens == 10
+        step_a.release(handle)
+
+
+def test_scoped_zero_stream_is_attributed_to_step_ceiling() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    with guard.step(max_tokens=5) as step:
+        with pytest.raises(TokenBudgetExceeded) as caught:
+            with StreamGuard(step, "manual", price=PRICE) as stream:
+                stream.feed_tokens(6)
+        assert caught.value.scope == "step"
+        assert step.advisory().step_spent_tokens == 6
+        assert guard._reserved_tokens == 0
+        assert guard._stream_costs == {}
+
+
+def test_scoped_stream_accepts_same_step_handle_and_settles() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    with guard.step(max_tokens=100) as step:
+        handle = step.reserve(0.0, estimated_tokens=10)
+        assert isinstance(handle, BudgetReservation)
+        stream = StreamGuard(step, "manual", reserved=handle, price=PRICE)
+        stream.feed_tokens(4)
+        assert stream.finish() == pytest.approx(8e-6)
+        assert step.advisory().step_spent_tokens == 4
+        assert guard._reserved_tokens == 0
+        assert guard._stream_costs == {}
+
+
+def test_scoped_stream_counts_same_step_but_not_sibling_streams() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    first = guard.step(max_tokens=5)
+    second = guard.step(max_tokens=5)
+    with first as step_a, second as step_b:
+        stream_a = StreamGuard(step_a, "manual", price=PRICE)
+        stream_b = StreamGuard(step_b, "manual", price=PRICE)
+        stream_a.feed_tokens(4)
+        stream_b.feed_tokens(4)
+
+        sibling_a = StreamGuard(step_a, "manual", price=PRICE)
+        with pytest.raises(TokenBudgetExceeded) as caught:
+            sibling_a.feed_tokens(2)
+        assert caught.value.scope == "step"
+
+        stream_a.finish()
+        stream_b.finish()
+        assert guard._stream_costs == {}
+
+
+def test_scoped_stream_rejects_inactive_step() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_tokens=50)
+    with scoped:
+        pass
+    with pytest.raises(RuntimeError, match="no longer active"):
+        StreamGuard(scoped, "manual", price=PRICE)
 
 
 def test_scoped_guard_blocks_adapter_before_provider_call() -> None:

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -1,0 +1,270 @@
+"""Aggregate token ceilings and explicit per-step budget scopes (issue #46)."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    BudgetReservation,
+    ManualPrice,
+    TokenBudgetExceeded,
+)
+from floe_guard.integrations.openai import guarded_completion
+from floe_guard.stream import StreamGuard
+
+PRICE = ManualPrice(1e-6, 2e-6)
+
+
+def quiet_guard(**kwargs) -> BudgetGuard:
+    return BudgetGuard(
+        limit_usd=10.0,
+        on_block=lambda _spent, _limit: None,
+        on_token_block=lambda _spent, _limit: None,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("bad", [-1, 1.5, True, float("nan"), float("inf")])
+def test_token_limit_rejects_invalid_values(bad: object) -> None:
+    with pytest.raises(ValueError):
+        quiet_guard(token_limit=bad)  # type: ignore[arg-type]
+
+
+def test_legacy_guard_keeps_numeric_handle_and_behavior() -> None:
+    guard = quiet_guard()
+    handle = guard.reserve(0.1)
+    assert isinstance(handle, float)
+    guard.release(handle)
+    assert guard.remaining_tokens is None
+    assert guard.advisory().token_limit is None
+
+
+def test_record_accumulates_all_token_buckets() -> None:
+    guard = quiet_guard(token_limit=10_000)
+    guard.record(
+        "manual",
+        100,
+        20,
+        price=PRICE,
+        cache_creation_input_tokens=30,
+        cache_creation_input_tokens_1h=40,
+        cache_read_input_tokens=50,
+    )
+    assert guard.spent_tokens == 240
+    assert guard.remaining_tokens == 9_760
+
+
+def test_explicit_and_last_call_estimates_block_before_call() -> None:
+    guard = quiet_guard(token_limit=100)
+    with pytest.raises(TokenBudgetExceeded):
+        guard.reserve(0.0, estimated_tokens=101)
+    guard.record("manual", 40, 10, price=PRICE)
+    assert guard.reserve(0.0).tokens == 50
+    with pytest.raises(TokenBudgetExceeded):
+        guard.reserve(0.0)
+
+
+def test_aggregate_token_advisory_flips_overall_near_limit() -> None:
+    guard = quiet_guard(token_limit=100, near_limit_bps=8000)
+    guard.record("manual", 80, 0, price=PRICE)
+    advisory = guard.advisory()
+    assert advisory.token_used_bps == 8000
+    assert advisory.near_token_limit is True
+    assert advisory.near_limit is True
+    assert advisory.remaining_tokens == 20
+
+
+def test_unpriceable_response_still_accrues_known_tokens() -> None:
+    guard = quiet_guard(token_limit=100, fail_closed=False)
+    with pytest.warns():
+        guard.record("unknown-model", 10, 5)
+    assert guard.spent_tokens == 15
+    assert guard.spent_usd == 0.0
+
+
+def test_zero_token_limit_blocks_first_llm_but_not_tool() -> None:
+    guard = quiet_guard(token_limit=0)
+    tool = guard.reserve_tool(0.01)
+    guard.settle_tool("cache.lookup", 0.01, reserved=tool)
+    with pytest.raises(TokenBudgetExceeded):
+        guard.check(estimated_next_tokens=0)
+
+
+def test_typed_handle_is_exactly_once_and_guard_owned() -> None:
+    first = quiet_guard(token_limit=100)
+    second = quiet_guard(token_limit=100)
+    handle = first.reserve(0.1, estimated_tokens=20)
+    assert isinstance(handle, BudgetReservation)
+    first.release(handle)
+    with pytest.raises(ValueError, match="already"):
+        first.release(handle)
+    foreign = second.reserve(0.1, estimated_tokens=20)
+    with pytest.raises(ValueError, match="different"):
+        first.release(foreign)
+    second.release(foreign)
+
+
+def test_concurrent_token_reservations_hold_the_ceiling() -> None:
+    guard = quiet_guard(token_limit=100)
+    barrier = threading.Barrier(5)
+    handles: list[BudgetReservation] = []
+    blocked = 0
+    lock = threading.Lock()
+
+    def worker() -> None:
+        nonlocal blocked
+        barrier.wait()
+        try:
+            handle = guard.reserve(0.0, estimated_tokens=30)
+        except TokenBudgetExceeded:
+            with lock:
+                blocked += 1
+            return
+        assert isinstance(handle, BudgetReservation)
+        with lock:
+            handles.append(handle)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert len(handles) == 3
+    assert blocked == 2
+    for handle in handles:
+        guard.release(handle)
+    assert guard.remaining_tokens == 100
+
+
+def test_step_resets_and_counts_against_parent() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    with guard.step(max_usd=1.0, max_tokens=100) as step:
+        step.record("manual", 40, 10, price=PRICE)
+        advisory = step.advisory()
+        assert advisory.step_spent_tokens == 50
+        assert advisory.step_remaining_tokens == 50
+    with guard.step(max_tokens=100) as next_step:
+        assert next_step.advisory().step_spent_tokens == 0
+        next_step.record("manual", 20, 10, price=PRICE)
+    assert guard.spent_tokens == 80
+
+
+def test_step_tightest_limit_blocks_with_scope() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    with guard.step(max_usd=0.05, max_tokens=50) as step:
+        step.record("manual", 30, 10, price=PRICE)
+        with pytest.raises(TokenBudgetExceeded) as caught:
+            step.check(0.001, estimated_next_tokens=11)
+        assert caught.value.scope == "step"
+
+    with guard.step(max_usd=0.001) as step:
+        with pytest.raises(BudgetExceeded) as caught:
+            step.check(0.002, estimated_next_tokens=0)
+        assert caught.value.scope == "step"
+
+
+def test_tool_counts_against_step_usd_not_tokens() -> None:
+    guard = quiet_guard(token_limit=100)
+    with guard.step(max_usd=0.02, max_tokens=0) as step:
+        handle = step.reserve_tool(0.01)
+        step.settle_tool("search", 0.01, reserved=handle)
+        assert step.advisory().step_spent_tokens == 0
+        with pytest.raises(BudgetExceeded):
+            step.reserve_tool(0.02)
+
+
+def test_overlapping_steps_keep_state_isolated() -> None:
+    guard = quiet_guard(token_limit=1_000)
+    first = guard.step(max_tokens=100)
+    second = guard.step(max_tokens=200)
+    with first as step_a, second as step_b:
+        step_a.record("manual", 30, 0, price=PRICE)
+        step_b.record("manual", 70, 0, price=PRICE)
+        assert step_a.advisory().step_spent_tokens == 30
+        assert step_b.advisory().step_spent_tokens == 70
+    assert guard.spent_tokens == 100
+
+
+def test_clean_step_exit_detects_leaked_reservation() -> None:
+    guard = quiet_guard(token_limit=100)
+    handle: BudgetReservation
+    with pytest.raises(RuntimeError, match="active reservation"):
+        with guard.step(max_tokens=50) as step:
+            reserved = step.reserve(0.0, estimated_tokens=10)
+            assert isinstance(reserved, BudgetReservation)
+            handle = reserved
+    guard.release(handle)
+
+
+def test_step_exception_is_not_masked_by_leaked_reservation() -> None:
+    guard = quiet_guard(token_limit=100)
+    handle: BudgetReservation
+    with pytest.raises(LookupError, match="provider failed"):
+        with guard.step(max_tokens=50) as step:
+            reserved = step.reserve(0.0, estimated_tokens=10)
+            assert isinstance(reserved, BudgetReservation)
+            handle = reserved
+            raise LookupError("provider failed")
+    guard.release(handle)
+
+
+def test_step_cannot_open_new_reservations_after_exit() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_tokens=50)
+
+    with scoped:
+        pass
+
+    with pytest.raises(RuntimeError, match="no longer active"):
+        scoped.reserve(0.0, estimated_tokens=1)
+    with pytest.raises(RuntimeError, match="no longer active"):
+        scoped.reserve_tool(0.01)
+
+
+def test_step_advisory_drives_existing_near_limit_signal() -> None:
+    guard = quiet_guard(token_limit=1_000, near_limit_bps=8000)
+    with guard.step(max_tokens=100) as step:
+        step.record("manual", 80, 0, price=PRICE)
+        advisory = step.advisory()
+        assert advisory.step_used_bps == 8000
+        assert advisory.step_near_limit is True
+        assert advisory.near_limit is True
+
+
+def test_stream_hard_stops_on_token_ceiling_and_settles_partial_usage() -> None:
+    guard = quiet_guard(token_limit=5)
+    handle = guard.reserve(0.0, estimated_tokens=0)
+    with pytest.raises(TokenBudgetExceeded):
+        with StreamGuard(
+            guard,
+            "manual",
+            prompt_tokens=2,
+            reserved=handle,
+            price=PRICE,
+        ) as stream:
+            stream.feed_tokens(3)
+            stream.feed_tokens(1)
+    assert guard.spent_tokens == 6
+
+
+def test_scoped_guard_blocks_adapter_before_provider_call() -> None:
+    called = False
+
+    class Completions:
+        def create(self, **kwargs):
+            nonlocal called
+            called = True
+            return {}
+
+    class Client:
+        chat = type("Chat", (), {"completions": Completions()})()
+
+    guard = quiet_guard(token_limit=1_000)
+    with guard.step(max_tokens=0) as step:
+        with pytest.raises(TokenBudgetExceeded):
+            guarded_completion(step, Client(), model="gpt-4o", messages=[])
+    assert called is False

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -394,7 +394,8 @@ def test_clean_step_exit_detects_leaked_reservation() -> None:
             reserved = step.reserve(0.0, estimated_tokens=10)
             assert isinstance(reserved, BudgetReservation)
             handle = reserved
-    guard.release(handle)
+    step.release(handle)
+    assert guard.remaining_tokens == 100
 
 
 def test_step_exception_is_not_masked_by_leaked_reservation() -> None:
@@ -452,15 +453,19 @@ def test_step_exit_and_reserve_share_one_lifecycle_boundary() -> None:
         except BaseException as exc:
             exit_errors.append(exc)
 
-    guard._lock.acquire()
     reserve_thread = threading.Thread(target=reserve)
-    reserve_thread.start()
-    assert reached_reserve.wait(timeout=1)
     exit_thread = threading.Thread(target=exit_step)
-    exit_thread.start()
-    guard._lock.release()
+    signalled = False
+    guard._lock.acquire()
+    try:
+        reserve_thread.start()
+        signalled = reached_reserve.wait(timeout=1)
+        exit_thread.start()
+    finally:
+        guard._lock.release()
     reserve_thread.join()
     exit_thread.join()
+    assert signalled
 
     if reserve_result:
         assert len(exit_errors) == 1
@@ -470,6 +475,27 @@ def test_step_exit_and_reserve_share_one_lifecycle_boundary() -> None:
         assert len(reserve_errors) == 1
         assert "no longer active" in str(reserve_errors[0])
         assert exit_errors == []
+    assert guard.remaining_tokens == 100
+
+
+def test_step_settlement_rejects_exit_but_release_still_cleans_up() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_usd=1.0, max_tokens=50)
+    with scoped:
+        llm_handle = scoped.reserve(0.0, estimated_tokens=0)
+        tool_handle = scoped.reserve_tool(0.0)
+        assert isinstance(llm_handle, BudgetReservation)
+        assert isinstance(tool_handle, BudgetReservation)
+
+    with pytest.raises(RuntimeError, match="no longer active"):
+        scoped.settle("manual", 1, 0, reserved=llm_handle, price=PRICE)
+    with pytest.raises(RuntimeError, match="no longer active"):
+        scoped.settle_tool("search", 0.01, reserved=tool_handle)
+
+    scoped.release(llm_handle)
+    scoped.release(tool_handle)
+    assert guard.spent_usd == 0.0
+    assert guard.spent_tokens == 0
     assert guard.remaining_tokens == 100
 
 

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -45,6 +45,26 @@ def test_legacy_guard_keeps_numeric_handle_and_behavior() -> None:
     assert guard.advisory().token_limit is None
 
 
+def test_legacy_numeric_handles_do_not_leak_token_reservations() -> None:
+    guard = quiet_guard()
+    guard.record("manual", 10, 5, price=PRICE)
+
+    fallback = guard.reserve(0.1)
+    assert isinstance(fallback, float)
+    assert guard._reserved_tokens == 0
+    guard.release(fallback)
+    assert guard._reserved == 0.0
+    assert guard._reserved_tokens == 0
+
+    explicit = guard.reserve(0.1, estimated_tokens=25)
+    assert isinstance(explicit, float)
+    assert guard._reserved_tokens == 0
+    guard.settle("manual", 2, 3, reserved=explicit, price=PRICE)
+    assert guard._reserved == 0.0
+    assert guard._reserved_tokens == 0
+    assert guard.spent_tokens == 20
+
+
 def test_record_accumulates_all_token_buckets() -> None:
     guard = quiet_guard(token_limit=10_000)
     guard.record(
@@ -68,9 +88,11 @@ def test_explicit_and_last_call_estimates_block_before_call() -> None:
     held = guard.reserve(0.0)
     assert isinstance(held, BudgetReservation)
     assert held.tokens == 50
+    assert guard._reserved_tokens == 50
     with pytest.raises(TokenBudgetExceeded):
         guard.reserve(0.0)
     guard.release(held)
+    assert guard._reserved_tokens == 0
 
 
 def test_aggregate_token_advisory_flips_overall_near_limit() -> None:
@@ -313,6 +335,18 @@ def test_step_resets_and_counts_against_parent() -> None:
         assert next_step.advisory().step_spent_tokens == 0
         next_step.record("manual", 20, 10, price=PRICE)
     assert guard.spent_tokens == 80
+
+
+def test_usd_only_step_tracks_typed_token_reservations_without_parent_limit() -> None:
+    guard = quiet_guard()
+    with guard.step(max_usd=1.0) as step:
+        handle = step.reserve(0.1, estimated_tokens=20)
+        assert isinstance(handle, BudgetReservation)
+        assert handle.tokens == 20
+        assert guard._reserved_tokens == 20
+        step.release(handle)
+        assert guard._reserved == 0.0
+        assert guard._reserved_tokens == 0
 
 
 def test_step_tightest_limit_blocks_with_scope() -> None:

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -225,6 +225,36 @@ def test_step_cannot_open_new_reservations_after_exit() -> None:
         scoped.reserve_tool(0.01)
 
 
+def test_step_record_tool_rejects_spend_after_exit() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_usd=0.05)
+
+    with scoped:
+        scoped.record_tool("search", 0.01)
+    aggregate_spend = guard.spent_usd
+    step_spend = scoped.advisory().step_spent_usd
+
+    with pytest.raises(RuntimeError, match="no longer active"):
+        scoped.record_tool("search", 0.01)
+    assert guard.spent_usd == aggregate_spend
+    assert scoped.advisory().step_spent_usd == step_spend
+
+
+def test_step_rejects_nested_entry_of_the_same_scope() -> None:
+    guard = quiet_guard(token_limit=100)
+    scoped = guard.step(max_tokens=50)
+
+    with scoped:
+        with pytest.raises(RuntimeError, match="cannot be re-entered"):
+            with scoped:
+                pass
+        scoped.check(estimated_next_tokens=1)
+
+    with pytest.raises(RuntimeError, match="cannot be re-entered"):
+        with scoped:
+            pass
+
+
 def test_step_advisory_drives_existing_near_limit_signal() -> None:
     guard = quiet_guard(token_limit=1_000, near_limit_bps=8000)
     with guard.step(max_tokens=100) as step:


### PR DESCRIPTION
## Summary

Adds aggregate token ceilings and independent per-step USD/token budgets to the Python and TypeScript packages.

Token and USD projections are enforced before calls using concurrency-safe reservations. Scoped step guards provide independent ceilings and advisory headroom while preserving existing aggregate-only behavior when the new options are not configured.

## Changes

- Add optional aggregate token ceilings and token spend tracking.
- Add explicit per-step USD/token budget scopes.
- Add concurrency-safe multidimensional reservations and settlement.
- Add `TokenBudgetExceeded` with aggregate and step scope reporting.
- Extend budget advisories with aggregate token utilization and per-step headroom.
- Count all metered LLM token buckets while keeping paid tools USD-only.
- Extend streaming enforcement to stop on token or USD ceilings.
- Add request-sized token estimates for LiteLLM and LangChain.
- Make LangChain reservations concurrency-safe using callback `run_id` values.
- Add scoped-guard support to affected adapters and TypeScript middleware.
- Correct Pipecat documentation to clarify that its post-LLM processor stops downstream work but cannot prevent the current provider charge.
- Add Python/TypeScript parity tests, documentation, and a no-network step-budget example.
- Bump Python to `0.12.0` and npm to `0.9.0`.

## Testing

- [x] `pytest` passes (Python changes) — 286 passed, 1 skipped
- [x] `ruff check .` passes and `ruff format --check` is clean for all touched Python files
- [x] `npm test` and `npm run typecheck` pass in `js/` — 105 tests passed
- [x] `npm run build` passes in `js/`
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)
- [x] `git diff --check` passes

## Related issues

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aggregate token ceilings alongside existing USD limits, with step-scoped budgeting and expanded advisory headroom (including near-limit signals).
  * Introduced `TokenBudgetExceeded` and identity-validated reservation handles, including step-scope error reporting.
* **Bug Fixes**
  * Token-budget violations are terminal and, where supported, block before provider execution.
  * Improved strict reservation ownership and concurrency-safe lifecycle handling.
* **Documentation**
  * Expanded token-budgeting guides across README materials and adapters; added a step-budget example and coding conventions.
* **Tests**
  * Added extensive coverage for token ceilings, step scoping, handle integrity, streaming behavior, and adapter enforcement semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->