### PR TITLE
feat: token ceilings + per-step budgets (#46) — minimal alternative to #58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,11 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
     now also flips on a near token ceiling or step cap.
   - `TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry
     treats a token block as terminal with no extra wiring.
-  - **Backward compatible:** with no `token_limit` and no `step()`, behaviour is
-    byte-for-byte unchanged — including `reserve()` still returning a plain
-    `float` / `number`. A `BudgetReservation` handle is returned only when a token
-    ceiling or an active step is involved.
+  - **Backward compatible:** USD enforcement is unchanged with no `token_limit`
+    and no `step()`, and `reserve()` still returns a plain `float` / `number`. A
+    `BudgetReservation` handle is returned only when tokens are actually reserved
+    or a step is active. `advisory()` additionally gains the token/step fields
+    above — additive, and `None` / `null` when their dimension is unused.
 - **`advisory()` exposes `expected_cost` + `est_calls_remaining`** (`expectedCost`
   / `estCallsRemaining` in TS, issue #49): the guard's own next-call estimate and
   how many more calls the remaining budget buys, so a planner can see call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,33 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.11.0 / js 0.8.0
+## Unreleased — py 0.12.0 / js 0.9.0
 
 ### Added (py + js)
 
+- **Token ceilings + per-step budgets** (issue #46) — a **minimal alternative to
+  PR #58** (~1.1k LOC vs 4.1k). Adds a second dimension (tokens) on the existing
+  enforcement choke point plus a step scope, not a new reservation system:
+  - `BudgetGuard(..., token_limit=N)` / `{ tokenLimit: N }` — an aggregate token
+    ceiling. `check` / `reserve` take `estimated_tokens` / `{ estimatedTokens }`
+    to pre-emptively block; a cross raises the new `TokenBudgetExceeded`
+    (`scope="aggregate"`). Tokens accrue for free from the counts `settle` /
+    `record` already receive.
+  - `guard.step(max_usd=…, max_tokens=…)` — a per-step cap for a **sequential**
+    agent loop. Python is a context manager (`with guard.step(...) as g:`, `g` is
+    the guard); TS is a callback (`guard.step({ maxTokens }, (g) => …)`). Both
+    yield the SAME guard, so adapters are untouched. A per-step block raises
+    `BudgetExceeded` (USD) / `TokenBudgetExceeded` (`scope="step"`) even when the
+    aggregate budget has room.
+  - `advisory()` gains `token_used_bps` / `remaining_tokens` and per-step
+    `step_remaining_usd` / `step_remaining_tokens` (camelCase in TS); `near_limit`
+    now also flips on a near token ceiling or step cap.
+  - `TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry
+    treats a token block as terminal with no extra wiring.
+  - **Backward compatible:** with no `token_limit` and no `step()`, behaviour is
+    byte-for-byte unchanged — including `reserve()` still returning a plain
+    `float` / `number`. A `BudgetReservation` handle is returned only when a token
+    ceiling or an active step is involved.
 - **`advisory()` exposes `expected_cost` + `est_calls_remaining`** (`expectedCost`
   / `estCallsRemaining` in TS, issue #49): the guard's own next-call estimate and
   how many more calls the remaining budget buys, so a planner can see call

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ is no tool cost-map); every tool call lands in `spend_log` as a
 ## Token ceilings and per-step budgets
 
 Dollars aren't the only runaway. A token ceiling caps *total recorded token
-usage — prompt and completion combined* regardless of price, and a **per-step**
-cap keeps one step of a sequential loop from starving the rest even when the
-global budget has room.
+usage — every bucket the guard counts: prompt, completion, and cache* regardless
+of price, and a **per-step** cap keeps one step of a sequential loop from
+starving the rest even when the global budget has room.
 Both ride on the same reserve/settle machinery — they're a second dimension, not
 a second guard:
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ is no tool cost-map); every tool call lands in `spend_log` as a
 
 ## Token ceilings and per-step budgets
 
-Dollars aren't the only runaway. A token ceiling caps *how much the agent
-generates* regardless of price, and a **per-step** cap keeps one step of a
-sequential loop from starving the rest even when the global budget has room.
+Dollars aren't the only runaway. A token ceiling caps *total recorded token
+usage — prompt and completion combined* regardless of price, and a **per-step**
+cap keeps one step of a sequential loop from starving the rest even when the
+global budget has room.
 Both ride on the same reserve/settle machinery — they're a second dimension, not
 a second guard:
 
@@ -281,15 +282,17 @@ with guard.step(max_tokens=5_000) as g:  # g IS guard — adapters pass it throu
 
 adv = guard.advisory()
 adv.token_used_bps        # aggregate token utilization (None if no token_limit)
-adv.remaining_tokens      # tokens left before the ceiling
-adv.step_remaining_tokens # headroom in the active step (None when no step)
+adv.remaining_tokens      # tokens left before the ceiling (None if no token_limit)
+adv.step_remaining_tokens # active step's headroom (None if no step, or its token cap is unset)
 ```
 
 `TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry treats a
-token block as terminal automatically. With no `token_limit` and no `step()`,
-the guard is byte-for-byte the USD-only guard — `reserve()` still returns a plain
-`float`; a `BudgetReservation` handle appears only when tokens or a step are in
-play. In TS the step is a callback and fields are camelCase:
+token block as terminal automatically. With no `token_limit` and no `step()`, USD
+enforcement is unchanged and `reserve()` still returns a plain `float` — a
+`BudgetReservation` handle appears only when tokens are actually reserved or a
+step is active. (`advisory()` gains the token/step fields shown above; they're
+additive and `None` when their dimension is unused.) In TS the step is a callback
+and fields are camelCase:
 
 ```ts
 const guard = new BudgetGuard(100, { tokenLimit: 20_000 });

--- a/README.md
+++ b/README.md
@@ -257,6 +257,52 @@ is no tool cost-map); every tool call lands in `spend_log` as a
 `kind: "tool"` event. Same API in TS (`reserveTool`/`settleTool`/`recordTool`/
 `toolCosts`). See [`examples/tool_budget.py`](examples/tool_budget.py).
 
+## Token ceilings and per-step budgets
+
+Dollars aren't the only runaway. A token ceiling caps *how much the agent
+generates* regardless of price, and a **per-step** cap keeps one step of a
+sequential loop from starving the rest even when the global budget has room.
+Both ride on the same reserve/settle machinery — they're a second dimension, not
+a second guard:
+
+```python
+from floe_guard import BudgetGuard, TokenBudgetExceeded
+
+# aggregate token ceiling alongside the USD ceiling
+guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
+
+guard.check(estimated_tokens=1_200)      # raises TokenBudgetExceeded if it'd cross
+guard.record("gpt-4o", 800, 400)         # tokens accrue for free from the counts
+
+# a per-step cap for one step of a sequential loop
+with guard.step(max_tokens=5_000) as g:  # g IS guard — adapters pass it through
+    g.record("gpt-4o", 3_000, 1_500)
+    g.check(estimated_tokens=1_000)       # 4_500 + 1_000 > 5_000 → scope="step"
+
+adv = guard.advisory()
+adv.token_used_bps        # aggregate token utilization (None if no token_limit)
+adv.remaining_tokens      # tokens left before the ceiling
+adv.step_remaining_tokens # headroom in the active step (None when no step)
+```
+
+`TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry treats a
+token block as terminal automatically. With no `token_limit` and no `step()`,
+the guard is byte-for-byte the USD-only guard — `reserve()` still returns a plain
+`float`; a `BudgetReservation` handle appears only when tokens or a step are in
+play. In TS the step is a callback and fields are camelCase:
+
+```ts
+const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+guard.check(undefined, { estimatedTokens: 1_200 });
+guard.step({ maxTokens: 5_000 }, (g) => {
+  g.record("gpt-4o", 3_000, 1_500);
+  g.check(undefined, { estimatedTokens: 1_000 }); // throws TokenBudgetExceeded
+});
+guard.advisory().stepRemainingTokens;
+```
+
+See [`examples/step_budget.py`](examples/step_budget.py) (no network).
+
 ## LatencyBudget — deadlines, the same way
 
 Money isn't the only budget an agent burns. `LatencyBudget` is `BudgetGuard`'s

--- a/examples/step_budget.py
+++ b/examples/step_budget.py
@@ -1,0 +1,56 @@
+"""Per-step token budgets for a sequential agent loop (issue #46).
+
+Run with:
+
+    python examples/step_budget.py
+
+No API key, no network. A three-step research agent runs under a global token
+ceiling, and each step also gets its own per-step token cap. When a step tries
+to spend past its cap, the guard hard-stops that call with a
+``TokenBudgetExceeded`` (scope="step") — even though the global budget still has
+room — so one runaway step can't starve the rest of the loop.
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetGuard, TokenBudgetExceeded
+
+MODEL = "gpt-4o"
+
+
+def main() -> None:
+    # Global ceiling: $100 (ample) and 20_000 tokens across the whole run.
+    guard = BudgetGuard(limit_usd=100.0, token_limit=20_000, near_limit_bps=8000)
+
+    # Step 1 — planning: a tight 2_000-token cap.
+    with guard.step(max_tokens=2_000) as g:
+        g.check(estimated_tokens=1_200)
+        g.record(MODEL, 800, 400)  # 1_200 tokens into the step
+        adv = g.advisory()
+        print(
+            f"step 1 (plan): used {adv.step_remaining_tokens} tokens of headroom left, "
+            f"near_limit={adv.near_limit}"
+        )
+
+    # Step 2 — retrieval: a 5_000-token cap, and a call that would blow it.
+    try:
+        with guard.step(max_tokens=5_000) as g:
+            g.record(MODEL, 3_000, 1_500)  # 4_500 into the step
+            g.check(estimated_tokens=1_000)  # 4_500 + 1_000 > 5_000 → blocked
+            print("step 2: this line should not print")
+    except TokenBudgetExceeded as exc:
+        print(f"step 2 (retrieve): hard-stopped at the step cap — {exc} (scope={exc.scope})")
+
+    # The global budget is untouched by the step block: the loop keeps going.
+    print(f"global tokens spent so far: {guard.spent_tokens} / {guard.token_limit}")
+
+    # Step 3 — synthesis: fits comfortably.
+    with guard.step(max_tokens=3_000) as g:
+        g.record(MODEL, 1_000, 800)
+        print(f"step 3 (synthesize): done, {g.advisory().step_remaining_tokens} step tokens left")
+
+    print(f"run complete — {guard.spent_tokens} total tokens across all steps")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/step_budget.py
+++ b/examples/step_budget.py
@@ -41,7 +41,9 @@ def main() -> None:
     except TokenBudgetExceeded as exc:
         print(f"step 2 (retrieve): hard-stopped at the step cap — {exc} (scope={exc.scope})")
 
-    # The global budget is untouched by the step block: the loop keeps going.
+    # The blocked call consumed no tokens, but Step 2's already-recorded 4,500
+    # tokens still count against the global ceiling — the step cap stopped the
+    # overshoot, not the run, so the loop keeps going.
     print(f"global tokens spent so far: {guard.spent_tokens} / {guard.token_limit}")
 
     # Step 3 — synthesis: fits comfortably.

--- a/js/README.md
+++ b/js/README.md
@@ -81,9 +81,10 @@ guard.toolCosts; // { "apollo.people_lookup": 0.42, "exa.search": 0.11 }
 
 ## Token ceilings and per-step budgets
 
-Cap *total token usage — prompt and completion combined* (a token ceiling) and
-keep one step of a sequential loop from starving the rest (a per-step cap) — a
-second dimension on the same reserve/settle machinery, not a second guard:
+Cap *total token usage — every bucket the guard counts: prompt, completion, and
+cache* (a token ceiling) and keep one step of a sequential loop from starving the
+rest (a per-step cap) — a second dimension on the same reserve/settle machinery,
+not a second guard:
 
 ```ts
 import { BudgetGuard, TokenBudgetExceeded } from "floe-guard";

--- a/js/README.md
+++ b/js/README.md
@@ -81,9 +81,9 @@ guard.toolCosts; // { "apollo.people_lookup": 0.42, "exa.search": 0.11 }
 
 ## Token ceilings and per-step budgets
 
-Cap *how much the agent generates* (a token ceiling) and keep one step of a
-sequential loop from starving the rest (a per-step cap) — a second dimension on
-the same reserve/settle machinery, not a second guard:
+Cap *total token usage — prompt and completion combined* (a token ceiling) and
+keep one step of a sequential loop from starving the rest (a per-step cap) — a
+second dimension on the same reserve/settle machinery, not a second guard:
 
 ```ts
 import { BudgetGuard, TokenBudgetExceeded } from "floe-guard";
@@ -101,15 +101,16 @@ guard.step({ maxTokens: 5_000 }, (g) => {
 
 const adv = guard.advisory();
 adv.tokenUsedBps; // aggregate token utilization (null if no tokenLimit)
-adv.remainingTokens; // tokens left before the ceiling
-adv.stepRemainingTokens; // headroom in the active step (null when no step)
+adv.remainingTokens; // tokens left before the ceiling (null if no tokenLimit)
+adv.stepRemainingTokens; // active step's headroom (null if no step, or its token cap is unset)
 ```
 
 `TokenBudgetExceeded` extends `BudgetExceeded`, so budget-aware retry treats a
-token block as terminal automatically. With no `tokenLimit` and no `step()` the
-guard is byte-for-byte the USD-only guard — `reserve()` still returns a plain
-`number`; a `BudgetReservation` handle appears only when tokens or a step are in
-play.
+token block as terminal automatically. With no `tokenLimit` and no `step()`, USD
+enforcement is unchanged and `reserve()` still returns a plain `number` — a
+`BudgetReservation` handle appears only when tokens are actually reserved or a
+step is active. (`advisory()` gains the token/step fields above; additive and
+`null` when their dimension is unused.)
 
 ## Per-call spend log
 

--- a/js/README.md
+++ b/js/README.md
@@ -79,6 +79,38 @@ guard.recordTool("exa.search", 0.004); // post-hoc, for metered APIs
 guard.toolCosts; // { "apollo.people_lookup": 0.42, "exa.search": 0.11 }
 ```
 
+## Token ceilings and per-step budgets
+
+Cap *how much the agent generates* (a token ceiling) and keep one step of a
+sequential loop from starving the rest (a per-step cap) — a second dimension on
+the same reserve/settle machinery, not a second guard:
+
+```ts
+import { BudgetGuard, TokenBudgetExceeded } from "floe-guard";
+
+// aggregate token ceiling alongside the USD one
+const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+guard.check(undefined, { estimatedTokens: 1_200 }); // throws TokenBudgetExceeded if it'd cross
+guard.record("gpt-4o", 800, 400); // tokens accrue for free from the counts
+
+// a per-step cap for one step of a sequential loop (callback — g IS guard)
+guard.step({ maxTokens: 5_000 }, (g) => {
+  g.record("gpt-4o", 3_000, 1_500);
+  g.check(undefined, { estimatedTokens: 1_000 }); // 4_500 + 1_000 > 5_000 → scope "step"
+});
+
+const adv = guard.advisory();
+adv.tokenUsedBps; // aggregate token utilization (null if no tokenLimit)
+adv.remainingTokens; // tokens left before the ceiling
+adv.stepRemainingTokens; // headroom in the active step (null when no step)
+```
+
+`TokenBudgetExceeded` extends `BudgetExceeded`, so budget-aware retry treats a
+token block as terminal automatically. With no `tokenLimit` and no `step()` the
+guard is byte-for-byte the USD-only guard — `reserve()` still returns a plain
+`number`; a `BudgetReservation` handle appears only when tokens or a step are in
+play.
+
 ## Per-call spend log
 
 The guard keeps a typed, in-memory ledger of everything it priced: each

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -38,6 +38,38 @@ export class BudgetExceeded extends FloeGuardError {
 }
 
 /**
+ * Thrown before a call that would cross a token ceiling (aggregate or step).
+ *
+ * The token twin of {@link BudgetExceeded} — it extends it so the same retry
+ * logic that treats a USD block as terminal (`!(error instanceof
+ * BudgetExceeded)`) treats a token block as terminal too, with no extra wiring.
+ * `spentUsd` / `limitUsd` are inherited but not meaningful here; the token
+ * fields are the payload.
+ *
+ * `scope` is `"aggregate"` (the guard-wide `tokenLimit`) or `"step"` (the
+ * innermost active {@link BudgetGuard.step} cap).
+ */
+export class TokenBudgetExceeded extends BudgetExceeded {
+  readonly spentTokens: number;
+  readonly limitTokens: number;
+  readonly scope: "aggregate" | "step";
+
+  constructor(spentTokens: number, limitTokens: number, scope: "aggregate" | "step") {
+    // BudgetExceeded's message is dollar-shaped; pass 0/0 for the inherited
+    // spentUsd/limitUsd (a token block spent no tracked USD), then overwrite
+    // the message with the token-shaped one.
+    super(0, 0);
+    this.message =
+      `TOKEN BUDGET EXCEEDED — call blocked (${scope}: ${spentTokens} of ` +
+      `${limitTokens} token ceiling)`;
+    this.name = "TokenBudgetExceeded";
+    this.spentTokens = spentTokens;
+    this.limitTokens = limitTokens;
+    this.scope = scope;
+  }
+}
+
+/**
  * Thrown when a model cannot be priced and the guard is fail-closed.
  *
  * We refuse rather than silently accrue $0 — "we cannot cap what we cannot price".

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -27,9 +27,12 @@ export class BudgetExceeded extends FloeGuardError {
   readonly spentUsd: number;
   readonly limitUsd: number;
 
-  constructor(spentUsd: number, limitUsd: number) {
+  constructor(spentUsd: number, limitUsd: number, message?: string) {
+    // Subclasses (the token twin) pass their own message through so they don't
+    // have to reassign `this.message` after super().
     super(
-      `BUDGET EXCEEDED — call blocked (spent $${spentUsd.toFixed(6)} of $${limitUsd.toFixed(6)} ceiling)`,
+      message ??
+        `BUDGET EXCEEDED — call blocked (spent $${spentUsd.toFixed(6)} of $${limitUsd.toFixed(6)} ceiling)`,
     );
     this.name = "BudgetExceeded";
     this.spentUsd = spentUsd;
@@ -55,13 +58,15 @@ export class TokenBudgetExceeded extends BudgetExceeded {
   readonly scope: "aggregate" | "step";
 
   constructor(spentTokens: number, limitTokens: number, scope: "aggregate" | "step") {
-    // BudgetExceeded's message is dollar-shaped; pass 0/0 for the inherited
-    // spentUsd/limitUsd (a token block spent no tracked USD), then overwrite
-    // the message with the token-shaped one.
-    super(0, 0);
-    this.message =
+    // Pass the token-shaped message through super (BudgetExceeded's default is
+    // dollar-shaped); 0/0 for the inherited spentUsd/limitUsd — a token block
+    // spent no tracked USD.
+    super(
+      0,
+      0,
       `TOKEN BUDGET EXCEEDED — call blocked (${scope}: ${spentTokens} of ` +
-      `${limitTokens} token ceiling)`;
+        `${limitTokens} token ceiling)`,
+    );
     this.name = "TokenBudgetExceeded";
     this.spentTokens = spentTokens;
     this.limitTokens = limitTokens;

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -294,6 +294,7 @@ export class BudgetGuard {
       );
     }
     const estimate = Math.max(0, rawEstimate);
+    this.validateTokenEstimate(options.estimatedTokens);
     const tokens = Math.max(0, options.estimatedTokens ?? 0);
     const blocked = this.blockingCross(estimate, tokens);
     if (blocked !== null) this.raiseBlock(blocked);
@@ -319,6 +320,10 @@ export class BudgetGuard {
       );
     }
     const estimate = Math.max(0, rawEstimate);
+    // Reject a fractional/NaN/Infinity token estimate BEFORE mutating
+    // reservedTokens/step holds — a NaN would fail-open the integer token
+    // comparisons and corrupt the tally. A negative int is clamped by Math.max.
+    this.validateTokenEstimate(options.estimatedTokens);
     const tokens = Math.max(0, options.estimatedTokens ?? 0);
     const blocked = this.blockingCross(estimate, tokens);
     if (blocked !== null) this.raiseBlock(blocked);
@@ -656,6 +661,19 @@ export class BudgetGuard {
    * number and a {@link BudgetReservation}'s `usd`/`tokens` fields — so a bad
    * hand-rolled handle can't corrupt the in-flight tally.
    */
+  /**
+   * Validate a caller-supplied token estimate. Rejects a fraction, NaN,
+   * Infinity, or boolean (via `Number.isInteger`) so it can't disable the
+   * integer token hard-stops or corrupt the in-flight token tally. `undefined`
+   * (the default) is fine; a negative integer is clamped by `Math.max(0, ...)`,
+   * matching the lenient USD estimate. Mirrors Python's `_validate_token_estimate`.
+   */
+  private validateTokenEstimate(estimatedTokens: number | undefined): void {
+    if (estimatedTokens !== undefined && !Number.isInteger(estimatedTokens)) {
+      throw new RangeError(`estimatedTokens must be an integer, got ${estimatedTokens}`);
+    }
+  }
+
   private reservedUsdOf(reserved: ReservationHandle): number {
     if (isReservation(reserved)) {
       // A BudgetReservation is public (re-exported), so validate its fields here

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -106,7 +106,9 @@ export interface BudgetGuardOptions {
   /**
    * Optional callback invoked with `(spentUsd, limitUsd)` right before
    * {@link BudgetExceeded} is thrown. Defaults to printing the
-   * `BUDGET EXCEEDED — call blocked` banner to stderr.
+   * `BUDGET EXCEEDED — call blocked` banner to stderr. Fires on **USD** ceiling
+   * crossings only; a token-ceiling block ({@link TokenBudgetExceeded}, aggregate
+   * or step) is thrown without invoking it, since the callback is dollar-shaped.
    */
   onBlock?: (spentUsd: number, limitUsd: number) => void;
   /**

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -23,7 +23,7 @@
  * same epsilon handling, same fail-closed default.
  */
 
-import { BudgetExceeded, UnpriceableModelError } from "./errors.js";
+import { BudgetExceeded, TokenBudgetExceeded, UnpriceableModelError } from "./errors.js";
 import {
   type ManualPrice,
   priceTokens,
@@ -32,6 +32,39 @@ import {
 
 /** Tolerance for float rounding in the running spend total (well below $0.000001). */
 const EPS = 1e-12;
+
+/**
+ * A two-dimensional in-flight hold (USD + tokens) returned by
+ * {@link BudgetGuard.reserve} when a token ceiling or an active
+ * {@link BudgetGuard.step} is involved. A dumb value handle — pass it straight
+ * back to {@link BudgetGuard.settle} / {@link BudgetGuard.release}. When neither
+ * tokens nor a step are involved, `reserve` returns a plain `number` instead
+ * (byte-for-byte the old behaviour), so {@link ReservationHandle} is the union.
+ */
+export interface BudgetReservation {
+  readonly usd: number;
+  readonly tokens: number;
+}
+
+/**
+ * A plain `number` when USD-only (backward compatible); a
+ * {@link BudgetReservation} when a token ceiling or an active step is in play.
+ */
+export type ReservationHandle = number | BudgetReservation;
+
+function isReservation(h: ReservationHandle): h is BudgetReservation {
+  return typeof h === "object";
+}
+
+/** One scope on the step stack (see {@link BudgetGuard.step}). Mutable. */
+interface StepState {
+  readonly maxUsd: number | null;
+  readonly maxTokens: number | null;
+  spentUsd: number;
+  spentTokens: number;
+  reservedUsd: number;
+  reservedTokens: number;
+}
 
 /**
  * One priced spend event in the guard's per-call ledger.
@@ -88,6 +121,11 @@ export interface BudgetGuardOptions {
    * unaffected. Default: keep every event.
    */
   maxLogEvents?: number;
+  /**
+   * Aggregate token ceiling. `null`/undefined disables the token dimension
+   * entirely (a pure USD guard, unchanged). `0` blocks the first token.
+   */
+  tokenLimit?: number;
 }
 
 /**
@@ -129,6 +167,19 @@ export interface BudgetAdvisory {
    * expectedCost; `advisory()` always sets it.
    */
   estCallsRemaining?: number | null;
+  /**
+   * Aggregate token utilization in basis points (0..10000), mirroring usedBps
+   * for the token ceiling. null when no `tokenLimit` is set (nothing to signal).
+   */
+  tokenUsedBps?: number | null;
+  /** Tokens left before the aggregate token ceiling. null when no `tokenLimit`. */
+  remainingTokens?: number | null;
+  /**
+   * Per-step headroom for the innermost active step — present (non-null) ONLY
+   * while a step() is active AND that dimension is capped. null otherwise.
+   */
+  stepRemainingUsd?: number | null;
+  stepRemainingTokens?: number | null;
 }
 
 export class BudgetGuard {
@@ -137,6 +188,14 @@ export class BudgetGuard {
   priceOverrides?: Record<string, ManualPrice>;
   failClosed: boolean;
   nearLimitBps: number;
+  /** Aggregate token ceiling, or null when the token dimension is disabled. */
+  readonly tokenLimit: number | null;
+  /** Aggregate tokens accrued (prompt + completion + cache buckets). */
+  spentTokens = 0;
+  /** Tokens held in-flight — the token twin of `reserved`. */
+  private reservedTokens = 0;
+  /** Step stack: innermost step is last. Empty when no step() is active. */
+  private readonly steps: StepState[] = [];
 
   private readonly onBlock: (spentUsd: number, limitUsd: number) => void;
   /**
@@ -187,7 +246,16 @@ export class BudgetGuard {
         `maxLogEvents must be a non-negative integer, got ${options.maxLogEvents}`,
       );
     }
+    if (
+      options.tokenLimit !== undefined &&
+      (!Number.isInteger(options.tokenLimit) || options.tokenLimit < 0)
+    ) {
+      throw new RangeError(
+        `tokenLimit must be a non-negative integer, got ${options.tokenLimit}`,
+      );
+    }
     this.limitUsd = limitUsd;
+    this.tokenLimit = options.tokenLimit ?? null;
     this.maxLogEvents = options.maxLogEvents;
     this.priceOverrides = options.priceOverrides;
     this.failClosed = options.failClosed ?? true;
@@ -208,7 +276,7 @@ export class BudgetGuard {
    * Note: `check` is a non-binding peek. For parallel calls, use `reserve()` /
    * `settle()`, which hold the estimate across the await.
    */
-  check(estimatedNextCost?: number): void {
+  check(estimatedNextCost?: number, options: { estimatedTokens?: number } = {}): void {
     const rawEstimate =
       estimatedNextCost === undefined ? this.defaultEstimate() : estimatedNextCost;
     if (!Number.isFinite(rawEstimate)) {
@@ -219,11 +287,9 @@ export class BudgetGuard {
       );
     }
     const estimate = Math.max(0, rawEstimate);
-    const committed = this.spentUsd + this.reserved;
-    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
-      this.onBlock(this.spentUsd, this.limitUsd);
-      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
-    }
+    const tokens = Math.max(0, options.estimatedTokens ?? 0);
+    const blocked = this.blockingCross(estimate, tokens);
+    if (blocked !== null) this.raiseBlock(blocked);
   }
 
   /**
@@ -237,7 +303,7 @@ export class BudgetGuard {
    * `estimatedCost` defaults to the costlier of the last LLM call and the last
    * tool call.
    */
-  reserve(estimatedCost?: number): number {
+  reserve(estimatedCost?: number, options: { estimatedTokens?: number } = {}): ReservationHandle {
     const rawEstimate = estimatedCost === undefined ? this.defaultEstimate() : estimatedCost;
     if (!Number.isFinite(rawEstimate)) {
       // NaN would poison this.reserved and fail-open the ceiling — reject it.
@@ -246,13 +312,20 @@ export class BudgetGuard {
       );
     }
     const estimate = Math.max(0, rawEstimate);
-    const committed = this.spentUsd + this.reserved;
-    if (committed > this.limitUsd - EPS || committed + estimate > this.limitUsd + EPS) {
-      this.onBlock(this.spentUsd, this.limitUsd);
-      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
-    }
+    const tokens = Math.max(0, options.estimatedTokens ?? 0);
+    const blocked = this.blockingCross(estimate, tokens);
+    if (blocked !== null) this.raiseBlock(blocked);
     this.reserved += estimate;
-    return estimate;
+    this.reservedTokens += tokens;
+    const step = this.steps.length ? this.steps[this.steps.length - 1] : null;
+    if (step !== null) {
+      step.reservedUsd += estimate;
+      step.reservedTokens += tokens;
+    }
+    // Plain number only when nothing token- or step-shaped is in play, so
+    // pre-existing USD-only callers get byte-for-byte the old handle.
+    if (tokens === 0 && step === null) return estimate;
+    return { usd: estimate, tokens };
   }
 
   /**
@@ -268,14 +341,13 @@ export class BudgetGuard {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { reserved?: number; price?: ManualPrice; label?: string } = {},
+    options: { reserved?: ReservationHandle; price?: ManualPrice; label?: string } = {},
   ): number {
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt this.reserved and break the ceiling for
     // OTHER in-flight calls (negative → phantom hold; Infinity → clears all holds).
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
-    }
+    // reservedUsdOf validates a raw number; a BudgetReservation is trusted.
+    const reservedUsd = this.reservedUsdOf(reserved);
     let overrides = this.priceOverrides;
     if (options.price !== undefined) {
       overrides = { ...(overrides ?? {}), [model]: options.price };
@@ -311,7 +383,12 @@ export class BudgetGuard {
     if (reserved) {
       this.consumeReservation(reserved);
     }
+    // Tokens accrued match what priceTokens bills (prompt + completion; negative
+    // counts clamp to 0, as in pricing).
+    const accruedTokens = Math.max(0, promptTokens) + Math.max(0, completionTokens);
     this.spentUsd += cost;
+    this.spentTokens += accruedTokens;
+    this.accrueStep(cost, accruedTokens);
     // Clamp a sub-epsilon float overshoot back to the limit so the running total
     // never reports as having crossed the ceiling by a rounding artifact.
     if (this.spentUsd - this.limitUsd > 0 && this.spentUsd - this.limitUsd < EPS) {
@@ -327,8 +404,9 @@ export class BudgetGuard {
       costUsd: cost,
       ...(options.label !== undefined ? { label: options.label } : {}),
       // 0 means "no reservation" (the plain record() path) — omit rather than
-      // log a meaningless zero.
-      ...(reserved ? { reserved } : {}),
+      // log a meaningless zero. Log the USD amount so the ledger schema stays
+      // number-shaped even for a BudgetReservation.
+      ...(reservedUsd ? { reserved: reservedUsd } : {}),
     });
     return cost;
   }
@@ -370,7 +448,7 @@ export class BudgetGuard {
    * worth falling back to. Pass the returned handle to
    * {@link BudgetGuard.settleTool}, or {@link BudgetGuard.release} on failure.
    */
-  reserveTool(estimatedCost: number): number {
+  reserveTool(estimatedCost: number): ReservationHandle {
     if (estimatedCost === undefined) {
       // reserve(undefined) would silently fall back to the last-cost prediction
       // (0 on a fresh guard) — an unguarded tool call. A missing price must
@@ -404,21 +482,22 @@ export class BudgetGuard {
   settleTool(
     tool: string,
     costUsd: number,
-    options: { reserved?: number; label?: string } = {},
+    options: { reserved?: ReservationHandle; label?: string } = {},
   ): number {
     if (!Number.isFinite(costUsd) || costUsd < 0) {
       throw new RangeError(`costUsd must be a finite, non-negative number, got ${costUsd}`);
     }
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt the in-flight tally and break the
-    // ceiling for OTHER calls — same contract as settle().
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
-    }
+    // ceiling for OTHER calls — same contract as settle(). reservedUsdOf
+    // validates a raw number; a BudgetReservation is trusted.
+    const reservedUsd = this.reservedUsdOf(reserved);
     if (reserved) {
       this.consumeReservation(reserved);
     }
     this.spentUsd += costUsd;
+    // A paid tool spends the step's USD too (no tokens to price).
+    this.accrueStep(costUsd, 0);
     // Same sub-epsilon clamp as settle(): never report a rounding-artifact
     // crossing of the ceiling.
     if (this.spentUsd - this.limitUsd > 0 && this.spentUsd - this.limitUsd < EPS) {
@@ -434,7 +513,7 @@ export class BudgetGuard {
       completionTokens: null,
       costUsd,
       ...(options.label !== undefined ? { label: options.label } : {}),
-      ...(reserved ? { reserved } : {}),
+      ...(reservedUsd ? { reserved: reservedUsd } : {}),
     });
     return costUsd;
   }
@@ -455,12 +534,11 @@ export class BudgetGuard {
    * Drop an in-flight reservation without recording spend (e.g. the call failed
    * before producing usage). Safe to call with `0`.
    */
-  release(reserved: number): void {
+  release(reserved: ReservationHandle): void {
     // Validate before the zero-check so a NaN handle throws instead of being
     // silently dropped (a leak); a bad handle corrupts the in-flight tally.
-    if (!Number.isFinite(reserved) || reserved < 0) {
-      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
-    }
+    // reservedUsdOf validates a raw number; a BudgetReservation is trusted.
+    this.reservedUsdOf(reserved);
     if (!reserved) return;
     this.consumeReservation(reserved);
   }
@@ -539,14 +617,160 @@ export class BudgetGuard {
    * undetectable without per-handle tracking and remains the caller's
    * responsibility.
    */
-  private consumeReservation(reserved: number): void {
-    if (reserved > this.reserved + EPS) {
+  private consumeReservation(reserved: ReservationHandle): void {
+    const usd = isReservation(reserved) ? reserved.usd : reserved;
+    const tokens = isReservation(reserved) ? reserved.tokens : 0;
+    if (usd > this.reserved + EPS) {
       throw new RangeError(
-        `reserved handle (${reserved}) exceeds total in-flight reservations ` +
+        `reserved handle (${usd}) exceeds total in-flight reservations ` +
           `(${this.reserved}) — a handle must come from a matching reserve()`,
       );
     }
-    this.reserved = Math.max(0, this.reserved - reserved);
+    if (tokens > this.reservedTokens) {
+      throw new RangeError(
+        `reserved token handle (${tokens}) exceeds total in-flight token ` +
+          `reservations (${this.reservedTokens}) — a handle must come from a matching reserve()`,
+      );
+    }
+    this.reserved = Math.max(0, this.reserved - usd);
+    this.reservedTokens = Math.max(0, this.reservedTokens - tokens);
+    // Drain the innermost active step too (mirrors the aggregate drain). A
+    // handle is drained against whatever step is innermost now — the
+    // sequential-loop contract; concurrent parallel steps are out of scope (#46).
+    const step = this.steps.length ? this.steps[this.steps.length - 1] : null;
+    if (step !== null) {
+      step.reservedUsd = Math.max(0, step.reservedUsd - usd);
+      step.reservedTokens = Math.max(0, step.reservedTokens - tokens);
+    }
+  }
+
+  /**
+   * The USD amount of a handle, validated. A {@link BudgetReservation} is a
+   * trusted value object; a raw number still gets the finite/non-negative guard
+   * so a bad hand-rolled handle can't corrupt the in-flight tally.
+   */
+  private reservedUsdOf(reserved: ReservationHandle): number {
+    if (isReservation(reserved)) return reserved.usd;
+    if (!Number.isFinite(reserved) || reserved < 0) {
+      throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
+    }
+    return reserved;
+  }
+
+  /**
+   * Accrue a settled call into the innermost active step (no-op when none).
+   * Sequential-loop contract: the innermost step owns the call.
+   */
+  private accrueStep(cost: number, tokens: number): void {
+    const step = this.steps.length ? this.steps[this.steps.length - 1] : null;
+    if (step !== null) {
+      step.spentUsd += cost;
+      step.spentTokens += tokens;
+    }
+  }
+
+  /**
+   * The ONE choke point, across two dimensions and two scopes. Returns the first
+   * ceiling that blocks as `[dimension, scope]` — dimension `"usd" | "tokens"`,
+   * scope `"aggregate" | "step"` — or `null` if the call fits everywhere.
+   * Aggregate is checked before step (the guard-wide ceiling is the hard limit).
+   */
+  private blockingCross(
+    estimateUsd: number,
+    estimateTokens: number,
+  ): ["usd" | "tokens", "aggregate" | "step"] | null {
+    // Aggregate USD — same comparison the original check/reserve used.
+    const committed = this.spentUsd + this.reserved;
+    if (committed > this.limitUsd - EPS || committed + estimateUsd > this.limitUsd + EPS) {
+      return ["usd", "aggregate"];
+    }
+    // Aggregate tokens (integers — no epsilon).
+    if (this.tokenLimit !== null) {
+      const committedT = this.spentTokens + this.reservedTokens;
+      if (committedT >= this.tokenLimit || committedT + estimateTokens > this.tokenLimit) {
+        return ["tokens", "aggregate"];
+      }
+    }
+    // Innermost active step's caps (crossing an outer step requires first
+    // crossing the inner one, so the innermost is sufficient).
+    const step = this.steps.length ? this.steps[this.steps.length - 1] : null;
+    if (step !== null) {
+      if (step.maxUsd !== null) {
+        const sCommitted = step.spentUsd + step.reservedUsd;
+        if (sCommitted > step.maxUsd - EPS || sCommitted + estimateUsd > step.maxUsd + EPS) {
+          return ["usd", "step"];
+        }
+      }
+      if (step.maxTokens !== null) {
+        const sCommittedT = step.spentTokens + step.reservedTokens;
+        if (sCommittedT >= step.maxTokens || sCommittedT + estimateTokens > step.maxTokens) {
+          return ["tokens", "step"];
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Notify + throw the right error for a [dimension, scope] block. */
+  private raiseBlock(blocked: ["usd" | "tokens", "aggregate" | "step"]): never {
+    const [dimension, scope] = blocked;
+    if (dimension === "usd") {
+      this.onBlock(this.spentUsd, this.limitUsd);
+      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
+    }
+    let spentT: number;
+    let limitT: number;
+    if (scope === "step") {
+      const step = this.steps[this.steps.length - 1];
+      spentT = step.spentTokens + step.reservedTokens;
+      limitT = step.maxTokens ?? 0;
+    } else {
+      spentT = this.spentTokens + this.reservedTokens;
+      limitT = this.tokenLimit ?? 0;
+    }
+    throw new TokenBudgetExceeded(spentT, limitT, scope);
+  }
+
+  /**
+   * Scope a per-step USD and/or token cap for a **sequential agent loop**.
+   *
+   * Runs `fn` with a step pushed onto the guard's stack; the
+   * enforcement/accrual path honours the innermost active step *on top of* the
+   * aggregate ceilings. A call that would cross the step's `maxUsd` / `maxTokens`
+   * is hard-blocked ({@link BudgetExceeded} / {@link TokenBudgetExceeded} with
+   * `scope: "step"`) even if the aggregate budget has room. `fn` receives the
+   * SAME guard, so no adapter needs to know about steps. The step is popped when
+   * `fn` settles or throws. **Not for concurrent parallel steps on one guard** —
+   * that's out of scope for issue #46; use one guard per parallel branch.
+   */
+  step<T>(
+    options: { maxUsd?: number; maxTokens?: number },
+    fn: (guard: BudgetGuard) => T,
+  ): T {
+    const { maxUsd, maxTokens } = options;
+    if (maxUsd !== undefined && (!Number.isFinite(maxUsd) || maxUsd < 0)) {
+      throw new RangeError(`maxUsd must be a finite, non-negative number, got ${maxUsd}`);
+    }
+    if (maxTokens !== undefined && (!Number.isInteger(maxTokens) || maxTokens < 0)) {
+      throw new RangeError(`maxTokens must be a non-negative integer, got ${maxTokens}`);
+    }
+    const state: StepState = {
+      maxUsd: maxUsd ?? null,
+      maxTokens: maxTokens ?? null,
+      spentUsd: 0,
+      spentTokens: 0,
+      reservedUsd: 0,
+      reservedTokens: 0,
+    };
+    this.steps.push(state);
+    try {
+      return fn(this);
+    } finally {
+      // Pop our own state; splice by identity so an out-of-order exit can't
+      // silently drop someone else's step.
+      const idx = this.steps.lastIndexOf(state);
+      if (idx !== -1) this.steps.splice(idx, 1);
+    }
   }
 
   private appendEvent(event: SpendEvent): void {
@@ -583,8 +807,52 @@ export class BudgetGuard {
     // rationale as usedBps above, and keeps Python int() parity).
     const estCallsRemaining =
       expectedCost > 0 ? Math.floor(remainingUsd / expectedCost + 1e-9) : null;
+    // Aggregate token utilization, mirroring usedBps. null (no signal) when the
+    // token dimension is unset — a pure USD guard's advisory is unchanged.
+    let tokenUsedBps: number | null = null;
+    let remainingTokens: number | null = null;
+    let nearToken = false;
+    if (this.tokenLimit !== null) {
+      tokenUsedBps =
+        this.tokenLimit <= 0
+          ? 10000
+          : Math.max(
+              0,
+              Math.min(10000, Math.floor((this.spentTokens / this.tokenLimit) * 10000 + 1e-9)),
+            );
+      remainingTokens = Math.max(0, this.tokenLimit - this.spentTokens);
+      nearToken = tokenUsedBps >= this.nearLimitBps;
+    }
+    // Innermost active step's headroom + nearness (per dimension, only when
+    // capped). null keeps the fields absent for old readers.
+    const step = this.steps.length ? this.steps[this.steps.length - 1] : null;
+    let stepRemainingUsd: number | null = null;
+    let stepRemainingTokens: number | null = null;
+    let nearStep = false;
+    if (step !== null) {
+      if (step.maxUsd !== null) {
+        stepRemainingUsd = Math.max(0, step.maxUsd - step.spentUsd);
+        if (step.maxUsd <= 0) {
+          nearStep = true;
+        } else {
+          const sBps = Math.floor((step.spentUsd / step.maxUsd) * 10000 + 1e-9);
+          nearStep = nearStep || sBps >= this.nearLimitBps;
+        }
+      }
+      if (step.maxTokens !== null) {
+        stepRemainingTokens = Math.max(0, step.maxTokens - step.spentTokens);
+        if (step.maxTokens <= 0) {
+          nearStep = true;
+        } else {
+          const sTBps = Math.floor((step.spentTokens / step.maxTokens) * 10000 + 1e-9);
+          nearStep = nearStep || sTBps >= this.nearLimitBps;
+        }
+      }
+    }
     return {
-      nearLimit: usedBps >= this.nearLimitBps,
+      // nearLimit now also flips when a token ceiling or the active step is near
+      // its cap, so a router can downshift before ANY hard-stop.
+      nearLimit: usedBps >= this.nearLimitBps || nearToken || nearStep,
       usedBps,
       // Settled budget: limit minus accrued spend, deliberately NOT net of
       // in-flight reservations. Unlike the remainingUsd getter (which subtracts
@@ -596,6 +864,10 @@ export class BudgetGuard {
       scope: "local",
       expectedCost,
       estCallsRemaining,
+      tokenUsedBps,
+      remainingTokens,
+      stepRemainingUsd,
+      stepRemainingTokens,
     };
   }
 }

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -53,7 +53,12 @@ export interface BudgetReservation {
 export type ReservationHandle = number | BudgetReservation;
 
 function isReservation(h: ReservationHandle): h is BudgetReservation {
-  return typeof h === "object";
+  return (
+    typeof h === "object" &&
+    h !== null &&
+    typeof (h as BudgetReservation).usd === "number" &&
+    typeof (h as BudgetReservation).tokens === "number"
+  );
 }
 
 /** One scope on the step stack (see {@link BudgetGuard.step}). Mutable. */
@@ -348,7 +353,7 @@ export class BudgetGuard {
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt this.reserved and break the ceiling for
     // OTHER in-flight calls (negative → phantom hold; Infinity → clears all holds).
-    // reservedUsdOf validates a raw number; a BudgetReservation is trusted.
+    // reservedUsdOf validates the handle (raw number, or a BudgetReservation's fields).
     const reservedUsd = this.reservedUsdOf(reserved);
     let overrides = this.priceOverrides;
     if (options.price !== undefined) {
@@ -492,7 +497,7 @@ export class BudgetGuard {
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt the in-flight tally and break the
     // ceiling for OTHER calls — same contract as settle(). reservedUsdOf
-    // validates a raw number; a BudgetReservation is trusted.
+    // validates the handle (raw number, or a BudgetReservation's fields).
     const reservedUsd = this.reservedUsdOf(reserved);
     if (reserved) {
       this.consumeReservation(reserved);
@@ -539,7 +544,7 @@ export class BudgetGuard {
   release(reserved: ReservationHandle): void {
     // Validate before the zero-check so a NaN handle throws instead of being
     // silently dropped (a leak); a bad handle corrupts the in-flight tally.
-    // reservedUsdOf validates a raw number; a BudgetReservation is trusted.
+    // reservedUsdOf validates the handle (raw number, or a BudgetReservation's fields).
     this.reservedUsdOf(reserved);
     if (!reserved) return;
     this.consumeReservation(reserved);
@@ -647,12 +652,28 @@ export class BudgetGuard {
   }
 
   /**
-   * The USD amount of a handle, validated. A {@link BudgetReservation} is a
-   * trusted value object; a raw number still gets the finite/non-negative guard
-   * so a bad hand-rolled handle can't corrupt the in-flight tally.
+   * The USD amount of a handle, validated. Both shapes are checked — a raw
+   * number and a {@link BudgetReservation}'s `usd`/`tokens` fields — so a bad
+   * hand-rolled handle can't corrupt the in-flight tally.
    */
   private reservedUsdOf(reserved: ReservationHandle): number {
-    if (isReservation(reserved)) return reserved.usd;
+    if (isReservation(reserved)) {
+      // A BudgetReservation is public (re-exported), so validate its fields here
+      // — a hand-rolled { usd: NaN, tokens: -1 } must not slip past into
+      // consumeReservation and corrupt the in-flight tallies. Mirrors Python's
+      // BudgetReservation.__post_init__.
+      if (!Number.isFinite(reserved.usd) || reserved.usd < 0) {
+        throw new RangeError(
+          `reserved.usd must be a finite, non-negative number, got ${reserved.usd}`,
+        );
+      }
+      if (!Number.isInteger(reserved.tokens) || reserved.tokens < 0) {
+        throw new RangeError(
+          `reserved.tokens must be a non-negative integer, got ${reserved.tokens}`,
+        );
+      }
+      return reserved.usd;
+    }
     if (!Number.isFinite(reserved) || reserved < 0) {
       throw new RangeError(`reserved must be a finite, non-negative number, got ${reserved}`);
     }
@@ -765,14 +786,27 @@ export class BudgetGuard {
       reservedTokens: 0,
     };
     this.steps.push(state);
-    try {
-      return fn(this);
-    } finally {
-      // Pop our own state; splice by identity so an out-of-order exit can't
-      // silently drop someone else's step.
+    // Pop our own state; splice by identity so an out-of-order exit can't
+    // silently drop someone else's step.
+    const pop = (): void => {
       const idx = this.steps.lastIndexOf(state);
       if (idx !== -1) this.steps.splice(idx, 1);
+    };
+    let result: T;
+    try {
+      result = fn(this);
+    } catch (err) {
+      pop();
+      throw err;
     }
+    // An async `fn` returns a promise synchronously — popping now would disable
+    // step enforcement across every `await` inside it (the common agent-loop
+    // shape). Keep the step on the stack until the promise settles, then pop.
+    if (result != null && typeof (result as { then?: unknown }).then === "function") {
+      return (result as unknown as Promise<unknown>).finally(pop) as unknown as T;
+    }
+    pop();
+    return result;
   }
 
   private appendEvent(event: SpendEvent): void {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -10,6 +10,8 @@ export {
   BudgetGuard,
   type BudgetGuardOptions,
   type BudgetAdvisory,
+  type BudgetReservation,
+  type ReservationHandle,
   type SpendEvent,
 } from "./guard.js";
 export {
@@ -20,6 +22,7 @@ export {
 export {
   FloeGuardError,
   BudgetExceeded,
+  TokenBudgetExceeded,
   DeadlineExceeded,
   UnpriceableModelError,
 } from "./errors.js";

--- a/js/test/concurrency.test.ts
+++ b/js/test/concurrency.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { BudgetExceeded, BudgetGuard, UnpriceableModelError, budgetGuardMiddleware } from "../src/index.js";
+import { BudgetExceeded, BudgetGuard, type ReservationHandle, UnpriceableModelError, budgetGuardMiddleware } from "../src/index.js";
 
 function fakeModel(modelId: string) {
   return { modelId } as never;
@@ -24,7 +24,7 @@ describe("BudgetGuard — concurrency (issue #18)", () => {
 
     let blocked = 0;
     const agent = async () => {
-      let reserved: number;
+      let reserved: ReservationHandle;
       try {
         reserved = guard.reserve();
       } catch (err) {

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -112,6 +112,29 @@ describe("per-step caps", () => {
     });
     expect(() => guard.settle(MODEL, 400, 300, { reserved: handle })).not.toThrow();
     expect(guard.spentTokens).toBe(700);
+    // The 1_000-token hold must be fully released: 700 spent + 19_300 estimated
+    // == 20_000 fits exactly; a leaked hold would push committed over the ceiling.
+    expect(() => guard.check(0, { estimatedTokens: 19_300 })).not.toThrow();
+  });
+
+  it("keeps the step active across awaits when fn is async", async () => {
+    // A promise-returning fn must not pop the step synchronously — enforcement
+    // has to hold across every await inside it.
+    const guard = new BudgetGuard(100, silent);
+    await guard.step({ maxTokens: 200 }, async (g) => {
+      await Promise.resolve();
+      // Still inside the step here: the per-step cap must still bite.
+      expect(() => g.check(undefined, { estimatedTokens: 500 })).toThrow(TokenBudgetExceeded);
+    });
+    // Popped once the promise settled: no step cap applies now.
+    expect(() => guard.check(undefined, { estimatedTokens: 1_000_000 })).not.toThrow();
+  });
+
+  it("rejects a hand-rolled reservation object with bad fields", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+    // NaN usd / negative tokens must be refused, not silently corrupt the tally.
+    expect(() => guard.release({ usd: NaN, tokens: 0 } as BudgetReservation)).toThrow(RangeError);
+    expect(() => guard.release({ usd: 0, tokens: -1 } as BudgetReservation)).toThrow(RangeError);
   });
 
   it("nested steps: innermost blocks first", () => {

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -102,6 +102,18 @@ describe("per-step caps", () => {
     });
   });
 
+  it("settles a BudgetReservation after its owning step has exited", () => {
+    // A token-aware handle may outlive the step() that made it; settling it once
+    // the step is gone must drain the aggregate hold and accrue, not throw.
+    const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+    let handle!: BudgetReservation;
+    guard.step({ maxTokens: 5_000 }, (g) => {
+      handle = g.reserve(undefined, { estimatedTokens: 1_000 }) as BudgetReservation;
+    });
+    expect(() => guard.settle(MODEL, 400, 300, { reserved: handle })).not.toThrow();
+    expect(guard.spentTokens).toBe(700);
+  });
+
   it("nested steps: innermost blocks first", () => {
     const guard = new BudgetGuard(100, silent);
     guard.step({ maxTokens: 10_000 }, (outer) => {

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -137,6 +137,16 @@ describe("per-step caps", () => {
     expect(() => guard.release({ usd: 0, tokens: -1 } as BudgetReservation)).toThrow(RangeError);
   });
 
+  it("rejects a non-integer or NaN token estimate without leaking a hold", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+    for (const bad of [1.5, NaN, Infinity]) {
+      expect(() => guard.reserve(undefined, { estimatedTokens: bad })).toThrow(RangeError);
+      expect(() => guard.check(undefined, { estimatedTokens: bad })).toThrow(RangeError);
+    }
+    // No phantom hold: a full-ceiling reservation still fits exactly.
+    expect(() => guard.reserve(0, { estimatedTokens: 20_000 })).not.toThrow();
+  });
+
   it("nested steps: innermost blocks first", () => {
     const guard = new BudgetGuard(100, silent);
     guard.step({ maxTokens: 10_000 }, (outer) => {

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for token ceilings and per-step budgets (issue #46) — the TS mirror of
+ * `tests/test_token_step_budgets.py`.
+ *
+ * The feature is a second dimension (tokens) on the existing enforcement choke
+ * point plus a step scope, so these tests also pin the backward-compat contract:
+ * a USD-only guard behaves exactly as before, including `reserve()` still
+ * returning a plain number.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BudgetExceeded,
+  BudgetGuard,
+  TokenBudgetExceeded,
+  type BudgetReservation,
+} from "../src/index.js";
+
+const MODEL = "gpt-4o"; // $2.5e-6/input token, $1e-5/output token
+const silent = { onBlock: () => {} };
+
+describe("aggregate token ceiling", () => {
+  it("hard-blocks when a call would cross the token limit", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 1_000, ...silent });
+    guard.record(MODEL, 400, 200); // 600 tokens accrued
+    try {
+      guard.check(undefined, { estimatedTokens: 500 }); // 600 + 500 > 1000
+      throw new Error("expected TokenBudgetExceeded");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TokenBudgetExceeded);
+      expect((err as TokenBudgetExceeded).scope).toBe("aggregate");
+      expect((err as TokenBudgetExceeded).limitTokens).toBe(1_000);
+    }
+  });
+
+  it("reserve holds tokens in-flight and blocks the overshoot", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 1_000, ...silent });
+    const handle = guard.reserve(0.01, { estimatedTokens: 900 }) as BudgetReservation;
+    expect(handle.tokens).toBe(900);
+    expect(() => guard.reserve(0.01, { estimatedTokens: 200 })).toThrow(TokenBudgetExceeded);
+  });
+
+  it("accrues tokens from prompt + completion", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 10_000 });
+    guard.record(MODEL, 100, 50);
+    expect(guard.spentTokens).toBe(150);
+  });
+
+  it("rejects a non-integer or negative tokenLimit", () => {
+    expect(() => new BudgetGuard(1, { tokenLimit: 1.5 })).toThrow(RangeError);
+    expect(() => new BudgetGuard(1, { tokenLimit: -1 })).toThrow(RangeError);
+  });
+});
+
+describe("per-step caps", () => {
+  it("token cap hard-blocks even with ample aggregate budget", () => {
+    const guard = new BudgetGuard(100, silent);
+    guard.step({ maxTokens: 500 }, (g) => {
+      expect(g).toBe(guard); // callback receives the SAME guard
+      g.record(MODEL, 300, 100); // 400 tokens into the step
+      try {
+        g.check(undefined, { estimatedTokens: 200 }); // 400 + 200 > 500
+        throw new Error("expected TokenBudgetExceeded");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TokenBudgetExceeded);
+        expect((err as TokenBudgetExceeded).scope).toBe("step");
+        expect((err as TokenBudgetExceeded).limitTokens).toBe(500);
+      }
+    });
+  });
+
+  it("USD cap hard-blocks with a plain BudgetExceeded", () => {
+    const guard = new BudgetGuard(100, silent);
+    guard.step({ maxUsd: 0.01 }, (g) => {
+      let caught: unknown;
+      try {
+        g.reserve(0.02);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(BudgetExceeded);
+      expect(caught).not.toBeInstanceOf(TokenBudgetExceeded);
+    });
+  });
+
+  it("frees the step cap on exit", () => {
+    const guard = new BudgetGuard(100, silent);
+    guard.step({ maxTokens: 100 }, (g) => {
+      expect(() => g.check(undefined, { estimatedTokens: 200 })).toThrow(TokenBudgetExceeded);
+    });
+    // Outside the step no token ceiling applies.
+    expect(() => guard.check(undefined, { estimatedTokens: 1_000_000 })).not.toThrow();
+  });
+
+  it("returns a BudgetReservation while a step is active, even USD-only", () => {
+    const guard = new BudgetGuard(100);
+    guard.step({ maxUsd: 1.0 }, (g) => {
+      const handle = g.reserve(0.02);
+      expect(typeof handle).toBe("object");
+      g.settle(MODEL, 100, 100, { reserved: handle });
+    });
+  });
+
+  it("nested steps: innermost blocks first", () => {
+    const guard = new BudgetGuard(100, silent);
+    guard.step({ maxTokens: 10_000 }, (outer) => {
+      outer.step({ maxTokens: 200 }, (inner) => {
+        try {
+          inner.check(undefined, { estimatedTokens: 500 });
+          throw new Error("expected TokenBudgetExceeded");
+        } catch (err) {
+          expect((err as TokenBudgetExceeded).limitTokens).toBe(200);
+        }
+      });
+    });
+  });
+});
+
+describe("advisory", () => {
+  it("reports aggregate token utilization", () => {
+    const guard = new BudgetGuard(100, { tokenLimit: 1_000 });
+    guard.record(MODEL, 500, 100); // 600 / 1000
+    const adv = guard.advisory();
+    expect(adv.tokenUsedBps).toBe(6000);
+    expect(adv.remainingTokens).toBe(400);
+  });
+
+  it("flags per-step near-limit before the hard block", () => {
+    const guard = new BudgetGuard(100, { nearLimitBps: 8000 });
+    guard.step({ maxTokens: 1_000 }, (g) => {
+      g.record(MODEL, 500, 300); // 800 / 1000 = 80%
+      const adv = g.advisory();
+      expect(adv.nearLimit).toBe(true);
+      expect(adv.stepRemainingTokens).toBe(200);
+      expect(() => g.check(undefined, { estimatedTokens: 100 })).not.toThrow();
+    });
+  });
+
+  it("leaves token/step fields null when the dimension is unused", () => {
+    const adv = new BudgetGuard(1).advisory();
+    expect(adv.tokenUsedBps).toBeNull();
+    expect(adv.remainingTokens).toBeNull();
+    expect(adv.stepRemainingUsd).toBeNull();
+    expect(adv.stepRemainingTokens).toBeNull();
+  });
+});
+
+describe("backward-compat: USD-only is unchanged", () => {
+  it("reserve() still returns a plain number", () => {
+    const guard = new BudgetGuard(1);
+    const handle = guard.reserve(0.0125);
+    expect(typeof handle).toBe("number");
+    expect(handle).toBeCloseTo(0.0125);
+    guard.settle(MODEL, 1_000, 1_000, { reserved: handle });
+    expect(guard.spentUsd).toBeCloseTo(0.0125);
+  });
+
+  it("default reserve() returns number 0 on a fresh guard", () => {
+    const guard = new BudgetGuard(1, silent);
+    expect(guard.reserve()).toBe(0);
+  });
+
+  it("advisory keeps its old fields and null for the new ones", () => {
+    const guard = new BudgetGuard(1);
+    guard.record(MODEL, 100, 100);
+    const adv = guard.advisory();
+    expect(adv.spentUsd).toBeCloseTo(guard.spentUsd);
+    expect(adv.tokenUsedBps).toBeNull();
+    expect(adv.stepRemainingUsd).toBeNull();
+  });
+
+  it("a token block is terminal like BudgetExceeded (subclass)", () => {
+    const err = new TokenBudgetExceeded(600, 500, "step");
+    expect(err).toBeInstanceOf(BudgetExceeded);
+  });
+});

--- a/js/test/tool-costs.test.ts
+++ b/js/test/tool-costs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { BudgetExceeded, BudgetGuard } from "../src/index.js";
+import { BudgetExceeded, BudgetGuard, type ReservationHandle } from "../src/index.js";
 
 const MODEL = "gpt-4o"; // 1k in + 1k out = $0.0125/call
 
@@ -160,7 +160,7 @@ describe("tool spend (reserveTool / settleTool / recordTool / toolCosts)", () =>
 
     let blocked = 0;
     const agents = Array.from({ length: 16 }, (_, i) => async () => {
-      let reserved: number;
+      let reserved: ReservationHandle;
       try {
         reserved = i % 2 ? guard.reserve() : guard.reserveTool(0.0125);
       } catch (err) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.11.0"
+version = "0.12.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -23,7 +23,13 @@ from .errors import (
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
-from .guard import BudgetAdvisory, BudgetGuard, BudgetReservation, SpendEvent
+from .guard import (
+    BudgetAdvisory,
+    BudgetGuard,
+    BudgetReservation,
+    ReservationHandle,
+    SpendEvent,
+)
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
@@ -36,6 +42,7 @@ __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
     "BudgetReservation",
+    "ReservationHandle",
     "SpendEvent",
     "LatencyBudget",
     "LatencyAdvisory",

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -19,21 +19,23 @@ from .errors import (
     DeadlineExceeded,
     FloeGuardError,
     HostedEnforcementError,
+    TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
-from .guard import BudgetAdvisory, BudgetGuard, SpendEvent
+from .guard import BudgetAdvisory, BudgetGuard, BudgetReservation, SpendEvent
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.10.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.12.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
+    "BudgetReservation",
     "SpendEvent",
     "LatencyBudget",
     "LatencyAdvisory",
@@ -43,6 +45,7 @@ __all__ = [
     "with_budget_retry",
     "async_with_budget_retry",
     "BudgetExceeded",
+    "TokenBudgetExceeded",
     "DeadlineExceeded",
     "FloeGuardError",
     "HostedEnforcementError",

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -32,12 +32,17 @@ class BudgetExceeded(FloeGuardError):
     loop stops here rather than burning more money.
     """
 
-    def __init__(self, spent_usd: float, limit_usd: float) -> None:
+    def __init__(self, spent_usd: float, limit_usd: float, message: str | None = None) -> None:
         self.spent_usd = spent_usd
         self.limit_usd = limit_usd
-        super().__init__(
-            f"BUDGET EXCEEDED — call blocked (spent ${spent_usd:.6f} of ${limit_usd:.6f} ceiling)"
-        )
+        # Subclasses (the token twin) pass their own message through so they don't
+        # have to bypass this constructor and re-set attrs by hand.
+        if message is None:
+            message = (
+                f"BUDGET EXCEEDED — call blocked "
+                f"(spent ${spent_usd:.6f} of ${limit_usd:.6f} ceiling)"
+            )
+        super().__init__(message)
 
 
 class TokenBudgetExceeded(BudgetExceeded):
@@ -54,17 +59,18 @@ class TokenBudgetExceeded(BudgetExceeded):
     """
 
     def __init__(self, spent_tokens: int, limit_tokens: int, scope: str) -> None:
-        # BudgetExceeded's message/attrs are dollar-shaped and don't apply; set
-        # our own attrs and message, and pass 0.0/0.0 so the inherited spent_usd
-        # / limit_usd stay well-defined (a token block spent no *tracked* USD it
-        # can attribute to this error).
-        FloeGuardError.__init__(
-            self,
-            f"TOKEN BUDGET EXCEEDED — call blocked ({scope}: {spent_tokens} of "
-            f"{limit_tokens} token ceiling)",
+        # Go through BudgetExceeded (not FloeGuardError directly) so any future
+        # parent field is inherited, not silently missed. Pass 0.0/0.0 for the
+        # inherited spent_usd/limit_usd (a token block spent no *tracked* USD) and
+        # the token-shaped message straight through.
+        super().__init__(
+            0.0,
+            0.0,
+            message=(
+                f"TOKEN BUDGET EXCEEDED — call blocked ({scope}: {spent_tokens} of "
+                f"{limit_tokens} token ceiling)"
+            ),
         )
-        self.spent_usd = 0.0
-        self.limit_usd = 0.0
         self.spent_tokens = spent_tokens
         self.limit_tokens = limit_tokens
         self.scope = scope

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -40,6 +40,36 @@ class BudgetExceeded(FloeGuardError):
         )
 
 
+class TokenBudgetExceeded(BudgetExceeded):
+    """Raised before a call that would cross a token ceiling (aggregate or step).
+
+    The token twin of :class:`BudgetExceeded` — it subclasses it so the same
+    retry logic that treats a USD block as terminal (``not isinstance(exc,
+    BudgetExceeded)``) treats a token block as terminal too, with no extra
+    wiring. ``spent_usd`` / ``limit_usd`` are inherited but not meaningful here;
+    the token fields are the payload.
+
+    ``scope`` is ``"aggregate"`` (the guard-wide ``token_limit``) or ``"step"``
+    (the innermost active :meth:`BudgetGuard.step` cap).
+    """
+
+    def __init__(self, spent_tokens: int, limit_tokens: int, scope: str) -> None:
+        # BudgetExceeded's message/attrs are dollar-shaped and don't apply; set
+        # our own attrs and message, and pass 0.0/0.0 so the inherited spent_usd
+        # / limit_usd stay well-defined (a token block spent no *tracked* USD it
+        # can attribute to this error).
+        FloeGuardError.__init__(
+            self,
+            f"TOKEN BUDGET EXCEEDED — call blocked ({scope}: {spent_tokens} of "
+            f"{limit_tokens} token ceiling)",
+        )
+        self.spent_usd = 0.0
+        self.limit_usd = 0.0
+        self.spent_tokens = spent_tokens
+        self.limit_tokens = limit_tokens
+        self.scope = scope
+
+
 class UnpriceableModelError(FloeGuardError):
     """Raised when a model cannot be priced and the guard is fail-closed.
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -67,6 +67,19 @@ class BudgetReservation:
     usd: float
     tokens: int
 
+    def __post_init__(self) -> None:
+        # Public, re-exported value object: validate at construction so a
+        # hand-rolled BudgetReservation(usd=nan, tokens=-5) can't slip past the
+        # raw-float guard and corrupt _reserved / _reserved_tokens downstream
+        # (settle/release trust these fields). Same contracts as reserve()'s
+        # inputs and the JS twin's reservedUsdOf validation.
+        if not math.isfinite(self.usd) or self.usd < 0:
+            raise ValueError(f"BudgetReservation.usd must be finite and >= 0, got {self.usd!r}")
+        if isinstance(self.tokens, bool) or not isinstance(self.tokens, int) or self.tokens < 0:
+            raise ValueError(
+                f"BudgetReservation.tokens must be a non-negative int, got {self.tokens!r}"
+            )
+
 
 # A plain float when USD-only (backward compatible); a BudgetReservation when a
 # token ceiling or an active step is in play.
@@ -432,7 +445,7 @@ class BudgetGuard:
         """
         # A bad reserved handle would corrupt _reserved and break the ceiling for
         # OTHER in-flight calls (negative → phantom hold; inf → clears all holds).
-        # _reserved_usd_of validates a raw float; a BudgetReservation is trusted.
+        # _reserved_usd_of validates the handle (raw float, or a BudgetReservation's fields).
         reserved_usd = self._reserved_usd_of(reserved)
         priced = self._resolve(model, price)
         if priced is None:
@@ -588,7 +601,7 @@ class BudgetGuard:
             raise ValueError(f"cost_usd must be a finite, non-negative number, got {cost_usd!r}")
         # A bad reserved handle would corrupt _reserved and break the ceiling for
         # OTHER in-flight calls — same contract as settle(). _reserved_usd_of
-        # validates a raw float; a BudgetReservation is trusted.
+        # validates the handle (raw float, or a BudgetReservation's fields).
         reserved_usd = self._reserved_usd_of(reserved)
         # int (and bool) are valid inputs; coerce so the logged event and the
         # return value are always float, like every other cost in the guard.
@@ -872,10 +885,11 @@ class BudgetGuard:
 
     @staticmethod
     def _reserved_usd_of(reserved: ReservationHandle) -> float:
-        """The USD amount of a handle, validated. A ``BudgetReservation`` is a
-        trusted value object (its fields were validated at reserve time); a raw
-        float still gets the same finite/non-negative guard as before so a bad
-        hand-rolled handle can't corrupt the in-flight tally."""
+        """The USD amount of a handle, validated. A ``BudgetReservation`` self-
+        validates at construction (:meth:`BudgetReservation.__post_init__`), so its
+        ``usd`` is already finite/non-negative; a raw float gets the same
+        finite/non-negative guard here so a bad hand-rolled handle can't corrupt
+        the in-flight tally."""
         if isinstance(reserved, BudgetReservation):
             return reserved.usd
         if not math.isfinite(reserved) or reserved < 0:
@@ -930,26 +944,28 @@ class BudgetGuard:
 
     def _blocking_cross_locked(
         self, estimate_usd: float, estimate_tokens: int
-    ) -> tuple[str, str, int, int] | None:
+    ) -> tuple[str, str, float, float] | None:
         """The ONE choke point, now across two dimensions and two scopes. Caller
         must hold ``self._lock``. Returns the first ceiling that blocks as
-        ``(dimension, scope, spent_tokens, limit_tokens)`` — dimension
-        ``"usd" | "tokens"``, scope ``"aggregate" | "step"`` — or ``None`` if the
-        call fits everywhere. The two token counts are captured HERE, under the
-        lock, so :meth:`_raise_block` (which runs after the lock is released) can
-        build the token error without re-reading ``self._steps`` — a concurrent
-        step() exit must not turn a token block into an ``IndexError``. They are
-        ``0, 0`` for a USD block (its message reads ``spent_usd`` / ``limit_usd``).
+        ``(dimension, scope, spent, limit)`` — dimension ``"usd" | "tokens"``,
+        scope ``"aggregate" | "step"`` — or ``None`` if the call fits everywhere.
+        The ``spent`` / ``limit`` pair is the crossed ceiling's own figures (USD
+        for a USD block, token counts for a token block), captured HERE under the
+        lock so :meth:`_raise_block` (which runs after the lock is released) builds
+        the error and fires ``on_block`` with a snapshot — never re-reading shared
+        state, so a concurrent write or step() exit can't make the reported values
+        inconsistent or raise an ``IndexError``.
 
         Order (aggregate before step) is deliberate: the guard-wide ceiling is
         the hard money/token limit, so it's reported first when both would block.
         The token ceilings are only consulted when ``token_limit`` / the step's
         ``max_tokens`` is set — an unset dimension never blocks.
         """
-        # Aggregate USD — same comparison the original _would_cross used.
+        # Aggregate USD — same comparison the original _would_cross used. The
+        # message/callback report the accrued total (spent_usd), as _block did.
         committed = self.spent_usd + self._reserved
         if committed > self.limit_usd - _EPS or committed + estimate_usd > self.limit_usd + _EPS:
-            return ("usd", "aggregate", 0, 0)
+            return ("usd", "aggregate", self.spent_usd, self.limit_usd)
         # Aggregate tokens (integers — no epsilon needed).
         if self.token_limit is not None:
             committed_t = self.spent_tokens + self._reserved_tokens
@@ -965,7 +981,10 @@ class BudgetGuard:
                     s_committed > step.max_usd - _EPS
                     or s_committed + estimate_usd > step.max_usd + _EPS
                 ):
-                    return ("usd", "step", 0, 0)
+                    # USD message stays aggregate-shaped (matches the original
+                    # _raise_block, which reported spent_usd/limit_usd for a step
+                    # USD block too).
+                    return ("usd", "step", self.spent_usd, self.limit_usd)
             if step.max_tokens is not None:
                 s_committed_t = step.spent_tokens + step.reserved_tokens
                 if (
@@ -982,18 +1001,19 @@ class BudgetGuard:
         self._on_block(self.spent_usd, self.limit_usd)
         raise BudgetExceeded(self.spent_usd, self.limit_usd)
 
-    def _raise_block(self, blocked: tuple[str, str, int, int]) -> NoReturn:
+    def _raise_block(self, blocked: tuple[str, str, float, float]) -> NoReturn:
         """Notify + raise the right error for a (dimension, scope) block. Called
-        OUTSIDE the lock (like the original _block). The token counts were
+        OUTSIDE the lock (like the original _block). ``spent`` / ``limit`` were
         snapshotted under the lock by :meth:`_blocking_cross_locked`, so this path
-        reads no shared step state and cannot race a concurrent step() exit."""
-        dimension, scope, spent_t, limit_t = blocked
+        reads no shared state — the reported figures stay consistent with the
+        blocking decision and can't race a concurrent write or step() exit."""
+        dimension, scope, spent, limit = blocked
         if dimension == "usd":
-            self._on_block(self.spent_usd, self.limit_usd)
-            raise BudgetExceeded(self.spent_usd, self.limit_usd)
-        # Token block — the crossed ceiling's counts (aggregate or step) came in
-        # with `blocked`; on_block is dollar-shaped so a token block skips it.
-        raise TokenBudgetExceeded(spent_t, limit_t, scope)
+            self._on_block(spent, limit)
+            raise BudgetExceeded(spent, limit)
+        # Token block — counts came in with `blocked`; on_block is dollar-shaped
+        # so a token block skips it.
+        raise TokenBudgetExceeded(int(spent), int(limit), scope)
 
     def _resolve(self, model: str, price: ManualPrice | None):
         overrides = self.price_overrides

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -34,12 +34,14 @@ import threading
 import time
 import warnings
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, NoReturn
 
 from .errors import (
     BudgetExceeded,
+    TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
 )
@@ -47,6 +49,42 @@ from .pricing import ManualPrice, price_tokens, resolve_price
 
 # Tolerance for float rounding in the running spend total (well below $0.000001).
 _EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class BudgetReservation:
+    """A two-dimensional in-flight hold (USD + tokens) returned by
+    :meth:`BudgetGuard.reserve` when a token ceiling or an active
+    :meth:`BudgetGuard.step` is involved.
+
+    A dumb value handle — it carries the amounts held, nothing else. Pass it
+    straight back to :meth:`BudgetGuard.settle` / :meth:`BudgetGuard.release`.
+    When neither tokens nor a step are involved, ``reserve`` returns a plain
+    ``float`` instead (byte-for-byte the old behaviour), so ``ReservationHandle``
+    is the union of the two.
+    """
+
+    usd: float
+    tokens: int
+
+
+# A plain float when USD-only (backward compatible); a BudgetReservation when a
+# token ceiling or an active step is in play.
+ReservationHandle = float | BudgetReservation
+
+
+@dataclass
+class _StepState:
+    """One scope on the step stack (see :meth:`BudgetGuard.step`). Mutable: the
+    guard accrues into ``spent_*`` / ``reserved_*`` as calls settle within the
+    step. ``max_usd`` / ``max_tokens`` are ``None`` for an uncapped dimension."""
+
+    max_usd: float | None
+    max_tokens: int | None
+    spent_usd: float = 0.0
+    spent_tokens: int = 0
+    reserved_usd: float = 0.0
+    reserved_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -79,6 +117,18 @@ class BudgetAdvisory:
     # floor(remaining_usd / expected_cost). None when expected_cost is 0.0
     # (no call recorded yet) — unknown, not zero.
     est_calls_remaining: int | None = None
+    # Aggregate token utilization in basis points (0..10000), mirroring used_bps
+    # for the token ceiling. None when no token_limit is set (nothing to signal).
+    token_used_bps: int | None = None
+    # Tokens left before the aggregate token ceiling (never negative). None when
+    # no token_limit is set.
+    remaining_tokens: int | None = None
+    # Per-step headroom for the innermost active step, present (non-None) ONLY
+    # while a step() is active AND that dimension is capped. Lets a router read
+    # how much room the current step has before its own cap, not just the global
+    # one. None when no step is active or the dimension is uncapped.
+    step_remaining_usd: float | None = None
+    step_remaining_tokens: int | None = None
 
 
 @dataclass(frozen=True)
@@ -165,6 +215,7 @@ class BudgetGuard:
         on_block: Callable[[float, float], None] | None = None,
         near_limit_bps: int = 8000,
         max_log_events: int | None = None,
+        token_limit: int | None = None,
     ) -> None:
         if not math.isfinite(limit_usd) or limit_usd < 0:
             # NaN/inf would make every check() comparison evaluate False and
@@ -179,7 +230,20 @@ class BudgetGuard:
             or not 0 <= near_limit_bps <= 10000
         ):
             raise ValueError(f"near_limit_bps must be an int in 0..10000, got {near_limit_bps!r}")
+        # Same int-not-bool contract as near_limit_bps (parity with TS
+        # Number.isInteger). None disables the token ceiling entirely.
+        if token_limit is not None and (
+            isinstance(token_limit, bool) or not isinstance(token_limit, int) or token_limit < 0
+        ):
+            raise ValueError(f"token_limit must be None or a non-negative int, got {token_limit!r}")
         self.limit_usd = float(limit_usd)
+        self.token_limit = token_limit
+        # Aggregate tokens accrued (prompt + completion + cache buckets), and
+        # tokens held in-flight — the token twin of spent_usd / _reserved.
+        self.spent_tokens = 0
+        self._reserved_tokens = 0
+        # Step stack: innermost step is last. Empty when no step() is active.
+        self._steps: list[_StepState] = []
         self.price_overrides = price_overrides
         self.fail_closed = fail_closed
         self._on_block = on_block or _default_on_block
@@ -216,23 +280,39 @@ class BudgetGuard:
 
     # ── enforcement ───────────────────────────────────────────────────────────
 
-    def check(self, estimated_next_cost: float | None = None) -> None:
-        """Raise :class:`BudgetExceeded` if the next call would cross the ceiling.
+    def check(
+        self,
+        estimated_next_cost: float | None = None,
+        *,
+        estimated_tokens: int = 0,
+    ) -> None:
+        """Raise if the next call would cross any active ceiling.
 
-        Call this immediately before each LLM request. The "next call" is
-        estimated conservatively as the costlier of the last LLM call and the
+        Call this immediately before each LLM request. The "next call" USD cost
+        is estimated conservatively as the costlier of the last LLM call and the
         last tool call (override with ``estimated_next_cost``); the first call
-        is always allowed unless the ceiling is already met. A belt-and-suspenders
+        is always allowed unless a ceiling is already met. A belt-and-suspenders
         check on the running total catches an overshoot if the estimate was too
         low. In-flight reservations count toward the total, so this stays
         correct alongside :meth:`reserve`.
+
+        Pass ``estimated_tokens`` to also pre-emptively block on the aggregate
+        ``token_limit`` or the active step's token cap (raises
+        :class:`TokenBudgetExceeded`). A USD block raises :class:`BudgetExceeded`.
 
         Note: ``check`` is a non-binding peek. For parallel calls, use
         :meth:`reserve` / :meth:`settle`, which hold the estimate atomically.
         """
         self._validate_estimate(estimated_next_cost)
-        if self._would_cross(estimated_next_cost):
-            self._block()
+        with self._lock:
+            estimate = (
+                self._default_estimate_locked()
+                if estimated_next_cost is None
+                else max(0.0, estimated_next_cost)
+            )
+            blocked = self._blocking_cross_locked(estimate, max(0, estimated_tokens))
+        if blocked is not None:
+            self._raise_block(blocked)
 
     def estimate_call(
         self,
@@ -264,35 +344,51 @@ class BudgetGuard:
             return None
         return price_tokens(priced, prompt_tokens, max_completion_tokens)
 
-    def reserve(self, estimated_cost: float | None = None) -> float:
-        """Atomically check the ceiling AND hold the estimated cost in-flight.
+    def reserve(
+        self,
+        estimated_cost: float | None = None,
+        *,
+        estimated_tokens: int = 0,
+    ) -> ReservationHandle:
+        """Atomically check every active ceiling AND hold the estimate in-flight.
 
         This is the concurrency-safe enforcement path. Each parallel caller
         reserves before its call, so N callers can't all clear the same stale
-        total and overshoot. Raises :class:`BudgetExceeded` (without reserving)
-        if the reservation would cross the ceiling.
+        total and overshoot. Raises :class:`BudgetExceeded` (USD) or
+        :class:`TokenBudgetExceeded` (tokens) — without reserving — if the
+        reservation would cross the aggregate ceiling or the active step's cap.
 
-        Returns a reservation handle (the USD amount held) to pass to
-        :meth:`settle` after the response, or to :meth:`release` if the call
-        fails. ``estimated_cost`` defaults to the costlier of the last LLM call
-        and the last tool call.
+        Returns a reservation handle to pass to :meth:`settle` after the
+        response, or to :meth:`release` if the call fails. **For backward
+        compatibility the handle is a plain ``float`` (the USD held) when no
+        tokens and no active :meth:`step` are involved** — old callers are
+        unchanged. Otherwise it is a :class:`BudgetReservation` carrying both
+        dimensions. ``estimated_cost`` defaults to the costlier of the last LLM
+        call and the last tool call.
         """
         self._validate_estimate(estimated_cost)
+        tokens = max(0, estimated_tokens)
         with self._lock:
             estimate = (
                 self._default_estimate_locked()
                 if estimated_cost is None
                 else max(0.0, estimated_cost)
             )
-            committed = self.spent_usd + self._reserved
-            if committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS:
-                spent, limit = self.spent_usd, self.limit_usd
-            else:
+            blocked = self._blocking_cross_locked(estimate, tokens)
+            if blocked is None:
                 self._reserved += estimate
-                return estimate
+                self._reserved_tokens += tokens
+                step = self._steps[-1] if self._steps else None
+                if step is not None:
+                    step.reserved_usd += estimate
+                    step.reserved_tokens += tokens
+                # Plain float only when nothing token- or step-shaped is in play,
+                # so pre-existing USD-only callers get byte-for-byte the old handle.
+                if tokens == 0 and step is None:
+                    return estimate
+                return BudgetReservation(usd=estimate, tokens=tokens)
         # Blocked — notify and raise outside the lock.
-        self._on_block(spent, limit)
-        raise BudgetExceeded(spent, limit)
+        self._raise_block(blocked)
 
     def settle(
         self,
@@ -300,7 +396,7 @@ class BudgetGuard:
         prompt_tokens: int,
         completion_tokens: int,
         *,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         price: ManualPrice | None = None,
         cache_creation_input_tokens: int = 0,
         cache_creation_input_tokens_1h: int = 0,
@@ -316,11 +412,16 @@ class BudgetGuard:
         :class:`SpendEvent` to :attr:`spend_log` (``label`` tags it, e.g. with an
         agent or task name); the warn-and-skip path accrues nothing and logs
         nothing, so the ledger stays in lockstep with ``spent_usd``.
+
+        ``reserved`` accepts a plain float (USD-only, backward compatible) or a
+        :class:`BudgetReservation` from a token/step-aware :meth:`reserve`; the
+        token hold is drained the same way. Tokens accrue free from the counts
+        this method already receives.
         """
         # A bad reserved handle would corrupt _reserved and break the ceiling for
         # OTHER in-flight calls (negative → phantom hold; inf → clears all holds).
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        # _reserved_usd_of validates a raw float; a BudgetReservation is trusted.
+        reserved_usd = self._reserved_usd_of(reserved)
         priced = self._resolve(model, price)
         if priced is None:
             warnings.warn(
@@ -355,10 +456,21 @@ class BudgetGuard:
             # path above.
             self.release(reserved)
             raise
+        # Tokens accrued match what USD bills: prompt + completion + every cache
+        # bucket price_tokens charges (negative counts clamp to 0, as in pricing).
+        accrued_tokens = (
+            max(0, prompt_tokens)
+            + max(0, completion_tokens)
+            + max(0, cache_creation_input_tokens)
+            + max(0, cache_creation_input_tokens_1h)
+            + max(0, cache_read_input_tokens)
+        )
         with self._lock:
             if reserved:
                 self._consume_reservation_locked(reserved)
             self.spent_usd += cost
+            self.spent_tokens += accrued_tokens
+            self._accrue_step_locked(cost, accrued_tokens)
             # Clamp a sub-epsilon float overshoot back to the limit so the running
             # total never reports as having crossed the ceiling by a rounding artifact.
             if 0.0 < self.spent_usd - self.limit_usd < _EPS:
@@ -374,8 +486,9 @@ class BudgetGuard:
                     cost_usd=cost,
                     label=label,
                     # 0.0 means "no reservation" (the plain record() path) — omit
-                    # rather than log a meaningless zero.
-                    reserved=reserved if reserved else None,
+                    # rather than log a meaningless zero. Log the USD amount so the
+                    # ledger schema stays float-shaped even for a BudgetReservation.
+                    reserved=reserved_usd if reserved_usd else None,
                 )
             )
         return cost
@@ -410,7 +523,7 @@ class BudgetGuard:
             label=label,
         )
 
-    def reserve_tool(self, estimated_cost: float) -> float:
+    def reserve_tool(self, estimated_cost: float) -> ReservationHandle:
         """Atomically check the ceiling AND hold a tool call's cost in-flight.
 
         The tool-spend counterpart of :meth:`reserve` — and STRONGER than the
@@ -444,7 +557,7 @@ class BudgetGuard:
         tool: str,
         cost_usd: float,
         *,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         label: str | None = None,
     ) -> float:
         """Release a reservation and record a tool call's actual cost.
@@ -462,9 +575,9 @@ class BudgetGuard:
         if not math.isfinite(cost_usd) or cost_usd < 0:
             raise ValueError(f"cost_usd must be a finite, non-negative number, got {cost_usd!r}")
         # A bad reserved handle would corrupt _reserved and break the ceiling for
-        # OTHER in-flight calls — same contract as settle().
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        # OTHER in-flight calls — same contract as settle(). _reserved_usd_of
+        # validates a raw float; a BudgetReservation is trusted.
+        reserved_usd = self._reserved_usd_of(reserved)
         # int (and bool) are valid inputs; coerce so the logged event and the
         # return value are always float, like every other cost in the guard.
         cost_usd = float(cost_usd)
@@ -472,6 +585,8 @@ class BudgetGuard:
             if reserved:
                 self._consume_reservation_locked(reserved)
             self.spent_usd += cost_usd
+            # A paid tool spends the step's USD too (no tokens to price).
+            self._accrue_step_locked(cost_usd, 0)
             # Same sub-epsilon clamp as settle(): never report a rounding-artifact
             # crossing of the ceiling.
             if 0.0 < self.spent_usd - self.limit_usd < _EPS:
@@ -487,7 +602,7 @@ class BudgetGuard:
                     completion_tokens=None,
                     cost_usd=cost_usd,
                     label=label,
-                    reserved=reserved if reserved else None,
+                    reserved=reserved_usd if reserved_usd else None,
                 )
             )
         return cost_usd
@@ -502,14 +617,14 @@ class BudgetGuard:
         """
         return self.settle_tool(tool, cost_usd, reserved=0.0, label=label)
 
-    def release(self, reserved: float) -> None:
+    def release(self, reserved: ReservationHandle) -> None:
         """Drop an in-flight reservation without recording spend (e.g. the call
-        failed before producing usage). Safe to call with ``0``."""
+        failed before producing usage). Safe to call with ``0``. Accepts a plain
+        float or a :class:`BudgetReservation` (drains its token hold too)."""
         # Validate before the zero-check so a NaN handle raises instead of being
         # silently dropped (which would leak the hold). A bad handle here corrupts
-        # _reserved for other in-flight calls.
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        # _reserved for other in-flight calls. _reserved_usd_of validates a raw float.
+        self._reserved_usd_of(reserved)
         if not reserved:
             return
         with self._lock:
@@ -561,6 +676,52 @@ class BudgetGuard:
             for event in self.spend_log
         )
 
+    @contextmanager
+    def step(
+        self, *, max_usd: float | None = None, max_tokens: int | None = None
+    ) -> Iterator[BudgetGuard]:
+        """Scope a per-step USD and/or token cap for a **sequential agent loop**.
+
+        Push a step onto the guard's stack on enter, pop it on exit; the
+        enforcement/accrual path honours the innermost active step *on top of*
+        the aggregate ceilings. A call that would cross the step's ``max_usd`` /
+        ``max_tokens`` is hard-blocked (``BudgetExceeded`` / ``TokenBudgetExceeded``
+        with ``scope="step"``) even if the aggregate budget has room::
+
+            with guard.step(max_tokens=5_000) as g:   # g IS guard
+                g.check(estimated_tokens=...)          # may raise scope="step"
+                g.record("gpt-4o", 1200, 350)
+
+        Yields the SAME guard, so no adapter needs to know about steps — pass the
+        guard through as usual. Steps nest (an inner step is checked first); the
+        innermost is the one that owns each call. **Not for concurrent parallel
+        steps on one guard** — that's a per-step identity registry, out of scope
+        for issue #46. Use one guard per parallel branch instead.
+        """
+        if max_usd is not None and (not math.isfinite(max_usd) or max_usd < 0):
+            raise ValueError(
+                f"max_usd must be None or a finite, non-negative number, got {max_usd!r}"
+            )
+        if max_tokens is not None and (
+            isinstance(max_tokens, bool) or not isinstance(max_tokens, int) or max_tokens < 0
+        ):
+            raise ValueError(f"max_tokens must be None or a non-negative int, got {max_tokens!r}")
+        state = _StepState(
+            max_usd=float(max_usd) if max_usd is not None else None, max_tokens=max_tokens
+        )
+        with self._lock:
+            self._steps.append(state)
+        try:
+            yield self
+        finally:
+            with self._lock:
+                # Pop our own state. Identity match (not just pop()) so an
+                # out-of-order exit can't silently drop someone else's step.
+                if self._steps and self._steps[-1] is state:
+                    self._steps.pop()
+                else:
+                    self._steps.remove(state)
+
     def advisory(self) -> BudgetAdvisory:
         """Context-aware spend advisory for this budget — see :class:`BudgetAdvisory`.
 
@@ -584,11 +745,46 @@ class BudgetGuard:
         expected_cost = max(self._last_llm_cost, self._last_tool_cost)
         # +1e-9 absorbs float noise so e.g. 0.6/0.2 floors to 3 not 2 (same
         # epsilon rationale as used_bps above, and keeps JS Math.floor parity).
-        est_calls_remaining = (
-            int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
-        )
+        est_calls_remaining = int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
+        # Aggregate token utilization, mirroring used_bps. None (no signal) when
+        # the token dimension is unset — an aggregate-only USD guard is unchanged.
+        token_used_bps: int | None = None
+        remaining_tokens: int | None = None
+        near_token = False
+        if self.token_limit is not None:
+            if self.token_limit <= 0:
+                token_used_bps = 10000
+            else:
+                token_used_bps = max(
+                    0, min(10000, int(self.spent_tokens / self.token_limit * 10000 + 1e-9))
+                )
+            remaining_tokens = max(0, self.token_limit - self.spent_tokens)
+            near_token = token_used_bps >= self.near_limit_bps
+        # Innermost active step's headroom + nearness (per dimension, only when
+        # that dimension is capped). None keeps the fields absent for old readers.
+        step = self._steps[-1] if self._steps else None
+        step_remaining_usd: float | None = None
+        step_remaining_tokens: int | None = None
+        near_step = False
+        if step is not None:
+            if step.max_usd is not None:
+                step_remaining_usd = max(0.0, step.max_usd - step.spent_usd)
+                if step.max_usd <= 0.0:
+                    near_step = True
+                else:
+                    s_bps = int(step.spent_usd / step.max_usd * 10000 + 1e-9)
+                    near_step = near_step or s_bps >= self.near_limit_bps
+            if step.max_tokens is not None:
+                step_remaining_tokens = max(0, step.max_tokens - step.spent_tokens)
+                if step.max_tokens <= 0:
+                    near_step = True
+                else:
+                    s_tbps = int(step.spent_tokens / step.max_tokens * 10000 + 1e-9)
+                    near_step = near_step or s_tbps >= self.near_limit_bps
         return BudgetAdvisory(
-            near_limit=used_bps >= self.near_limit_bps,
+            # near_limit now also flips when a token ceiling or the active step is
+            # near its cap, so a router can downshift before ANY hard-stop.
+            near_limit=used_bps >= self.near_limit_bps or near_token or near_step,
             used_bps=used_bps,
             # Settled budget: limit minus accrued spend, deliberately NOT net of
             # in-flight reservations. This differs from the remaining_usd property
@@ -600,6 +796,10 @@ class BudgetGuard:
             spent_usd=self.spent_usd,
             expected_cost=expected_cost,
             est_calls_remaining=est_calls_remaining,
+            token_used_bps=token_used_bps,
+            remaining_tokens=remaining_tokens,
+            step_remaining_usd=step_remaining_usd,
+            step_remaining_tokens=step_remaining_tokens,
         )
 
     # ── internals ──────────────────────────────────────────────────────────────
@@ -614,8 +814,8 @@ class BudgetGuard:
         """
         return max(self._last_llm_cost, self._last_tool_cost)
 
-    def _consume_reservation_locked(self, reserved: float) -> None:
-        """Subtract a settled/released hold from the in-flight tally. Caller
+    def _consume_reservation_locked(self, reserved: ReservationHandle) -> None:
+        """Subtract a settled/released hold from the in-flight tallies. Caller
         must hold ``self._lock``. A handle larger than EVERYTHING currently
         held cannot have come from a matching :meth:`reserve` — raising beats
         silently clamping, which would free OTHER callers' holds and fail the
@@ -623,13 +823,33 @@ class BudgetGuard:
         draining many holds; per-caller over-release (a handle within the
         total but larger than the caller's own hold) is undetectable without
         per-handle tracking and remains the caller's responsibility.
+
+        Drains both dimensions the SAME way — a ``BudgetReservation`` carries a
+        token hold too, and (like the USD float) it also unwinds the innermost
+        active step. A plain ``float`` handle drains only USD (the backward-compat
+        path). We do NOT track which step a handle came from: a handle is drained
+        against whatever step is innermost now, matching the sequential-loop
+        contract (concurrent parallel steps on one guard are out of scope, #46).
         """
-        if reserved > self._reserved + _EPS:
+        usd = reserved.usd if isinstance(reserved, BudgetReservation) else reserved
+        tokens = reserved.tokens if isinstance(reserved, BudgetReservation) else 0
+        if usd > self._reserved + _EPS:
             raise ValueError(
-                f"reserved handle ({reserved!r}) exceeds total in-flight reservations "
+                f"reserved handle ({usd!r}) exceeds total in-flight reservations "
                 f"({self._reserved!r}) — a handle must come from a matching reserve()"
             )
-        self._reserved = max(0.0, self._reserved - reserved)
+        if tokens > self._reserved_tokens:
+            raise ValueError(
+                f"reserved token handle ({tokens!r}) exceeds total in-flight token "
+                f"reservations ({self._reserved_tokens!r}) — a handle must come from a "
+                f"matching reserve()"
+            )
+        self._reserved = max(0.0, self._reserved - usd)
+        self._reserved_tokens = max(0, self._reserved_tokens - tokens)
+        step = self._steps[-1] if self._steps else None
+        if step is not None:
+            step.reserved_usd = max(0.0, step.reserved_usd - usd)
+            step.reserved_tokens = max(0, step.reserved_tokens - tokens)
 
     def _validate_estimate(self, estimated: float | None) -> None:
         # NaN/inf would poison the ceiling comparisons and fail-open (or poison
@@ -637,6 +857,29 @@ class BudgetGuard:
         # matching the constructor's math.isfinite guard and the TS Number.isFinite.
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
+
+    @staticmethod
+    def _reserved_usd_of(reserved: ReservationHandle) -> float:
+        """The USD amount of a handle, validated. A ``BudgetReservation`` is a
+        trusted value object (its fields were validated at reserve time); a raw
+        float still gets the same finite/non-negative guard as before so a bad
+        hand-rolled handle can't corrupt the in-flight tally."""
+        if isinstance(reserved, BudgetReservation):
+            return reserved.usd
+        if not math.isfinite(reserved) or reserved < 0:
+            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        return reserved
+
+    def _accrue_step_locked(self, cost: float, tokens: int) -> None:
+        """Accrue a settled call into the innermost active step. Caller must
+        hold ``self._lock``. No-op when no step is active — the reservation was
+        already drained by _consume_reservation_locked, this adds the *settled*
+        amount. Sequential-loop contract: the innermost step is the one that
+        owns the call (concurrent parallel steps on one guard are out of scope)."""
+        step = self._steps[-1] if self._steps else None
+        if step is not None:
+            step.spent_usd += cost
+            step.spent_tokens += tokens
 
     def _stream_register(self, reserved: float) -> object:
         """Register an active stream (see :class:`~floe_guard.stream.StreamGuard`)
@@ -673,19 +916,71 @@ class BudgetGuard:
             others = self.spent_usd + max(0.0, self._reserved - own_reserved) + other_overage
             return others + cumulative_call_cost > self.limit_usd + _EPS
 
-    def _would_cross(self, estimated_next_cost: float | None) -> bool:
-        with self._lock:
-            estimate = (
-                self._default_estimate_locked()
-                if estimated_next_cost is None
-                else max(0.0, estimated_next_cost)
-            )
-            committed = self.spent_usd + self._reserved
-            return committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS
+    def _blocking_cross_locked(
+        self, estimate_usd: float, estimate_tokens: int
+    ) -> tuple[str, str] | None:
+        """The ONE choke point, now across two dimensions and two scopes. Caller
+        must hold ``self._lock``. Returns the first ceiling that blocks as
+        ``(dimension, scope)`` — dimension ``"usd" | "tokens"``, scope
+        ``"aggregate" | "step"`` — or ``None`` if the call fits everywhere.
 
-    def _block(self) -> None:
+        Order (aggregate before step) is deliberate: the guard-wide ceiling is
+        the hard money/token limit, so it's reported first when both would block.
+        The token ceilings are only consulted when ``token_limit`` / the step's
+        ``max_tokens`` is set — an unset dimension never blocks.
+        """
+        # Aggregate USD — same comparison the original _would_cross used.
+        committed = self.spent_usd + self._reserved
+        if committed > self.limit_usd - _EPS or committed + estimate_usd > self.limit_usd + _EPS:
+            return ("usd", "aggregate")
+        # Aggregate tokens (integers — no epsilon needed).
+        if self.token_limit is not None:
+            committed_t = self.spent_tokens + self._reserved_tokens
+            if committed_t >= self.token_limit or committed_t + estimate_tokens > self.token_limit:
+                return ("tokens", "aggregate")
+        # Innermost active step's caps (an outer step can only be crossed by
+        # first crossing the inner one, so checking the innermost is sufficient).
+        step = self._steps[-1] if self._steps else None
+        if step is not None:
+            if step.max_usd is not None:
+                s_committed = step.spent_usd + step.reserved_usd
+                if (
+                    s_committed > step.max_usd - _EPS
+                    or s_committed + estimate_usd > step.max_usd + _EPS
+                ):
+                    return ("usd", "step")
+            if step.max_tokens is not None:
+                s_committed_t = step.spent_tokens + step.reserved_tokens
+                if (
+                    s_committed_t >= step.max_tokens
+                    or s_committed_t + estimate_tokens > step.max_tokens
+                ):
+                    return ("tokens", "step")
+        return None
+
+    def _block(self) -> NoReturn:
+        """Notify + raise a USD :class:`BudgetExceeded`. The aggregate-USD path
+        used by :class:`~floe_guard.stream.StreamGuard`; :meth:`_raise_block` is
+        the dimension-aware generalisation used by check/reserve."""
         self._on_block(self.spent_usd, self.limit_usd)
         raise BudgetExceeded(self.spent_usd, self.limit_usd)
+
+    def _raise_block(self, blocked: tuple[str, str]) -> NoReturn:
+        """Notify + raise the right error for a (dimension, scope) block. Called
+        OUTSIDE the lock (like the original _block)."""
+        dimension, scope = blocked
+        if dimension == "usd":
+            self._on_block(self.spent_usd, self.limit_usd)
+            raise BudgetExceeded(self.spent_usd, self.limit_usd)
+        # Token block — report against the crossed ceiling (aggregate or step).
+        if scope == "step":
+            step = self._steps[-1]
+            spent_t = step.spent_tokens + step.reserved_tokens
+            limit_t = step.max_tokens if step.max_tokens is not None else 0
+        else:
+            spent_t = self.spent_tokens + self._reserved_tokens
+            limit_t = self.token_limit if self.token_limit is not None else 0
+        raise TokenBudgetExceeded(spent_t, limit_t, scope)
 
     def _resolve(self, model: str, price: ManualPrice | None):
         overrides = self.price_overrides

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -73,7 +73,11 @@ class BudgetReservation:
 ReservationHandle = float | BudgetReservation
 
 
-@dataclass
+# eq=False: identity, not value, equality. The step stack is popped by identity
+# (``is`` / ``list.remove`` on the exact object), so two nested steps with the
+# same caps and no spend yet must not compare equal or ``remove`` could drop the
+# wrong one. Matches the JS twin, which splices by ``lastIndexOf`` (reference).
+@dataclass(eq=False)
 class _StepState:
     """One scope on the step stack (see :meth:`BudgetGuard.step`). Mutable: the
     guard accrues into ``spent_*`` / ``reserved_*`` as calls settle within the
@@ -192,7 +196,10 @@ class BudgetGuard:
             (you have explicitly opted into un-enforced spend for that model).
         on_block: optional callback invoked with ``(spent_usd, limit_usd)`` right
             before :class:`BudgetExceeded` is raised. Defaults to printing the
-            ``BUDGET EXCEEDED — call blocked`` banner to stderr.
+            ``BUDGET EXCEEDED — call blocked`` banner to stderr. Fires on **USD**
+            ceiling crossings only; a token-ceiling block
+            (:class:`TokenBudgetExceeded`, aggregate or step) is raised without
+            invoking it, because the callback is dollar-shaped (spent/limit USD).
         near_limit_bps: utilization (basis points, 0..10000) at which
             :meth:`advisory` flags ``near_limit`` so an agent can taper before the
             hard-stop. Defaults to ``8000`` (80%).
@@ -200,6 +207,11 @@ class BudgetGuard:
             (:attr:`spend_log`). When set, the ledger is a ring buffer keeping the
             most recent N events so a long-running agent's memory stays bounded;
             the running totals are unaffected. ``None`` (default) keeps every event.
+        token_limit: optional aggregate token ceiling (prompt + completion + cache
+            buckets) enforced alongside ``limit_usd``. ``check`` / ``reserve`` take
+            ``estimated_tokens`` to pre-emptively block; a cross raises
+            :class:`TokenBudgetExceeded` (``scope="aggregate"``). ``None`` (default)
+            disables the token dimension entirely.
 
     Thread-safe: the running total and in-flight reservations are guarded by a
     lock, so the guard can back a parallel crew (use :meth:`reserve` /
@@ -918,11 +930,16 @@ class BudgetGuard:
 
     def _blocking_cross_locked(
         self, estimate_usd: float, estimate_tokens: int
-    ) -> tuple[str, str] | None:
+    ) -> tuple[str, str, int, int] | None:
         """The ONE choke point, now across two dimensions and two scopes. Caller
         must hold ``self._lock``. Returns the first ceiling that blocks as
-        ``(dimension, scope)`` — dimension ``"usd" | "tokens"``, scope
-        ``"aggregate" | "step"`` — or ``None`` if the call fits everywhere.
+        ``(dimension, scope, spent_tokens, limit_tokens)`` — dimension
+        ``"usd" | "tokens"``, scope ``"aggregate" | "step"`` — or ``None`` if the
+        call fits everywhere. The two token counts are captured HERE, under the
+        lock, so :meth:`_raise_block` (which runs after the lock is released) can
+        build the token error without re-reading ``self._steps`` — a concurrent
+        step() exit must not turn a token block into an ``IndexError``. They are
+        ``0, 0`` for a USD block (its message reads ``spent_usd`` / ``limit_usd``).
 
         Order (aggregate before step) is deliberate: the guard-wide ceiling is
         the hard money/token limit, so it's reported first when both would block.
@@ -932,12 +949,12 @@ class BudgetGuard:
         # Aggregate USD — same comparison the original _would_cross used.
         committed = self.spent_usd + self._reserved
         if committed > self.limit_usd - _EPS or committed + estimate_usd > self.limit_usd + _EPS:
-            return ("usd", "aggregate")
+            return ("usd", "aggregate", 0, 0)
         # Aggregate tokens (integers — no epsilon needed).
         if self.token_limit is not None:
             committed_t = self.spent_tokens + self._reserved_tokens
             if committed_t >= self.token_limit or committed_t + estimate_tokens > self.token_limit:
-                return ("tokens", "aggregate")
+                return ("tokens", "aggregate", committed_t, self.token_limit)
         # Innermost active step's caps (an outer step can only be crossed by
         # first crossing the inner one, so checking the innermost is sufficient).
         step = self._steps[-1] if self._steps else None
@@ -948,14 +965,14 @@ class BudgetGuard:
                     s_committed > step.max_usd - _EPS
                     or s_committed + estimate_usd > step.max_usd + _EPS
                 ):
-                    return ("usd", "step")
+                    return ("usd", "step", 0, 0)
             if step.max_tokens is not None:
                 s_committed_t = step.spent_tokens + step.reserved_tokens
                 if (
                     s_committed_t >= step.max_tokens
                     or s_committed_t + estimate_tokens > step.max_tokens
                 ):
-                    return ("tokens", "step")
+                    return ("tokens", "step", s_committed_t, step.max_tokens)
         return None
 
     def _block(self) -> NoReturn:
@@ -965,21 +982,17 @@ class BudgetGuard:
         self._on_block(self.spent_usd, self.limit_usd)
         raise BudgetExceeded(self.spent_usd, self.limit_usd)
 
-    def _raise_block(self, blocked: tuple[str, str]) -> NoReturn:
+    def _raise_block(self, blocked: tuple[str, str, int, int]) -> NoReturn:
         """Notify + raise the right error for a (dimension, scope) block. Called
-        OUTSIDE the lock (like the original _block)."""
-        dimension, scope = blocked
+        OUTSIDE the lock (like the original _block). The token counts were
+        snapshotted under the lock by :meth:`_blocking_cross_locked`, so this path
+        reads no shared step state and cannot race a concurrent step() exit."""
+        dimension, scope, spent_t, limit_t = blocked
         if dimension == "usd":
             self._on_block(self.spent_usd, self.limit_usd)
             raise BudgetExceeded(self.spent_usd, self.limit_usd)
-        # Token block — report against the crossed ceiling (aggregate or step).
-        if scope == "step":
-            step = self._steps[-1]
-            spent_t = step.spent_tokens + step.reserved_tokens
-            limit_t = step.max_tokens if step.max_tokens is not None else 0
-        else:
-            spent_t = self.spent_tokens + self._reserved_tokens
-            limit_t = self.token_limit if self.token_limit is not None else 0
+        # Token block — the crossed ceiling's counts (aggregate or step) came in
+        # with `blocked`; on_block is dollar-shaped so a token block skips it.
         raise TokenBudgetExceeded(spent_t, limit_t, scope)
 
     def _resolve(self, model: str, price: ManualPrice | None):

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -329,6 +329,7 @@ class BudgetGuard:
         :meth:`reserve` / :meth:`settle`, which hold the estimate atomically.
         """
         self._validate_estimate(estimated_next_cost)
+        self._validate_token_estimate(estimated_tokens)
         with self._lock:
             estimate = (
                 self._default_estimate_locked()
@@ -392,6 +393,7 @@ class BudgetGuard:
         call and the last tool call.
         """
         self._validate_estimate(estimated_cost)
+        self._validate_token_estimate(estimated_tokens)
         tokens = max(0, estimated_tokens)
         with self._lock:
             estimate = (
@@ -754,7 +756,27 @@ class BudgetGuard:
         80%), so an agent can taper *before* the hard-stop. Advisory only: read it
         to adapt; :meth:`check` is what enforces the ceiling.
         """
-        if self.limit_usd <= 0.0:
+        # Snapshot every shared field under the lock — running totals, last-call
+        # costs, and the innermost step's mutable fields — so a concurrent
+        # settle()/step() can't change them mid-read, and a step() exit can't pop
+        # the last step between the truthiness check and the index (IndexError).
+        # The arithmetic below runs on the snapshot, lock-free.
+        with self._lock:
+            limit_usd = self.limit_usd
+            spent_usd = self.spent_usd
+            last_llm = self._last_llm_cost
+            last_tool = self._last_tool_cost
+            token_limit = self.token_limit
+            spent_tokens = self.spent_tokens
+            near_limit_bps = self.near_limit_bps
+            step = self._steps[-1] if self._steps else None
+            step_active = step is not None
+            step_max_usd = step.max_usd if step is not None else None
+            step_spent_usd = step.spent_usd if step is not None else 0.0
+            step_max_tokens = step.max_tokens if step is not None else None
+            step_spent_tokens = step.spent_tokens if step is not None else 0
+
+        if limit_usd <= 0.0:
             used_bps = 10000
         else:
             # Floor (not round) so used_bps never over-reports utilization and
@@ -762,12 +784,11 @@ class BudgetGuard:
             # early. The tiny epsilon absorbs float noise (0.7*10000 = 6999.9999…),
             # and floor matches JS Math.floor exactly — round() would diverge
             # (Python banker's rounding vs JS ties-up).
-            used_bps = max(0, min(10000, int(self.spent_usd / self.limit_usd * 10000 + 1e-9)))
-        remaining = max(0.0, self.limit_usd - self.spent_usd)
-        # Lock-free read of the last-cost fields, consistent with reading
-        # spent_usd above: the estimate is the costlier of the last LLM and tool
-        # call (the guard's own default reservation), 0.0 before any call.
-        expected_cost = max(self._last_llm_cost, self._last_tool_cost)
+            used_bps = max(0, min(10000, int(spent_usd / limit_usd * 10000 + 1e-9)))
+        remaining = max(0.0, limit_usd - spent_usd)
+        # The estimate is the costlier of the last LLM and tool call (the guard's
+        # own default reservation), 0.0 before any call.
+        expected_cost = max(last_llm, last_tool)
         # +1e-9 absorbs float noise so e.g. 0.6/0.2 floors to 3 not 2 (same
         # epsilon rationale as used_bps above, and keeps JS Math.floor parity).
         est_calls_remaining = int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
@@ -776,40 +797,37 @@ class BudgetGuard:
         token_used_bps: int | None = None
         remaining_tokens: int | None = None
         near_token = False
-        if self.token_limit is not None:
-            if self.token_limit <= 0:
+        if token_limit is not None:
+            if token_limit <= 0:
                 token_used_bps = 10000
             else:
-                token_used_bps = max(
-                    0, min(10000, int(self.spent_tokens / self.token_limit * 10000 + 1e-9))
-                )
-            remaining_tokens = max(0, self.token_limit - self.spent_tokens)
-            near_token = token_used_bps >= self.near_limit_bps
+                token_used_bps = max(0, min(10000, int(spent_tokens / token_limit * 10000 + 1e-9)))
+            remaining_tokens = max(0, token_limit - spent_tokens)
+            near_token = token_used_bps >= near_limit_bps
         # Innermost active step's headroom + nearness (per dimension, only when
         # that dimension is capped). None keeps the fields absent for old readers.
-        step = self._steps[-1] if self._steps else None
         step_remaining_usd: float | None = None
         step_remaining_tokens: int | None = None
         near_step = False
-        if step is not None:
-            if step.max_usd is not None:
-                step_remaining_usd = max(0.0, step.max_usd - step.spent_usd)
-                if step.max_usd <= 0.0:
+        if step_active:
+            if step_max_usd is not None:
+                step_remaining_usd = max(0.0, step_max_usd - step_spent_usd)
+                if step_max_usd <= 0.0:
                     near_step = True
                 else:
-                    s_bps = int(step.spent_usd / step.max_usd * 10000 + 1e-9)
-                    near_step = near_step or s_bps >= self.near_limit_bps
-            if step.max_tokens is not None:
-                step_remaining_tokens = max(0, step.max_tokens - step.spent_tokens)
-                if step.max_tokens <= 0:
+                    s_bps = int(step_spent_usd / step_max_usd * 10000 + 1e-9)
+                    near_step = near_step or s_bps >= near_limit_bps
+            if step_max_tokens is not None:
+                step_remaining_tokens = max(0, step_max_tokens - step_spent_tokens)
+                if step_max_tokens <= 0:
                     near_step = True
                 else:
-                    s_tbps = int(step.spent_tokens / step.max_tokens * 10000 + 1e-9)
-                    near_step = near_step or s_tbps >= self.near_limit_bps
+                    s_tbps = int(step_spent_tokens / step_max_tokens * 10000 + 1e-9)
+                    near_step = near_step or s_tbps >= near_limit_bps
         return BudgetAdvisory(
             # near_limit now also flips when a token ceiling or the active step is
             # near its cap, so a router can downshift before ANY hard-stop.
-            near_limit=used_bps >= self.near_limit_bps or near_token or near_step,
+            near_limit=used_bps >= near_limit_bps or near_token or near_step,
             used_bps=used_bps,
             # Settled budget: limit minus accrued spend, deliberately NOT net of
             # in-flight reservations. This differs from the remaining_usd property
@@ -817,8 +835,8 @@ class BudgetGuard:
             # about money already spent, while the property reports what a new call
             # can still claim.
             remaining_usd=remaining,
-            limit_usd=self.limit_usd,
-            spent_usd=self.spent_usd,
+            limit_usd=limit_usd,
+            spent_usd=spent_usd,
             expected_cost=expected_cost,
             est_calls_remaining=est_calls_remaining,
             token_used_bps=token_used_bps,
@@ -882,6 +900,17 @@ class BudgetGuard:
         # matching the constructor's math.isfinite guard and the TS Number.isFinite.
         if estimated is not None and not math.isfinite(estimated):
             raise ValueError(f"estimated cost must be a finite number, got {estimated!r}")
+
+    @staticmethod
+    def _validate_token_estimate(estimated_tokens: int) -> None:
+        # Reject a float (incl. NaN/inf) or bool token estimate BEFORE reserve()
+        # mutates _reserved_tokens / the step's hold. Otherwise the mutation lands
+        # and BudgetReservation.__post_init__ rejects the handle only afterwards —
+        # leaking the hold — and a NaN cast into the integer token comparisons
+        # would fail-open the ceiling. A negative int is clamped by max(0, ...),
+        # matching the lenient USD estimate. Mirrors the TS Number.isInteger guard.
+        if isinstance(estimated_tokens, bool) or not isinstance(estimated_tokens, int):
+            raise ValueError(f"estimated_tokens must be an int, got {estimated_tokens!r}")
 
     @staticmethod
     def _reserved_usd_of(reserved: ReservationHandle) -> float:

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -25,13 +25,12 @@ See ``examples/streaming_guard.py`` for a runnable demo (no API key).
 
 from __future__ import annotations
 
-import math
 import warnings
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 from .errors import UnpriceableModelError, UnpriceableModelWarning
-from .guard import BudgetGuard
+from .guard import BudgetGuard, ReservationHandle
 from .pricing import ManualPrice, price_tokens
 
 
@@ -71,19 +70,24 @@ class StreamGuard:
         model: str,
         *,
         prompt_tokens: int = 0,
-        reserved: float = 0.0,
+        reserved: ReservationHandle = 0.0,
         price: ManualPrice | None = None,
         label: str | None = None,
         count_tokens: Callable[[str], int] | None = None,
     ) -> None:
         # Same contract as settle(): a bad handle would corrupt the guard's
-        # in-flight tally. Reject it before the stream starts, not at settle time.
-        if not math.isfinite(reserved) or reserved < 0:
-            raise ValueError(f"reserved must be a finite, non-negative number, got {reserved!r}")
+        # in-flight tally. Validate it before the stream starts, not at settle
+        # time. Accepts a plain float (USD-only) OR a BudgetReservation from a
+        # token/step-aware reserve() — a token-aware handle used to crash here.
+        reserved_usd = guard._reserved_usd_of(reserved)
         self._guard = guard
         self._model = model
         self._prompt_tokens = max(0, int(prompt_tokens))
-        self._reserved = float(reserved)
+        # Keep the ORIGINAL handle so settle()/release() drain the token hold too;
+        # keep the USD amount for the stream-cost registry (mid-stream enforcement
+        # is USD-only — a stream's token hold is reconciled at settle()).
+        self._reserved = reserved
+        self._reserved_usd = reserved_usd
         self._price = price
         self._label = label
         self._count = count_tokens or approx_tokens
@@ -109,8 +113,9 @@ class StreamGuard:
             raise UnpriceableModelError(model)
         # Registered AFTER the fail-closed raise so a refused stream leaves no
         # entry; _settle() unregisters, so entries live exactly as long as the
-        # stream. Parallel streams see each other's accrual through this.
-        self._key = guard._stream_register(self._reserved)
+        # stream. Parallel streams see each other's accrual through this. The
+        # registry tracks USD only, so pass the USD amount of the handle.
+        self._key = guard._stream_register(self._reserved_usd)
 
     def feed_text(self, delta: str) -> None:
         """Meter one text delta (token count via the heuristic/``count_tokens``).
@@ -195,7 +200,7 @@ def guard_stream(
     *,
     get_text: Callable[[Any], str] | None = None,
     prompt_tokens: int = 0,
-    reserved: float = 0.0,
+    reserved: ReservationHandle = 0.0,
     price: ManualPrice | None = None,
     label: str | None = None,
     count_tokens: Callable[[str], int] | None = None,

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -213,3 +213,17 @@ def test_stream_guard_accepts_token_reservation() -> None:
     # settle() drained the token hold and accrued prompt+completion (100 + 50).
     assert guard._reserved_tokens == 0
     assert guard.spent_tokens == 150
+
+
+def test_budget_reservation_rejects_bad_fields() -> None:
+    # Public, re-exported value object: a hand-rolled reservation with a NaN usd
+    # or negative/bool tokens must be refused at construction, not silently
+    # corrupt _reserved / _reserved_tokens when passed to settle()/release().
+    with pytest.raises(ValueError):
+        BudgetReservation(usd=float("nan"), tokens=0)
+    with pytest.raises(ValueError):
+        BudgetReservation(usd=-1.0, tokens=0)
+    with pytest.raises(ValueError):
+        BudgetReservation(usd=0.0, tokens=-5)
+    with pytest.raises(ValueError):
+        BudgetReservation(usd=0.0, tokens=True)  # bool is not a valid token count

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -227,3 +227,18 @@ def test_budget_reservation_rejects_bad_fields() -> None:
         BudgetReservation(usd=0.0, tokens=-5)
     with pytest.raises(ValueError):
         BudgetReservation(usd=0.0, tokens=True)  # bool is not a valid token count
+
+
+def test_invalid_token_estimate_rejected_without_leak() -> None:
+    # A float/NaN/inf/bool token estimate must be refused up front — otherwise
+    # reserve() would mutate the in-flight token hold before BudgetReservation
+    # rejected the handle, leaking it and disabling the ceiling.
+    guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
+    for bad in (1.5, float("nan"), float("inf"), True):
+        with pytest.raises(ValueError):
+            guard.reserve(estimated_tokens=bad)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            guard.check(estimated_tokens=bad)  # type: ignore[arg-type]
+    # No phantom hold left behind by the rejected calls.
+    assert guard._reserved_tokens == 0
+    assert guard.remaining_usd == 100.0

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -179,3 +179,37 @@ def test_token_block_is_terminal_like_budget_exceeded() -> None:
     assert issubclass(TokenBudgetExceeded, BudgetExceeded)
     err = TokenBudgetExceeded(600, 500, "step")
     assert isinstance(err, BudgetExceeded)
+
+
+# ── reservation handle lifecycle ────────────────────────────────────────────────
+
+
+def test_reservation_settled_after_owning_step_exits() -> None:
+    # A BudgetReservation may outlive the step() that created it. Settling it once
+    # the step has exited must drain the aggregate token hold (there's no active
+    # step to drain) and accrue the actual counts — not raise.
+    guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
+    with guard.step(max_tokens=5_000) as g:
+        handle = g.reserve(estimated_tokens=1_000)
+        assert isinstance(handle, BudgetReservation)
+    # Step popped; the aggregate hold is still outstanding until we settle it.
+    guard.settle(MODEL, 400, 300, reserved=handle)
+    assert guard._reserved_tokens == 0  # hold fully drained, no phantom left behind
+    assert guard.spent_tokens == 700
+
+
+def test_stream_guard_accepts_token_reservation() -> None:
+    # Regression: a token-aware BudgetReservation (from a token/step-aware
+    # reserve()) must be accepted by StreamGuard — it used to crash on a
+    # float-only isfinite() check before the stream even started.
+    from floe_guard import StreamGuard
+
+    guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
+    handle = guard.reserve(0.01, estimated_tokens=500)
+    assert isinstance(handle, BudgetReservation)
+    with StreamGuard(guard, MODEL, prompt_tokens=100, reserved=handle) as sg:
+        sg.feed_tokens(50)
+        sg.finish(completion_tokens=50)
+    # settle() drained the token hold and accrued prompt+completion (100 + 50).
+    assert guard._reserved_tokens == 0
+    assert guard.spent_tokens == 150

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -1,0 +1,181 @@
+"""Tests for token ceilings and per-step budgets (issue #46).
+
+The feature is a second dimension (tokens) on the existing enforcement choke
+point plus a step scope — so these tests also pin the backward-compat contract:
+an aggregate-only USD guard behaves byte-for-byte as before, including
+``reserve()`` still returning a plain float.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    BudgetReservation,
+    TokenBudgetExceeded,
+)
+
+MODEL = "gpt-4o"  # $2.5e-6/input token, $1e-5/output token
+
+
+# ── aggregate token ceiling ─────────────────────────────────────────────────────
+
+
+def test_aggregate_token_limit_hard_blocks_when_crossing() -> None:
+    guard = BudgetGuard(limit_usd=100.0, token_limit=1_000, on_block=lambda *_: None)
+    guard.record(MODEL, 400, 200)  # 600 tokens accrued
+    # 600 already spent; a 500-token call would cross the 1_000 ceiling.
+    with pytest.raises(TokenBudgetExceeded) as exc:
+        guard.check(estimated_tokens=500)
+    assert exc.value.scope == "aggregate"
+    assert exc.value.limit_tokens == 1_000
+
+
+def test_aggregate_token_reserve_holds_and_blocks() -> None:
+    guard = BudgetGuard(limit_usd=100.0, token_limit=1_000, on_block=lambda *_: None)
+    handle = guard.reserve(0.01, estimated_tokens=900)
+    assert isinstance(handle, BudgetReservation)
+    assert handle.tokens == 900
+    # 900 held in-flight; another 200 would cross → blocked without reserving.
+    with pytest.raises(TokenBudgetExceeded):
+        guard.reserve(0.01, estimated_tokens=200)
+
+
+def test_tokens_accrue_from_all_billed_buckets() -> None:
+    guard = BudgetGuard(limit_usd=100.0, token_limit=10_000)
+    guard.record(
+        MODEL,
+        100,
+        50,
+        cache_creation_input_tokens=10,
+        cache_read_input_tokens=5,
+    )
+    assert guard.spent_tokens == 100 + 50 + 10 + 5
+
+
+def test_token_limit_validation_rejects_bool_and_negative() -> None:
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.0, token_limit=True)  # bool is not a valid int here
+    with pytest.raises(ValueError):
+        BudgetGuard(limit_usd=1.0, token_limit=-1)
+
+
+# ── per-step caps ────────────────────────────────────────────────────────────────
+
+
+def test_step_token_cap_hard_blocks() -> None:
+    guard = BudgetGuard(limit_usd=100.0, on_block=lambda *_: None)  # ample aggregate
+    with guard.step(max_tokens=500) as g:
+        assert g is guard  # yields the SAME guard — no adapter needs to know
+        g.record(MODEL, 300, 100)  # 400 tokens into the step
+        with pytest.raises(TokenBudgetExceeded) as exc:
+            g.check(estimated_tokens=200)  # 400 + 200 > 500
+    assert exc.value.scope == "step"
+    assert exc.value.limit_tokens == 500
+
+
+def test_step_usd_cap_hard_blocks() -> None:
+    guard = BudgetGuard(limit_usd=100.0, on_block=lambda *_: None)
+    with guard.step(max_usd=0.01) as g:
+        with pytest.raises(BudgetExceeded) as exc:
+            g.reserve(0.02)  # one call alone exceeds the step's $0.01
+    # A step USD block is a plain BudgetExceeded (scope lives on the token error).
+    assert not isinstance(exc.value, TokenBudgetExceeded)
+
+
+def test_step_cap_frees_on_exit() -> None:
+    guard = BudgetGuard(limit_usd=100.0, on_block=lambda *_: None)
+    with guard.step(max_tokens=100) as g:
+        with pytest.raises(TokenBudgetExceeded):
+            g.check(estimated_tokens=200)
+    # Outside the step, only the (absent) aggregate token ceiling applies.
+    guard.check(estimated_tokens=1_000_000)  # does not raise
+
+
+def test_step_reservation_returns_budget_reservation() -> None:
+    guard = BudgetGuard(limit_usd=100.0)
+    with guard.step(max_usd=1.0) as g:
+        handle = g.reserve(0.02)  # USD-only, but a step is active
+        assert isinstance(handle, BudgetReservation)
+        g.settle(MODEL, 100, 100, reserved=handle)
+
+
+def test_nested_steps_innermost_blocks_first() -> None:
+    guard = BudgetGuard(limit_usd=100.0, on_block=lambda *_: None)
+    with guard.step(max_tokens=10_000):
+        with guard.step(max_tokens=200) as inner:
+            with pytest.raises(TokenBudgetExceeded) as exc:
+                inner.check(estimated_tokens=500)
+    assert exc.value.limit_tokens == 200  # the inner cap, not the outer
+
+
+# ── advisory ─────────────────────────────────────────────────────────────────────
+
+
+def test_advisory_reports_token_utilization() -> None:
+    guard = BudgetGuard(limit_usd=100.0, token_limit=1_000)
+    guard.record(MODEL, 500, 100)  # 600 / 1000 = 60%
+    adv = guard.advisory()
+    assert adv.token_used_bps == 6000
+    assert adv.remaining_tokens == 400
+
+
+def test_advisory_step_near_limit_fires_before_hard_block() -> None:
+    # near_limit_bps=8000 → advisory flags near at 80% of the step cap, BEFORE
+    # the hard block at 100%, so a router can downshift.
+    guard = BudgetGuard(limit_usd=100.0, near_limit_bps=8000)
+    with guard.step(max_tokens=1_000) as g:
+        g.record(MODEL, 500, 300)  # 800 / 1000 = 80%
+        adv = g.advisory()
+        assert adv.near_limit is True
+        assert adv.step_remaining_tokens == 200
+        # Still under the cap — a fitting call is NOT blocked yet.
+        g.check(estimated_tokens=100)
+
+
+def test_advisory_no_token_fields_when_dimension_unused() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    adv = guard.advisory()
+    assert adv.token_used_bps is None
+    assert adv.remaining_tokens is None
+    assert adv.step_remaining_usd is None
+    assert adv.step_remaining_tokens is None
+
+
+# ── backward-compat regression: aggregate-only USD is unchanged ──────────────────
+
+
+def test_usd_only_reserve_still_returns_plain_float() -> None:
+    # THE regression guard: with no token_limit and no step, reserve() returns a
+    # plain float exactly as before — old callers are byte-for-byte unchanged.
+    guard = BudgetGuard(limit_usd=1.0)
+    handle = guard.reserve(0.0125)
+    assert type(handle) is float
+    assert handle == pytest.approx(0.0125)
+    guard.settle(MODEL, 1_000, 1_000, reserved=handle)
+    assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_usd_only_default_reserve_returns_float_zero() -> None:
+    guard = BudgetGuard(limit_usd=1.0, on_block=lambda *_: None)
+    assert guard.reserve() == 0.0  # first-call default, plain float
+
+
+def test_usd_only_advisory_shape_unchanged() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    guard.record(MODEL, 100, 100)
+    adv = guard.advisory()
+    # The pre-existing fields still populate; the new ones stay None.
+    assert adv.spent_usd == pytest.approx(guard.spent_usd)
+    assert adv.token_used_bps is None
+    assert adv.step_remaining_usd is None
+
+
+def test_token_block_is_terminal_like_budget_exceeded() -> None:
+    # Retry logic treats a block as terminal via isinstance(exc, BudgetExceeded);
+    # TokenBudgetExceeded subclasses it, so a token block is terminal too.
+    assert issubclass(TokenBudgetExceeded, BudgetExceeded)
+    err = TokenBudgetExceeded(600, 500, "step")
+    assert isinstance(err, BudgetExceeded)


### PR DESCRIPTION
Minimal alternative to the open **PR #58** (4,171 LOC), addressing issue **#46** (token ceilings + per-step budgets) in **~1.2k LOC** — a ~3.5x reduction — while keeping strict Python/TS parity.

## Design

The feature is a **second dimension (tokens) on the existing enforcement machinery + a step scope**, not a new reservation system.

- **One choke point, generalized.** The existing `_would_cross` becomes a dimension/scope-aware check (`_blocking_cross_locked` / `blockingCross`) covering: aggregate USD → aggregate tokens → active step USD → active step tokens. `reserve`/`settle`/`release` drain both dims through the *same* "a handle cannot exceed total in-flight" guard already used for the USD float — **no per-handle identity registry**.
- **Backward-compatible reservations.** `reserve()` returns a plain `float`/`number` when no tokens and no active step are involved (old callers byte-for-byte unchanged); otherwise a `BudgetReservation { usd, tokens }`.
- **Step = a stack, not a wrapper class.** `guard.step(...)` pushes a mutable step state and yields the **same guard** (Python context manager `with guard.step(...) as g:`; TS callback `guard.step({...}, (g) => …)`), so **no adapter changes**. Enforcement/accrual honour the innermost step. Sequential loops only — concurrent parallel steps on one guard are explicitly out of scope for #46.
- **Token accrual is free** — it flows through the existing `settle`/`record` token counts; **integration adapters are untouched**.
- **`TokenBudgetExceeded` subclasses `BudgetExceeded`**, so budget-aware retry treats a token block as terminal with zero new wiring.

Deliberately avoided the things that made #58 4x larger: no `CODEBASE_CONVENTIONS.md`, no `StepBudgetGuard` wrapper class / union threaded through adapters, no reservation identity registry, no LangChain `run_id` concurrent-step machinery.

## Public API added

**Python** — `BudgetGuard(..., token_limit=int|None)`; `check(..., estimated_tokens=int)`; `reserve(..., estimated_tokens=int) -> float | BudgetReservation`; `guard.step(*, max_usd=None, max_tokens=None)` (context manager); `guard.spent_tokens`; `BudgetReservation(usd, tokens)`; `ReservationHandle`; `TokenBudgetExceeded(spent_tokens, limit_tokens, scope)`; advisory fields `token_used_bps`, `remaining_tokens`, `step_remaining_usd`, `step_remaining_tokens`.

**TS** — `new BudgetGuard(limit, { tokenLimit })`; `check(cost?, { estimatedTokens })`; `reserve(cost?, { estimatedTokens }) -> number | BudgetReservation`; `guard.step({ maxUsd?, maxTokens? }, (g) => …)`; `guard.spentTokens`; `BudgetReservation`, `ReservationHandle` types; `TokenBudgetExceeded`; advisory fields `tokenUsedBps`, `remainingTokens`, `stepRemainingUsd`, `stepRemainingTokens`.

Version bump: **py 0.12.0 / js 0.9.0**.

## Acceptance (tests, Py + TS parity)

- Per-step USD cap and per-step token cap each hard-block a crossing call (`BudgetExceeded` / `TokenBudgetExceeded` scope="step").
- Aggregate `token_limit` hard-blocks a crossing call (scope="aggregate").
- `advisory()` signals per-step near-limit *before* the hard block and reports token utilization + step headroom.
- **Regression:** aggregate-only USD behaviour is byte-for-byte unchanged with `token_limit`/`step()` unused — including `reserve()` returning a plain float/number.

## Results

- Python: `pytest` **269 passed**; `ruff check` + `ruff format --check` clean on touched files.
- TS: `npm test` **97 passed**; `npm run typecheck` clean; `npm run build` succeeds.
- `src/floe_guard/cost_map.json` == `js/src/cost_map.json` (unchanged).
- New tests: `tests/test_token_step_budgets.py` (16) + `js/test/token-step-budgets.test.ts` (18).
- No-network example: `examples/step_budget.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aggregate token ceilings alongside spending limits.
  * Added per-step USD and token budgets for sequential workflows.
  * Added token-aware reservations, usage tracking, and advisory details.
  * Added clear errors identifying aggregate or step budget overruns.
  * Extended streaming support for token-aware reservations.
  * Preserved existing USD-only behavior for backward compatibility.
* **Documentation**
  * Updated Python and JavaScript guides with configuration details and examples.
  * Added a runnable step-level token budgeting example.
* **Chores**
  * Released Python 0.12.0 and JavaScript 0.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->