### PR TITLE
Non-model budget-adaptation examples (retrieval depth, context, planning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   is `None` / `null` until then (unknown, not zero).
   Additive fields — existing advisory consumers are unaffected.
 
+### Added (py)
+
+- **Non-model budget-adaptation examples** (issue #50):
+  `examples/retrieval_depth.py`, `examples/context_size.py`, and
+  `examples/plan_complexity.py` show `advisory()` driving RAG `top_k`, history and
+  `max_tokens` truncation, and optional-sub-task pruning — each with the model
+  held fixed, so the savings come from the non-model knob. Examples and docs
+  only; no API change.
+
 ## py 0.10.0 / js 0.7.0 — 2026-07-23
 
 ### Added (py + js)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ ignore it; `check()` is what enforces the ceiling. See
 [`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
 (no API key).
 
+Model choice is only one axis. The same signal drives **any** cost lever, and in
+most agents the bigger levers are elsewhere — retrieval depth
+([`examples/retrieval_depth.py`](examples/retrieval_depth.py): RAG `top_k` falls
+20 → 12 → 5), context size
+([`examples/context_size.py`](examples/context_size.py): stop resending the whole
+transcript, cap replies shorter), and plan complexity
+([`examples/plan_complexity.py`](examples/plan_complexity.py): thin the reasoning,
+then drop the optional sub-tasks to protect the required ones). Each holds the
+model fixed and shrinks a non-model parameter as the budget drains (no API key).
+
 ### Budget-aware retry
 
 Blind retries can spend the same expensive path again right when the agent is

--- a/examples/context_size.py
+++ b/examples/context_size.py
@@ -55,6 +55,7 @@ def stub_chat_call(turns_sent: int, max_tokens: int) -> dict[str, object]:
 
 
 def main() -> None:
+    """Run the context size adaptation example."""
     # Taper at 70% used so there's room to trim before the ceiling.
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · context size adapts")

--- a/examples/context_size.py
+++ b/examples/context_size.py
@@ -1,0 +1,107 @@
+"""Context size adapts to budget — history and ``max_tokens`` shrink, the model doesn't.
+
+No API key, no account, no network. A stub chat call returns the token usage a
+real provider would report; the conversation history grows every turn, and once
+``BudgetGuard.advisory()`` reports ``near_limit`` the agent stops resending the
+whole transcript and caps its replies shorter.
+
+The model is a constant here on purpose. A long-running conversation gets more
+expensive per turn even on a fixed model, because the prompt carries every turn
+before it — so trimming the context is the lever, not downgrading the model.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee. (Hosted Floe returns the same advisory shape, but across every
+vendor/cap with server-truth balances — your taper logic ports unchanged.)
+
+Run:  python examples/context_size.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetAdvisory, BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # fixed for the whole run: only the context size adapts
+
+SYSTEM_PROMPT_TOKENS = 400
+TOKENS_PER_TURN = 400
+MAX_TOKENS_FULL = 800  # full replies while there's headroom
+MAX_TOKENS_TAPER = 250  # terser replies near the cap
+KEEP_RECENT_TURNS = 2  # how much transcript survives the trim
+
+
+def plan_context(adv: BudgetAdvisory, turns_held: int) -> tuple[int, int]:
+    """The whole adaptation: how much history to resend, and how long a reply.
+
+    Returns ``(turns_to_send, max_tokens)``. Near the cap the agent keeps only
+    the most recent turns instead of the full transcript.
+    """
+    if adv.near_limit:
+        return min(turns_held, KEEP_RECENT_TURNS), MAX_TOKENS_TAPER
+    return turns_held, MAX_TOKENS_FULL
+
+
+def prompt_tokens_for(turns_sent: int) -> int:
+    """The resent transcript is the part of the prompt the agent controls."""
+    return SYSTEM_PROMPT_TOKENS + turns_sent * TOKENS_PER_TURN
+
+
+def stub_chat_call(turns_sent: int, max_tokens: int) -> dict[str, object]:
+    """A fake chat completion — no network, no key."""
+    return {
+        "model": MODEL,
+        "prompt_tokens": prompt_tokens_for(turns_sent),
+        "completion_tokens": max_tokens,
+    }
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to trim before the ceiling.
+    guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · context size adapts")
+    print(
+        f"  full transcript + max_tokens {MAX_TOKENS_FULL} → last {KEEP_RECENT_TURNS} turns "
+        f"+ max_tokens {MAX_TOKENS_TAPER} at {guard.near_limit_bps / 100:.0f}% used\n"
+    )
+
+    history: list[str] = []
+    turn = 0
+    trimmed = False
+    while True:
+        turn += 1
+        history.append(f"turn {turn}")
+        adv = guard.advisory()
+        turns_sent, max_tokens = plan_context(adv, len(history))
+        if turns_sent < len(history) and not trimmed:
+            trimmed = True
+            print(
+                f"  [advisory] {adv.used_bps / 100:.0f}% used, "
+                f"${adv.remaining_usd:.4f} left → trimming to the last "
+                f"{turns_sent} turns, max_tokens {max_tokens}\n"
+            )
+
+        # Request-sized: the prompt grows with the transcript, so the last call's
+        # cost under-predicts the next one. estimate_call() prices THIS request.
+        est = guard.estimate_call(MODEL, prompt_tokens_for(turns_sent), max_tokens)
+        try:
+            guard.check(est)  # the hard guarantee — trimmed or not, this holds the line
+        except BudgetExceeded:
+            print(
+                f"\nStopped at turn {turn}. "
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            )
+            break
+
+        response = stub_chat_call(turns_sent, max_tokens)
+        cost = guard.record(
+            str(response["model"]),
+            int(response["prompt_tokens"]),  # type: ignore[arg-type]
+            int(response["completion_tokens"]),  # type: ignore[arg-type]
+        )
+        print(
+            f"  turn {turn:>2}: {turns_sent:>2} of {len(history):>2} turns sent · "
+            f"max_tokens {max_tokens:>3}  +${cost:.4f}  (total ${guard.spent_usd:.4f})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plan_complexity.py
+++ b/examples/plan_complexity.py
@@ -64,7 +64,7 @@ def stub_subtask_call(reasoning_steps: int) -> dict[str, object]:
 
 
 def main() -> None:
-    # Taper at 70% used so there's room to simplify before the ceiling.
+    # Reasoning thins at 40% used (TAPER_BPS), optional tasks drop at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     required = sum(1 for _, is_required, _ in PLAN if is_required)
     print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · plan complexity adapts")

--- a/examples/plan_complexity.py
+++ b/examples/plan_complexity.py
@@ -1,0 +1,126 @@
+"""Plan complexity adapts to budget — optional sub-tasks drop, the model doesn't.
+
+No API key, no account, no network. A stub sub-task call returns the token usage
+a real provider would report; the agent works through the same plan every round
+and reads ``BudgetGuard.advisory()`` before choosing how ambitious that round is:
+fewer reasoning steps first, then the optional sub-tasks stop running at all.
+
+The model is a constant here on purpose. Dropping work the task does not require
+protects the sub-tasks that it does require, so the agent finishes its mandatory
+plan on budget instead of being cut off partway through a lavish one.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee. (Hosted Floe returns the same advisory shape, but across every
+vendor/cap with server-truth balances — your taper logic ports unchanged.)
+
+Run:  python examples/plan_complexity.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetAdvisory, BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # fixed for the whole run: only the plan adapts
+
+# (sub-task, required, reasoning steps at full complexity)
+PLAN = (
+    ("gather sources", True, 3),
+    ("cross-check claims", False, 3),
+    ("draft answer", True, 2),
+    ("polish tone", False, 2),
+)
+
+TAPER_BPS = 4000  # thin the reasoning at 40% used, before near_limit trips
+PROMPT_TOKENS_PER_SUBTASK = 600
+COMPLETION_TOKENS_PER_STEP = 400
+
+
+def plan_round(adv: BudgetAdvisory) -> tuple[bool, bool]:
+    """The whole adaptation: how much of the plan this round can afford.
+
+    Returns ``(run_optional, full_reasoning)``. Reasoning depth is cut first
+    because it degrades quality gradually; the optional sub-tasks are dropped
+    only once ``near_limit`` trips, to protect the required ones.
+    """
+    if adv.near_limit:
+        return False, False
+    if adv.used_bps >= TAPER_BPS:
+        return True, False
+    return True, True
+
+
+def reasoning_steps_for(steps: int, full_reasoning: bool) -> int:
+    # One pass fewer, never zero — a sub-task that runs still has to produce an answer.
+    return steps if full_reasoning else max(1, steps - 1)
+
+
+def stub_subtask_call(reasoning_steps: int) -> dict[str, object]:
+    """A fake sub-task call — no network, no key."""
+    return {
+        "model": MODEL,
+        "prompt_tokens": PROMPT_TOKENS_PER_SUBTASK,
+        "completion_tokens": reasoning_steps * COMPLETION_TOKENS_PER_STEP,
+    }
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to simplify before the ceiling.
+    guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
+    required = sum(1 for _, is_required, _ in PLAN if is_required)
+    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · plan complexity adapts")
+    print(
+        f"  {len(PLAN)} sub-tasks ({required} required) · thinner reasoning at "
+        f"{TAPER_BPS / 100:.0f}% used · optional dropped at "
+        f"{guard.near_limit_bps / 100:.0f}%\n"
+    )
+
+    round_no = 0
+    completed_required = 0
+    stopped = False
+    while not stopped:
+        round_no += 1
+        adv = guard.advisory()
+        run_optional, full_reasoning = plan_round(adv)
+        planned = len(PLAN) if run_optional else required
+        print(
+            f"  round {round_no}: {planned} of {len(PLAN)} sub-tasks · "
+            f"{'full' if full_reasoning else 'reduced'} reasoning  "
+            f"[{adv.used_bps / 100:.0f}% used, ${adv.remaining_usd:.4f} left]"
+        )
+
+        for name, is_required, steps in PLAN:
+            if not is_required and not run_optional:
+                print(f"    {name:<19} [skipped — optional]")
+                continue
+
+            reasoning_steps = reasoning_steps_for(steps, full_reasoning)
+            est = guard.estimate_call(
+                MODEL, PROMPT_TOKENS_PER_SUBTASK, reasoning_steps * COMPLETION_TOKENS_PER_STEP
+            )
+            try:
+                guard.check(est)  # the hard guarantee — simplified or not, this holds the line
+            except BudgetExceeded:
+                print(f"    {name:<19} [blocked — would cross the ceiling]")
+                stopped = True
+                break
+
+            response = stub_subtask_call(reasoning_steps)
+            cost = guard.record(
+                str(response["model"]),
+                int(response["prompt_tokens"]),  # type: ignore[arg-type]
+                int(response["completion_tokens"]),  # type: ignore[arg-type]
+            )
+            if is_required:
+                completed_required += 1
+            plural = "s" if reasoning_steps > 1 else ""
+            steps_label = f"{reasoning_steps} reasoning step{plural}"
+            print(f"    {name:<19} {steps_label:<18} +${cost:.4f}  (total ${guard.spent_usd:.4f})")
+
+    print(
+        f"\nStopped in round {round_no} after {completed_required} required sub-tasks. "
+        f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plan_complexity.py
+++ b/examples/plan_complexity.py
@@ -50,6 +50,7 @@ def plan_round(adv: BudgetAdvisory) -> tuple[bool, bool]:
 
 
 def reasoning_steps_for(steps: int, full_reasoning: bool) -> int:
+    """Calculate the number of reasoning steps to execute."""
     # One pass fewer, never zero — a sub-task that runs still has to produce an answer.
     return steps if full_reasoning else max(1, steps - 1)
 
@@ -64,6 +65,7 @@ def stub_subtask_call(reasoning_steps: int) -> dict[str, object]:
 
 
 def main() -> None:
+    """Run the plan complexity adaptation example."""
     # Reasoning thins at 40% used (TAPER_BPS), optional tasks drop at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     required = sum(1 for _, is_required, _ in PLAN if is_required)

--- a/examples/retrieval_depth.py
+++ b/examples/retrieval_depth.py
@@ -1,0 +1,105 @@
+"""Retrieval depth adapts to budget — ``top_k`` shrinks, the model never changes.
+
+No API key, no account, no network. A stub retrieve-then-generate step returns
+the token usage a real provider would report; before each step the agent reads
+``BudgetGuard.advisory()`` and pulls fewer chunks into the context window as the
+remaining budget drains.
+
+The model is a constant here on purpose. Model choice is only one adaptation
+axis — in a RAG agent most of the bill is prompt tokens the retriever decided to
+send, so ``top_k`` is the cheaper lever to pull first.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee. (Hosted Floe returns the same advisory shape, but across every
+vendor/cap with server-truth balances — your taper logic ports unchanged.)
+
+Run:  python examples/retrieval_depth.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetAdvisory, BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # fixed for the whole run: only the retrieval depth adapts
+
+TOP_K_FULL = 20  # ~$0.0130 / step
+TOP_K_TAPER = 12  # ~$0.0098 / step
+TOP_K_FLOOR = 5  # ~$0.0070 / step
+
+TAPER_BPS = 4000  # first downshift at 40% used, before near_limit trips
+BASE_PROMPT_TOKENS = 400  # system prompt + question, independent of top_k
+TOKENS_PER_CHUNK = 160
+MAX_COMPLETION_TOKENS = 400
+
+
+def prompt_tokens_for(top_k: int) -> int:
+    """Retrieved chunks are the part of the prompt the agent controls."""
+    return BASE_PROMPT_TOKENS + top_k * TOKENS_PER_CHUNK
+
+
+def stub_rag_call(top_k: int) -> dict[str, object]:
+    """A fake retrieve-then-generate call — no network, no key."""
+    return {
+        "model": MODEL,
+        "prompt_tokens": prompt_tokens_for(top_k),
+        "completion_tokens": MAX_COMPLETION_TOKENS,
+    }
+
+
+def choose_top_k(adv: BudgetAdvisory) -> int:
+    """The whole adaptation: retrieve shallower as utilization climbs."""
+    if adv.near_limit:
+        return TOP_K_FLOOR
+    if adv.used_bps >= TAPER_BPS:
+        return TOP_K_TAPER
+    return TOP_K_FULL
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to downshift before the ceiling.
+    guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · retrieval depth adapts")
+    print(
+        f"  {TOP_K_FULL} chunks → {TOP_K_TAPER} at {TAPER_BPS / 100:.0f}% used "
+        f"→ {TOP_K_FLOOR} at {guard.near_limit_bps / 100:.0f}%\n"
+    )
+
+    step = 0
+    depth = TOP_K_FULL
+    while True:
+        step += 1
+        adv = guard.advisory()
+        top_k = choose_top_k(adv)
+        if top_k != depth:
+            print(
+                f"  [advisory] {adv.used_bps / 100:.0f}% used, "
+                f"${adv.remaining_usd:.4f} left → retrieving {top_k} chunks, not {depth}\n"
+            )
+            depth = top_k
+
+        # Request-sized: the prompt changes with top_k every step, so the last
+        # call's cost is the wrong prediction. estimate_call() prices THIS one.
+        est = guard.estimate_call(MODEL, prompt_tokens_for(top_k), MAX_COMPLETION_TOKENS)
+        try:
+            guard.check(est)  # the hard guarantee — taper or not, this holds the line
+        except BudgetExceeded:
+            print(
+                f"\nStopped at step {step}. "
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            )
+            break
+
+        response = stub_rag_call(top_k)
+        cost = guard.record(
+            str(response["model"]),
+            int(response["prompt_tokens"]),  # type: ignore[arg-type]
+            int(response["completion_tokens"]),  # type: ignore[arg-type]
+        )
+        print(
+            f"  step {step:>2}: {MODEL:<8} {top_k:>2} chunks  "
+            f"+${cost:.4f}  (total ${guard.spent_usd:.4f})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/retrieval_depth.py
+++ b/examples/retrieval_depth.py
@@ -56,7 +56,7 @@ def choose_top_k(adv: BudgetAdvisory) -> int:
 
 
 def main() -> None:
-    # Taper at 70% used so there's room to downshift before the ceiling.
+    # First downshift at 40% used (TAPER_BPS), final floor at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · retrieval depth adapts")
     print(

--- a/examples/retrieval_depth.py
+++ b/examples/retrieval_depth.py
@@ -56,6 +56,7 @@ def choose_top_k(adv: BudgetAdvisory) -> int:
 
 
 def main() -> None:
+    """Run the retrieval depth adaptation example."""
     # First downshift at 40% used (TAPER_BPS), final floor at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · retrieval depth adapts")

--- a/tests/test_non_model_adaptation.py
+++ b/tests/test_non_model_adaptation.py
@@ -31,6 +31,7 @@ def _run_example(name: str, capsys: pytest.CaptureFixture[str]) -> str:
 def test_retrieval_depth_example_shrinks_top_k_without_switching_models(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Verify retrieval depth shrinks and the model remains constant."""
     # Ensure no account/key is involved.
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -52,6 +53,7 @@ def test_retrieval_depth_example_shrinks_top_k_without_switching_models(
 def test_context_size_example_trims_history_and_max_tokens(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Verify context size and reply cap shrink."""
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
@@ -71,6 +73,7 @@ def test_context_size_example_trims_history_and_max_tokens(
 def test_plan_complexity_example_drops_optional_subtasks(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Verify reasoning steps reduce and optional subtasks are dropped."""
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 

--- a/tests/test_non_model_adaptation.py
+++ b/tests/test_non_model_adaptation.py
@@ -1,0 +1,88 @@
+"""The non-model adaptation examples must run offline and visibly shrink a non-model knob.
+
+Issue #50: ``advisory()`` drives any cost axis, not just model choice. Each example
+holds the model fixed, so these tests assert two things — the non-model parameter
+really did step down, and no model downgrade sneaked in to explain the savings.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _run_example(name: str, capsys: pytest.CaptureFixture[str]) -> str:
+    """Import and run an example the way a user would, returning everything it printed."""
+    sys.path.insert(0, str(EXAMPLES))
+    try:
+        importlib.import_module(name).main()
+    finally:
+        sys.path.remove(str(EXAMPLES))
+    out = capsys.readouterr()
+    return out.out + out.err
+
+
+def test_retrieval_depth_example_shrinks_top_k_without_switching_models(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Ensure no account/key is involved.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    combined = _run_example("retrieval_depth", capsys)
+
+    # The adapted axis: retrieval depth walks all the way down. Match the step
+    # lines, not the header — a header substring would pass even if top_k froze.
+    assert "20 chunks  +$" in combined
+    assert "12 chunks  +$" in combined
+    assert "5 chunks  +$" in combined
+    # ...and the model did NOT change, so the savings came from top_k alone.
+    assert "model fixed at gpt-4o" in combined
+    assert "gpt-4o-mini" not in combined
+    assert "held under $0.10" in combined
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+def test_context_size_example_trims_history_and_max_tokens(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    combined = _run_example("context_size", capsys)
+
+    # Both context knobs move: the resent transcript and the reply cap. Anchored
+    # to the step lines, since the header mentions both caps unconditionally.
+    assert "trimming to the last 2 turns" in combined
+    assert "turns sent · max_tokens 800" in combined
+    assert "turns sent · max_tokens 250" in combined
+    assert "model fixed at gpt-4o" in combined
+    assert "gpt-4o-mini" not in combined
+    assert "held under $0.10" in combined
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+def test_plan_complexity_example_drops_optional_subtasks(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    combined = _run_example("plan_complexity", capsys)
+
+    # Reasoning thins out first, then the optional sub-tasks stop running.
+    assert "full reasoning" in combined
+    assert "reduced reasoning" in combined
+    assert "[skipped — optional]" in combined
+    # The required sub-tasks are what the taper protects.
+    assert "required sub-tasks" in combined
+    assert "model fixed at gpt-4o" in combined
+    assert "gpt-4o-mini" not in combined
+    assert "held under $0.10" in combined
+    assert "OPENAI_API_KEY" not in os.environ


### PR DESCRIPTION
## Summary                                                                                                                          
   
Adds three stub-based examples showing `advisory()` driving non-model cost levers - retrieval depth, context size, and plan complexity - each holding the model fixed so the savings come from the non-model knob. Includes a README note clarifying that `advisory()` drives any adaptation axis, not just model choice.
    
## Changes                                                                                                                          
 - `examples/retrieval_depth.py` — RAG `top_k` tapers 20 → 12 → 5 as budget drains                                                   
 - `examples/context_size.py` — conversation history and `max_tokens` shrink near the cap                                            
 - `examples/plan_complexity.py` — reasoning steps thin, then optional sub-tasks are dropped                                         
 - `tests/test_non_model_adaptation.py` — verifies each example runs offline, the non-model                                          
      parameter visibly stepped down, and the model stayed fixed                                                                        
 - `README.md` — new paragraph in "Context-aware budgeting" linking all three examples                                               
 - `CHANGELOG.md` — `Added (py)` entry under Unreleased
 
 ## Testing                                                                                                                          
 All examples run standalone offline with no API key.                                                                                
                                                                                                                                        
 - [x] `pytest` passes (Python changes)                                                                                              
 - [x] `ruff check .` and `ruff format .` are clean (Python changes)                                                                 
 - [ ] ~~`npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)~~ N/A — no TS changes                                 
 - [ ] ~~Cost-map copies still match~~ N/A — cost map not touched                                                                    
 - [x] CHANGELOG.md updated (user-facing changes)                                                                                    
                                                                                                                                        
## Related issues                                                                                                                   
Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline examples showing budget-aware adjustments to retrieval depth, conversation context, and task complexity.
  * Expanded documentation with guidance on reducing non-model costs as budget limits approach.
* **Tests**
  * Added coverage verifying these examples reduce costs while keeping the selected model unchanged and requiring no API keys or network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->