### PR TITLE
Add stub examples for non-model budget adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,17 @@ ignore it; `check()` is what enforces the ceiling. See
 [`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
 (no API key).
 
+Model choice is only one adaptation axis — `advisory()` drives whatever lever
+dominates your agent's spend. Runnable stub demos (no API key) for the other
+common ones:
+
+- [`examples/budget_aware_retrieval.py`](examples/budget_aware_retrieval.py) —
+  RAG retrieval depth: `top_k` shrinks 20 → 5 past `near_limit`
+- [`examples/budget_aware_context.py`](examples/budget_aware_context.py) —
+  context size: history window and `max_tokens` shrink near the cap
+- [`examples/budget_aware_planning.py`](examples/budget_aware_planning.py) —
+  plan complexity: optional sub-tasks (critique, polish) drop off near the cap
+
 ### Budget-aware retry
 
 Blind retries can spend the same expensive path again right when the agent is

--- a/examples/budget_aware_context.py
+++ b/examples/budget_aware_context.py
@@ -59,7 +59,7 @@ def main() -> None:
         except BudgetExceeded:
             print(
                 f"\nStopped at turn {turn}. "
-                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+                f"Final spend ${guard.spent_usd:.4f} against the ${guard.limit_usd:.2f} ceiling."
             )
             break
 

--- a/examples/budget_aware_context.py
+++ b/examples/budget_aware_context.py
@@ -1,0 +1,77 @@
+"""Budget-aware context size — history window and max_tokens shrink near the cap.
+
+No API key, no account, no network. Model choice stays FIXED: the levers here
+are how much conversation history rides along on every turn and how long the
+reply is allowed to be. Chat agents resend history each turn, so context is a
+compounding cost — the longest turns arrive exactly when the budget is lowest.
+Once ``advisory().near_limit`` trips, the agent truncates history to the last
+few turns and caps the completion, trading verbosity for staying alive.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee.
+
+Run:  python examples/budget_aware_context.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # never changes — the levers are history window and max_tokens
+TOKENS_PER_TURN = 400  # each kept history turn adds prompt tokens
+FULL_WINDOW = 12  # turns of history on a healthy budget
+NEAR_WINDOW = 3  # turns of history once near_limit trips
+FULL_MAX_TOKENS = 800
+NEAR_MAX_TOKENS = 200
+
+
+def stub_llm(history_turns: int, max_tokens: int) -> dict[str, int]:
+    """A fake chat call — prompt scales with history, completion hits max_tokens."""
+    return {
+        "prompt_tokens": 300 + TOKENS_PER_TURN * history_turns,
+        "completion_tokens": max_tokens,
+    }
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to truncate before the ceiling.
+    guard = BudgetGuard(limit_usd=0.40, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+
+    history: list[int] = []  # one entry per past turn
+    turn = 0
+    tapered = False
+    while True:
+        turn += 1
+        adv = guard.advisory()
+        window = NEAR_WINDOW if adv.near_limit else FULL_WINDOW
+        max_tokens = NEAR_MAX_TOKENS if adv.near_limit else FULL_MAX_TOKENS
+        if adv.near_limit and not tapered:
+            tapered = True
+            print(
+                f"  [advisory] {adv.used_bps / 100:.0f}% used, ${adv.remaining_usd:.4f} left "
+                f"→ history {FULL_WINDOW} → {NEAR_WINDOW} turns, "
+                f"max_tokens {FULL_MAX_TOKENS} → {NEAR_MAX_TOKENS}\n"
+            )
+
+        try:
+            guard.check()  # the hard guarantee — long or short context, this holds the line
+        except BudgetExceeded:
+            print(
+                f"\nStopped at turn {turn}. "
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            )
+            break
+
+        kept = min(len(history), window)
+        usage = stub_llm(kept, max_tokens)
+        cost = guard.record(MODEL, usage["prompt_tokens"], usage["completion_tokens"])
+        history.append(turn)
+        print(
+            f"  turn {turn:>2}: history={kept:>2}/{len(history) - 1:<2} max_tokens={max_tokens:<3} "
+            f"+${cost:.4f}  (total ${guard.spent_usd:.4f})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/budget_aware_planning.py
+++ b/examples/budget_aware_planning.py
@@ -60,7 +60,7 @@ def main() -> None:
     except BudgetExceeded:
         print(
             f"\nStopped at item {item}. "
-            f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            f"Final spend ${guard.spent_usd:.4f} against the ${guard.limit_usd:.2f} ceiling."
         )
 
 

--- a/examples/budget_aware_planning.py
+++ b/examples/budget_aware_planning.py
@@ -1,0 +1,68 @@
+"""Budget-aware planning — optional sub-tasks drop off the plan near the cap.
+
+No API key, no account, no network. Model choice stays FIXED: the lever here is
+plan complexity. Each work item expands into sub-tasks (draft, critique,
+polish), and every sub-task is a metered LLM call. On a healthy budget the
+agent runs the full plan; once ``advisory().near_limit`` trips it keeps only
+the core sub-task, finishing every remaining item at reduced depth instead of
+finishing half of them at full depth.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee.
+
+Run:  python examples/budget_aware_planning.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # never changes — the lever is how many sub-tasks each item gets
+FULL_PLAN = ["draft", "critique", "polish"]  # core + optional refinement passes
+NEAR_PLAN = ["draft"]  # core only, once near_limit trips
+
+
+def stub_llm(subtask: str) -> dict[str, int]:
+    """A fake sub-task call — refinement passes read more context than drafting."""
+    prompt = {"draft": 600, "critique": 900, "polish": 900}[subtask]
+    return {"prompt_tokens": prompt, "completion_tokens": 400}
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to simplify the plan before the ceiling.
+    guard = BudgetGuard(limit_usd=0.35, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+
+    item = 0
+    tapered = False
+    try:
+        while True:
+            item += 1
+            adv = guard.advisory()
+            plan = NEAR_PLAN if adv.near_limit else FULL_PLAN
+            if adv.near_limit and not tapered:
+                tapered = True
+                print(
+                    f"  [advisory] {adv.used_bps / 100:.0f}% used, "
+                    f"${adv.remaining_usd:.4f} left → plan "
+                    f"{'+'.join(FULL_PLAN)} → {'+'.join(NEAR_PLAN)}\n"
+                )
+
+            item_cost = 0.0
+            for subtask in plan:
+                guard.check()  # the hard guarantee — before every sub-task call
+                usage = stub_llm(subtask)
+                item_cost += guard.record(MODEL, usage["prompt_tokens"], usage["completion_tokens"])
+            print(
+                f"  item {item:>2}: {len(plan)} sub-task(s) [{', '.join(plan)}] "
+                f"+${item_cost:.4f}  (total ${guard.spent_usd:.4f})"
+            )
+    except BudgetExceeded:
+        print(
+            f"\nStopped at item {item}. "
+            f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/budget_aware_retrieval.py
+++ b/examples/budget_aware_retrieval.py
@@ -1,0 +1,77 @@
+"""Budget-aware retrieval depth — RAG top_k shrinks as the budget drains.
+
+No API key, no account, no network. Model choice stays FIXED throughout: the
+adaptation lever here is how many retrieved chunks get stuffed into the prompt.
+Every chunk costs prompt tokens, so retrieval depth is often a bigger spend
+lever than the model picker. Once ``advisory().near_limit`` trips, the agent
+drops from 20 chunks to 5 and keeps answering questions instead of slamming
+into the hard-stop mid-run.
+
+The advisory is a *soft* signal you choose to act on; ``check()`` is still the
+hard guarantee.
+
+Run:  python examples/budget_aware_retrieval.py
+"""
+
+from __future__ import annotations
+
+from floe_guard import BudgetExceeded, BudgetGuard
+
+MODEL = "gpt-4o"  # never changes — the lever is top_k, not the model
+FULL_K = 20  # chunks per query on a healthy budget
+NEAR_K = 5  # chunks per query once near_limit trips
+TOKENS_PER_CHUNK = 150  # each retrieved chunk adds prompt tokens
+COMPLETION_TOKENS = 300
+
+
+def stub_retriever(query_id: int, top_k: int) -> list[str]:
+    """A fake vector store — returns top_k 'chunks' for the query."""
+    return [f"chunk-{query_id}-{i}" for i in range(top_k)]
+
+
+def stub_llm(chunks: list[str]) -> dict[str, int]:
+    """A fake RAG call — prompt size scales with retrieval depth."""
+    return {
+        "prompt_tokens": 200 + TOKENS_PER_CHUNK * len(chunks),
+        "completion_tokens": COMPLETION_TOKENS,
+    }
+
+
+def main() -> None:
+    # Taper at 70% used so there's room to shrink retrieval before the ceiling.
+    guard = BudgetGuard(limit_usd=0.30, near_limit_bps=7000)
+    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+
+    query = 0
+    tapered = False
+    while True:
+        query += 1
+        adv = guard.advisory()
+        top_k = NEAR_K if adv.near_limit else FULL_K
+        if adv.near_limit and not tapered:
+            tapered = True
+            print(
+                f"  [advisory] {adv.used_bps / 100:.0f}% used, "
+                f"${adv.remaining_usd:.4f} left → top_k {FULL_K} → {NEAR_K}\n"
+            )
+
+        try:
+            guard.check()  # the hard guarantee — deep or shallow, this holds the line
+        except BudgetExceeded:
+            print(
+                f"\nStopped at query {query}. "
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+            )
+            break
+
+        chunks = stub_retriever(query, top_k)
+        usage = stub_llm(chunks)
+        cost = guard.record(MODEL, usage["prompt_tokens"], usage["completion_tokens"])
+        print(
+            f"  query {query:>2}: top_k={top_k:<2}  {usage['prompt_tokens']:>4} prompt tok  "
+            f"+${cost:.4f}  (total ${guard.spent_usd:.4f})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/budget_aware_retrieval.py
+++ b/examples/budget_aware_retrieval.py
@@ -60,7 +60,7 @@ def main() -> None:
         except BudgetExceeded:
             print(
                 f"\nStopped at query {query}. "
-                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+                f"Final spend ${guard.spent_usd:.4f} against the ${guard.limit_usd:.2f} ceiling."
             )
             break
 


### PR DESCRIPTION
Adds three runnable, offline examples showing `advisory()` driving adaptation axes other than model choice, per #50:

- `budget_aware_retrieval.py` -- RAG retrieval depth: `top_k` shrinks 20 -> 5 past `near_limit`
- `budget_aware_context.py` -- context size: history window and `max_tokens` shrink near the cap
- `budget_aware_planning.py` -- plan complexity: optional sub-tasks (critique, polish) drop off near the cap

Each mirrors `budget_aware.py`'s shape, keeps the model **fixed** so the non-model lever is the visible change, and finishes under the ceiling with `check()` as the hard stop. README gets a short note that `advisory()` drives any adaptation axis, with links to the three demos.

`ruff check` and `ruff format` are clean. Test suite matches main on my machine: 212 passed; the two async retry failures in `test_budget_retry.py` pre-exist on main for me (Python 3.13), unrelated to this change.

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three offline demonstrations of budget-aware adaptation for retrieval depth, conversation context, and planning complexity.
  * Examples dynamically reduce work as spending approaches configured thresholds and stop safely when the budget is exceeded.
  * Added progress and final usage reporting for each demonstration.

* **Documentation**
  * Added README guidance covering the new budget-aware examples, which run without an API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->