### PR TITLE
feat: persistent utc-day budget (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.12.0 / js 0.9.0
+## Unreleased — py 0.13.0 / js 0.9.0
 
 ### Added (py)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.11.0 / js 0.8.0
+## Unreleased — py 0.12.0 / js 0.8.0
+
+### Added (py)
+
+- **Persistent UTC-day budgets** (issue #47): `BudgetGuard(...,
+  window="utc-day", store=SqliteStore(path))` keeps spend and in-flight
+  reservations in dependency-free SQLite transactions, so sequential and
+  overlapping Python processes share one daily ceiling. With no store/window,
+  the existing in-memory behavior is unchanged.
 
 ### Added (py + js)
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ be the thing standing in front of the next call:
 
 ### Persist one UTC-day budget across processes (Python)
 
-Cron and serverless jobs can share one ceiling through the standard-library
-SQLite store:
+Cron and serverless jobs can share one ceiling only when every process opens the
+same database file on storage with reliable SQLite file locking. Isolated
+serverless instances with separate local files do not coordinate; use hosted
+enforcement when no shared file is available:
 
 ```python
 from floe_guard import BudgetGuard, SqliteStore

--- a/README.md
+++ b/README.md
@@ -105,6 +105,31 @@ be the thing standing in front of the next call:
   [LiteLLM cost map](src/floe_guard/cost_map.json) and adds the USD to a running
   total.
 
+### Persist one UTC-day budget across processes (Python)
+
+Cron and serverless jobs can share one ceiling through the standard-library
+SQLite store:
+
+```python
+from floe_guard import BudgetGuard, SqliteStore
+
+guard = BudgetGuard(
+    limit_usd=5.00,
+    window="utc-day",
+    store=SqliteStore("agent-budget.sqlite3"),
+)
+reservation = guard.reserve_tool(0.02)  # atomic across sharing processes
+guard.settle_tool("search", 0.02, reserved=reservation)
+```
+
+One database file represents one logical budget. Settled spend and in-flight
+reservations persist until a new UTC date selects a fresh window; per-call logs,
+tool attribution, and next-call estimates remain process-local. A process that
+dies with a reservation leaves a fail-closed hold that must be recovered
+manually. This feature is Python-only and supports `window="utc-day"` only;
+arbitrary rolling durations are not yet supported. As elsewhere, enforcement is
+estimate-based, so size reservations to the real request when possible.
+
 ### Unpriceable models fail closed
 
 If a model isn't in the cost map and you didn't supply a price, the guard **warns
@@ -210,7 +235,8 @@ for a no-network demo.
 This is the **same advisory shape** hosted Floe returns on every proxied call
 (the `X-Floe-Budget-Advisory` header), so the logic you write here ports
 unchanged — hosted just answers across *every* vendor and cap with server-truth
-balances and rolling-window reset timing, which a single local budget can't know.
+balances and arbitrary rolling-window timing, which a local UTC-day budget can't
+know.
 The TS package exposes the identical `guard.advisory()`.
 
 ## Per-call spend log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.12.0"
+version = "0.13.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.11.0"
+version = "0.12.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -38,7 +38,7 @@ from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.12.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.13.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -2,8 +2,9 @@
 
 Hard-stops an agent before its next LLM or paid tool call when it would cross a
 spend ceiling — tokens and tool costs share one local ceiling.
-Zero account, no network, runs in-process. Hosted Floe is the un-bypassable,
-cross-vendor upgrade path (see the README).
+Zero account and no network; enforcement runs locally, with optional SQLite
+state shared across processes. Hosted Floe is the un-bypassable, cross-vendor
+upgrade path (see the README).
 
     from floe_guard import BudgetGuard
 
@@ -27,14 +28,17 @@ from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
 from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
+from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.10.0"  # keep in lockstep with pyproject.toml
+__version__ = "0.12.0"  # keep in lockstep with pyproject.toml
 
 __all__ = [
     "BudgetGuard",
     "BudgetAdvisory",
     "SpendEvent",
+    "StateStore",
+    "SqliteStore",
     "LatencyBudget",
     "LatencyAdvisory",
     "StreamGuard",

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -1,4 +1,4 @@
-"""The local, in-process budget guard.
+"""The local budget guard, with optional cross-process UTC-day state.
 
 ``BudgetGuard`` is a kill-switch that lives in the LLM call path. The contract:
 
@@ -36,6 +36,7 @@ import warnings
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Literal
 
 from .errors import (
@@ -44,9 +45,24 @@ from .errors import (
     UnpriceableModelWarning,
 )
 from .pricing import ManualPrice, price_tokens, resolve_price
+from .store import StateStore
 
 # Tolerance for float rounding in the running spend total (well below $0.000001).
 _EPS = 1e-12
+
+
+class _PersistentReservation(float):
+    """Numeric reservation handle carrying its authoritative store window."""
+
+    _window_id: str
+
+    def __new__(cls, amount_usd: float, window_id: str) -> _PersistentReservation:
+        handle = super().__new__(cls, amount_usd)
+        handle._window_id = window_id
+        return handle
+
+    def __reduce__(self) -> tuple[object, tuple[float, str]]:
+        return _PersistentReservation, (float(self), self._window_id)
 
 
 @dataclass(frozen=True)
@@ -58,7 +74,7 @@ class BudgetAdvisory:
     unchanged to the hosted path. Hosted adds what a local, single-budget guard
     cannot know: which of several caps is tightest (``scope`` across
     ``credit_line | session | task | api | vendor``), cross-vendor reasoning,
-    server-truth balances, and rolling-window reset timing.
+    server-truth balances, and arbitrary rolling-window reset timing.
 
     This is a **soft** signal — the model may ignore it. The hard-stop
     (:meth:`BudgetGuard.check`) is what actually enforces the ceiling; the
@@ -150,10 +166,15 @@ class BudgetGuard:
             (:attr:`spend_log`). When set, the ledger is a ring buffer keeping the
             most recent N events so a long-running agent's memory stays bounded;
             the running totals are unaffected. ``None`` (default) keeps every event.
+        window: optional persistence window. ``"utc-day"`` shares one ceiling
+            from midnight to midnight UTC and requires ``store``.
+        store: persistent state store used with ``window="utc-day"``. When both
+            persistence options are omitted, behavior remains entirely in-memory.
 
     Thread-safe: the running total and in-flight reservations are guarded by a
     lock, so the guard can back a parallel crew (use :meth:`reserve` /
-    :meth:`settle`).
+    :meth:`settle`). A configured :class:`~floe_guard.store.StateStore` extends
+    that reservation boundary across processes.
     """
 
     def __init__(
@@ -165,6 +186,8 @@ class BudgetGuard:
         on_block: Callable[[float, float], None] | None = None,
         near_limit_bps: int = 8000,
         max_log_events: int | None = None,
+        window: Literal["utc-day"] | None = None,
+        store: StateStore | None = None,
     ) -> None:
         if not math.isfinite(limit_usd) or limit_usd < 0:
             # NaN/inf would make every check() comparison evaluate False and
@@ -180,6 +203,13 @@ class BudgetGuard:
         ):
             raise ValueError(f"near_limit_bps must be an int in 0..10000, got {near_limit_bps!r}")
         self.limit_usd = float(limit_usd)
+        if (window is None) != (store is None):
+            raise ValueError("window and store must be configured together")
+        if window not in (None, "utc-day"):
+            raise ValueError(f"window must be 'utc-day' or None, got {window!r}")
+        self._window = window
+        self._store = store
+        self._active_window_id: str | None = None
         self.price_overrides = price_overrides
         self.fail_closed = fail_closed
         self._on_block = on_block or _default_on_block
@@ -213,6 +243,9 @@ class BudgetGuard:
         # the one shared ceiling, exposed via the tool_costs property.
         self._tool_costs: dict[str, float] = {}
         self._lock = threading.Lock()
+        if self._store is not None:
+            with self._lock:
+                self._refresh_persistent_state_locked()
 
     # ── enforcement ───────────────────────────────────────────────────────────
 
@@ -279,17 +312,28 @@ class BudgetGuard:
         """
         self._validate_estimate(estimated_cost)
         with self._lock:
+            window_id = self._current_window_id_locked() if self._store is not None else ""
             estimate = (
                 self._default_estimate_locked()
                 if estimated_cost is None
                 else max(0.0, estimated_cost)
             )
-            committed = self.spent_usd + self._reserved
-            if committed > self.limit_usd - _EPS or committed + estimate > self.limit_usd + _EPS:
-                spent, limit = self.spent_usd, self.limit_usd
+            if self._store is not None:
+                accepted, spent, reserved = self._store.reserve(window_id, self.limit_usd, estimate)
+                self.spent_usd = spent
+                self._reserved = reserved
+                if accepted:
+                    return _PersistentReservation(estimate, window_id)
             else:
-                self._reserved += estimate
-                return estimate
+                committed = self.spent_usd + self._reserved
+                if (
+                    committed <= self.limit_usd - _EPS
+                    and committed + estimate <= self.limit_usd + _EPS
+                ):
+                    self._reserved += estimate
+                    return estimate
+                spent = self.spent_usd
+            limit = self.limit_usd
         # Blocked — notify and raise outside the lock.
         self._on_block(spent, limit)
         raise BudgetExceeded(spent, limit)
@@ -356,13 +400,25 @@ class BudgetGuard:
             self.release(reserved)
             raise
         with self._lock:
-            if reserved:
-                self._consume_reservation_locked(reserved)
-            self.spent_usd += cost
-            # Clamp a sub-epsilon float overshoot back to the limit so the running
-            # total never reports as having crossed the ceiling by a rounding artifact.
-            if 0.0 < self.spent_usd - self.limit_usd < _EPS:
-                self.spent_usd = self.limit_usd
+            if self._store is not None:
+                window_id = self._reservation_window_id_locked(reserved)
+                updates_active_window = self._prepare_persistent_terminal_locked(window_id)
+                snapshot = self._store.settle(
+                    window_id,
+                    self.limit_usd,
+                    reserved,
+                    cost,
+                )
+                if updates_active_window:
+                    self.spent_usd, self._reserved = snapshot
+            else:
+                if reserved:
+                    self._consume_reservation_locked(reserved)
+                self.spent_usd += cost
+                # Clamp a sub-epsilon float overshoot back to the limit so the running
+                # total never reports as having crossed the ceiling by a rounding artifact.
+                if 0.0 < self.spent_usd - self.limit_usd < _EPS:
+                    self.spent_usd = self.limit_usd
             self._last_llm_cost = cost
             self._spend_log.append(
                 SpendEvent(
@@ -469,13 +525,25 @@ class BudgetGuard:
         # return value are always float, like every other cost in the guard.
         cost_usd = float(cost_usd)
         with self._lock:
-            if reserved:
-                self._consume_reservation_locked(reserved)
-            self.spent_usd += cost_usd
-            # Same sub-epsilon clamp as settle(): never report a rounding-artifact
-            # crossing of the ceiling.
-            if 0.0 < self.spent_usd - self.limit_usd < _EPS:
-                self.spent_usd = self.limit_usd
+            if self._store is not None:
+                window_id = self._reservation_window_id_locked(reserved)
+                updates_active_window = self._prepare_persistent_terminal_locked(window_id)
+                snapshot = self._store.settle(
+                    window_id,
+                    self.limit_usd,
+                    reserved,
+                    cost_usd,
+                )
+                if updates_active_window:
+                    self.spent_usd, self._reserved = snapshot
+            else:
+                if reserved:
+                    self._consume_reservation_locked(reserved)
+                self.spent_usd += cost_usd
+                # Same sub-epsilon clamp as settle(): never report a rounding-artifact
+                # crossing of the ceiling.
+                if 0.0 < self.spent_usd - self.limit_usd < _EPS:
+                    self.spent_usd = self.limit_usd
             self._last_tool_cost = cost_usd
             self._tool_costs[tool] = self._tool_costs.get(tool, 0.0) + cost_usd
             self._spend_log.append(
@@ -513,12 +581,20 @@ class BudgetGuard:
         if not reserved:
             return
         with self._lock:
-            self._consume_reservation_locked(reserved)
+            if self._store is not None:
+                window_id = self._reservation_window_id_locked(reserved)
+                updates_active_window = self._prepare_persistent_terminal_locked(window_id)
+                snapshot = self._store.release(window_id, self.limit_usd, reserved)
+                if updates_active_window:
+                    self.spent_usd, self._reserved = snapshot
+            else:
+                self._consume_reservation_locked(reserved)
 
     @property
     def remaining_usd(self) -> float:
         """USD left before the ceiling, net of in-flight reservations (never negative)."""
         with self._lock:
+            self._refresh_persistent_state_locked()
             return max(0.0, self.limit_usd - self.spent_usd - self._reserved)
 
     @property
@@ -568,6 +644,10 @@ class BudgetGuard:
         80%), so an agent can taper *before* the hard-stop. Advisory only: read it
         to adapt; :meth:`check` is what enforces the ceiling.
         """
+        with self._lock:
+            self._refresh_persistent_state_locked()
+            spent_usd = self.spent_usd
+            expected_cost = max(self._last_llm_cost, self._last_tool_cost)
         if self.limit_usd <= 0.0:
             used_bps = 10000
         else:
@@ -576,17 +656,13 @@ class BudgetGuard:
             # early. The tiny epsilon absorbs float noise (0.7*10000 = 6999.9999…),
             # and floor matches JS Math.floor exactly — round() would diverge
             # (Python banker's rounding vs JS ties-up).
-            used_bps = max(0, min(10000, int(self.spent_usd / self.limit_usd * 10000 + 1e-9)))
-        remaining = max(0.0, self.limit_usd - self.spent_usd)
-        # Lock-free read of the last-cost fields, consistent with reading
-        # spent_usd above: the estimate is the costlier of the last LLM and tool
-        # call (the guard's own default reservation), 0.0 before any call.
-        expected_cost = max(self._last_llm_cost, self._last_tool_cost)
+            used_bps = max(0, min(10000, int(spent_usd / self.limit_usd * 10000 + 1e-9)))
+        remaining = max(0.0, self.limit_usd - spent_usd)
+        # The estimate is the costlier of the last LLM and tool call (the
+        # guard's own default reservation), 0.0 before any call.
         # +1e-9 absorbs float noise so e.g. 0.6/0.2 floors to 3 not 2 (same
         # epsilon rationale as used_bps above, and keeps JS Math.floor parity).
-        est_calls_remaining = (
-            int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
-        )
+        est_calls_remaining = int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
         return BudgetAdvisory(
             near_limit=used_bps >= self.near_limit_bps,
             used_bps=used_bps,
@@ -597,12 +673,49 @@ class BudgetGuard:
             # can still claim.
             remaining_usd=remaining,
             limit_usd=self.limit_usd,
-            spent_usd=self.spent_usd,
+            spent_usd=spent_usd,
             expected_cost=expected_cost,
             est_calls_remaining=est_calls_remaining,
         )
 
     # ── internals ──────────────────────────────────────────────────────────────
+
+    def _current_window_id_locked(self) -> str:
+        """Return today's store key and reset process-local per-window views."""
+        window_id = _utc_day_window_id()
+        if window_id != self._active_window_id:
+            self._active_window_id = window_id
+            self._last_llm_cost = 0.0
+            self._last_tool_cost = 0.0
+            self._spend_log.clear()
+            self._tool_costs.clear()
+        return window_id
+
+    def _refresh_persistent_state_locked(self) -> None:
+        """Refresh the local cache from the configured authoritative store."""
+        if self._store is None:
+            return
+        self.spent_usd, self._reserved = self._store.load(
+            self._current_window_id_locked(), self.limit_usd
+        )
+
+    def _reservation_window_id_locked(self, reserved: float) -> str:
+        """Use a persistent handle's issuing window for its terminal operation."""
+        if isinstance(reserved, _PersistentReservation):
+            return reserved._window_id
+        return self._current_window_id_locked()
+
+    def _prepare_persistent_terminal_locked(self, window_id: str) -> bool:
+        """Refresh an active window that differs from a reservation's window."""
+        current_window_id = self._current_window_id_locked()
+        if window_id == current_window_id:
+            return True
+        # Load before consuming the old hold: once that terminal mutation commits,
+        # no follow-up store error should make successful cleanup look unsuccessful.
+        if self._store is None:  # pragma: no cover - persistent callers only
+            raise RuntimeError("persistent terminal operation requires a configured store")
+        self.spent_usd, self._reserved = self._store.load(current_window_id, self.limit_usd)
+        return False
 
     def _default_estimate_locked(self) -> float:
         """The default next-call prediction when the caller supplies no
@@ -675,6 +788,7 @@ class BudgetGuard:
 
     def _would_cross(self, estimated_next_cost: float | None) -> bool:
         with self._lock:
+            self._refresh_persistent_state_locked()
             estimate = (
                 self._default_estimate_locked()
                 if estimated_next_cost is None
@@ -702,3 +816,8 @@ def _default_on_block(spent_usd: float, limit_usd: float) -> None:
         "before it ran.",
         file=sys.stderr,
     )
+
+
+def _utc_day_window_id() -> str:
+    """Return the current UTC calendar date used as a persistent window key."""
+    return datetime.now(timezone.utc).date().isoformat()

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -248,10 +248,23 @@ class BudgetGuard:
             ``estimated_tokens`` to pre-emptively block; a cross raises
             :class:`TokenBudgetExceeded` (``scope="aggregate"``). ``None`` (default)
             disables the token dimension entirely.
+        window: optional persistence window. ``"utc-day"`` shares one ceiling from
+            midnight to midnight UTC across every process using the same ``store``;
+            requires ``store``. ``None`` (default) is the in-memory guard.
+        store: persistent :class:`~floe_guard.store.StateStore` (e.g.
+            :class:`~floe_guard.store.SqliteStore`) used with ``window``. When set,
+            ``spent_usd`` / reservations are the store's authoritative window
+            snapshot, so a fresh process continues where the last left off and the
+            cap resets at the UTC-day boundary. Persistence is **USD-only**: it
+            cannot be combined with ``token_limit``, :meth:`step`, or a per-call
+            ``estimated_tokens`` (each raises). ``window`` and ``store`` are
+            all-or-nothing. Note ``spend_log`` / ``tool_costs`` remain
+            process-local (not persisted, not window-reset).
 
     Thread-safe: the running total and in-flight reservations are guarded by a
     lock, so the guard can back a parallel crew (use :meth:`reserve` /
-    :meth:`settle`).
+    :meth:`settle`). A configured ``store`` extends that hard-stop across
+    processes (SQLite transactions), where the in-process lock cannot reach.
     """
 
     def __init__(
@@ -769,9 +782,15 @@ class BudgetGuard:
         """Per-tool running USD totals, keyed by the name given to
         :meth:`settle_tool` / :meth:`record_tool` — e.g.
         ``{"apollo.people_lookup": 0.42, "exa.search": 0.11}``. Makes the
-        token/tool split of the one shared ceiling inspectable
-        (``spent_usd - sum(tool_costs.values())`` is the token side).
-        Returns a snapshot copy."""
+        token/tool split of the one shared ceiling inspectable: in the in-memory
+        guard, ``spent_usd - sum(tool_costs.values())`` is the token side.
+        Returns a snapshot copy.
+
+        With a persistent ``store``, ``spent_usd`` is the current UTC-day window's
+        authoritative total while ``tool_costs`` is this process's own cumulative
+        tally (not windowed, not shared), so that identity does not hold across a
+        day rollover or a second process — use it for per-process attribution, not
+        as a cross-window invariant."""
         with self._lock:
             return dict(self._tool_costs)
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -52,7 +52,12 @@ _EPS = 1e-12
 
 
 class _PersistentReservation(float):
-    """Numeric reservation handle carrying its authoritative store window."""
+    """Numeric reservation handle carrying its authoritative store window.
+
+    Pass this handle through unchanged. It is float-compatible, but arithmetic
+    or normalization such as ``float()``, ``abs()``, ``round()``, or ``max()``
+    can return a plain float and discard its issuing-window provenance.
+    """
 
     _window_id: str
 
@@ -681,14 +686,12 @@ class BudgetGuard:
     # ── internals ──────────────────────────────────────────────────────────────
 
     def _current_window_id_locked(self) -> str:
-        """Return today's store key and reset process-local per-window views."""
+        """Return today's store key and reset the process-local estimate."""
         window_id = _utc_day_window_id()
         if window_id != self._active_window_id:
             self._active_window_id = window_id
             self._last_llm_cost = 0.0
             self._last_tool_cost = 0.0
-            self._spend_log.clear()
-            self._tool_costs.clear()
         return window_id
 
     def _refresh_persistent_state_locked(self) -> None:

--- a/src/floe_guard/store.py
+++ b/src/floe_guard/store.py
@@ -1,0 +1,214 @@
+"""Persistent state stores for cross-process budget enforcement.
+
+The core guard remains in-memory unless a store is explicitly configured.
+``SqliteStore`` uses only the Python standard library and serializes each
+reserve/settle/release mutation in a SQLite write transaction, allowing
+separate processes to enforce one shared UTC-day ceiling.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Protocol
+
+_EPS = 1e-12
+_BUSY_TIMEOUT_MS = 5_000
+
+
+class StateStore(Protocol):
+    """Storage contract for one budget's windowed spend and reservations.
+
+    Snapshots are returned as ``(spent_usd, reserved_usd)``. Implementations
+    must make each mutation atomic across every caller sharing the store.
+    """
+
+    def load(self, window_id: str, limit_usd: float) -> tuple[float, float]:
+        """Load or initialize a window and return its authoritative snapshot."""
+
+    def reserve(
+        self, window_id: str, limit_usd: float, amount_usd: float
+    ) -> tuple[bool, float, float]:
+        """Atomically hold ``amount_usd`` if it fits beneath the ceiling.
+
+        Returns ``(accepted, spent_usd, reserved_usd)``. A rejected operation
+        must leave the stored snapshot unchanged.
+        """
+
+    def settle(
+        self,
+        window_id: str,
+        limit_usd: float,
+        reserved_usd: float,
+        actual_usd: float,
+    ) -> tuple[float, float]:
+        """Atomically consume a hold and add actual spend."""
+
+    def release(self, window_id: str, limit_usd: float, reserved_usd: float) -> tuple[float, float]:
+        """Atomically consume a hold without adding spend."""
+
+
+class SqliteStore:
+    """SQLite-backed :class:`StateStore` for one logical shared budget.
+
+    Args:
+        path: Filesystem path to the SQLite database. Every guard sharing this
+            path and UTC-day window shares one ceiling.
+
+    Connections are short-lived so a store can be used safely from multiple
+    threads and processes. A process that exits without settling or releasing
+    a reservation leaves that hold in place; this deliberately fails closed.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = os.fspath(path)
+        connection = self._connect()
+        try:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS budget_windows (
+                    window_id TEXT PRIMARY KEY,
+                    limit_usd REAL NOT NULL,
+                    spent_usd REAL NOT NULL,
+                    reserved_usd REAL NOT NULL
+                )
+                """
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def load(self, window_id: str, limit_usd: float) -> tuple[float, float]:
+        """Load or initialize ``window_id`` in a serialized transaction."""
+        with self._transaction() as connection:
+            return self._load_or_create_locked(connection, window_id, limit_usd)
+
+    def reserve(
+        self, window_id: str, limit_usd: float, amount_usd: float
+    ) -> tuple[bool, float, float]:
+        """Atomically check the ceiling and add an in-flight hold."""
+        _validate_amount("amount_usd", amount_usd)
+        with self._transaction() as connection:
+            spent, reserved = self._load_or_create_locked(connection, window_id, limit_usd)
+            committed = spent + reserved
+            if committed > limit_usd - _EPS or committed + amount_usd > limit_usd + _EPS:
+                return False, spent, reserved
+            reserved += amount_usd
+            connection.execute(
+                "UPDATE budget_windows SET reserved_usd = ? WHERE window_id = ?",
+                (reserved, window_id),
+            )
+            return True, spent, reserved
+
+    def settle(
+        self,
+        window_id: str,
+        limit_usd: float,
+        reserved_usd: float,
+        actual_usd: float,
+    ) -> tuple[float, float]:
+        """Atomically consume a reservation and accrue actual spend."""
+        _validate_amount("reserved_usd", reserved_usd)
+        _validate_amount("actual_usd", actual_usd)
+        with self._transaction() as connection:
+            spent, total_reserved = self._load_or_create_locked(connection, window_id, limit_usd)
+            total_reserved = _consume_reservation(total_reserved, reserved_usd)
+            spent += actual_usd
+            if 0.0 < spent - limit_usd < _EPS:
+                spent = limit_usd
+            connection.execute(
+                """
+                UPDATE budget_windows
+                SET spent_usd = ?, reserved_usd = ?
+                WHERE window_id = ?
+                """,
+                (spent, total_reserved, window_id),
+            )
+            return spent, total_reserved
+
+    def release(self, window_id: str, limit_usd: float, reserved_usd: float) -> tuple[float, float]:
+        """Atomically consume a reservation without accruing spend."""
+        _validate_amount("reserved_usd", reserved_usd)
+        with self._transaction() as connection:
+            spent, total_reserved = self._load_or_create_locked(connection, window_id, limit_usd)
+            total_reserved = _consume_reservation(total_reserved, reserved_usd)
+            connection.execute(
+                "UPDATE budget_windows SET reserved_usd = ? WHERE window_id = ?",
+                (total_reserved, window_id),
+            )
+            return spent, total_reserved
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=_BUSY_TIMEOUT_MS / 1_000)
+        connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        return connection
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            yield connection
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def _load_or_create_locked(
+        self, connection: sqlite3.Connection, window_id: str, limit_usd: float
+    ) -> tuple[float, float]:
+        _validate_window(window_id, limit_usd)
+        row = connection.execute(
+            """
+            SELECT limit_usd, spent_usd, reserved_usd
+            FROM budget_windows
+            WHERE window_id = ?
+            """,
+            (window_id,),
+        ).fetchone()
+        if row is None:
+            connection.execute(
+                """
+                INSERT INTO budget_windows (window_id, limit_usd, spent_usd, reserved_usd)
+                VALUES (?, ?, 0.0, 0.0)
+                """,
+                (window_id, limit_usd),
+            )
+            return 0.0, 0.0
+        stored_limit, spent, reserved = (float(value) for value in row)
+        if not math.isclose(stored_limit, limit_usd, rel_tol=0.0, abs_tol=_EPS):
+            raise ValueError(
+                f"stored limit_usd ({stored_limit!r}) does not match guard limit_usd "
+                f"({limit_usd!r}) for window {window_id!r}"
+            )
+        _validate_amount("stored spent_usd", spent)
+        _validate_amount("stored reserved_usd", reserved)
+        return spent, reserved
+
+
+def _validate_window(window_id: str, limit_usd: float) -> None:
+    if not window_id:
+        raise ValueError("window_id must not be empty")
+    _validate_amount("limit_usd", limit_usd)
+
+
+def _validate_amount(name: str, value: float) -> None:
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be a finite, non-negative number, got {value!r}")
+
+
+def _consume_reservation(total_reserved: float, reserved_usd: float) -> float:
+    if reserved_usd > total_reserved + _EPS:
+        raise ValueError(
+            f"reserved handle ({reserved_usd!r}) exceeds total in-flight reservations "
+            f"({total_reserved!r}) — a handle must come from a matching reserve()"
+        )
+    return max(0.0, total_reserved - reserved_usd)
+
+
+__all__ = ["SqliteStore", "StateStore"]

--- a/src/floe_guard/store.py
+++ b/src/floe_guard/store.py
@@ -67,6 +67,15 @@ class SqliteStore:
         self.path = os.fspath(path)
         connection = self._connect()
         try:
+            # WAL lets readers proceed while one writer commits, so the read-heavy
+            # check()/advisory() paths don't queue behind a settling process. The
+            # mode is persisted on the file. Some network filesystems can't back
+            # WAL's shared memory — fall back to the default journal rather than
+            # failing to open the store.
+            try:
+                connection.execute("PRAGMA journal_mode = WAL")
+            except sqlite3.OperationalError:
+                pass
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS budget_windows (
@@ -82,7 +91,31 @@ class SqliteStore:
             connection.close()
 
     def load(self, window_id: str, limit_usd: float) -> tuple[float, float]:
-        """Load or initialize ``window_id`` in a serialized transaction."""
+        """Load or initialize ``window_id`` and return its snapshot.
+
+        Read-only fast path: an existing window is read in autocommit mode (a
+        brief shared lock, no write lock), so the common case — every
+        ``check()`` / ``advisory()`` / ``remaining_usd`` on a window that already
+        exists — never serializes behind a writer. Only a missing window escalates
+        to the ``BEGIN IMMEDIATE`` write transaction to create it, and that
+        transaction re-reads first, so two processes racing to create the same
+        window stay correct.
+        """
+        _validate_window(window_id, limit_usd)
+        connection = self._connect()
+        try:
+            row = connection.execute(
+                """
+                SELECT limit_usd, spent_usd, reserved_usd
+                FROM budget_windows
+                WHERE window_id = ?
+                """,
+                (window_id,),
+            ).fetchone()
+        finally:
+            connection.close()
+        if row is not None:
+            return self._snapshot_from_row(row, window_id, limit_usd)
         with self._transaction() as connection:
             return self._load_or_create_locked(connection, window_id, limit_usd)
 
@@ -180,6 +213,13 @@ class SqliteStore:
                 (window_id, limit_usd),
             )
             return 0.0, 0.0
+        return self._snapshot_from_row(row, window_id, limit_usd)
+
+    @staticmethod
+    def _snapshot_from_row(
+        row: tuple[float, float, float], window_id: str, limit_usd: float
+    ) -> tuple[float, float]:
+        """Validate a stored ``(limit, spent, reserved)`` row and return its snapshot."""
         stored_limit, spent, reserved = (float(value) for value in row)
         if not math.isclose(stored_limit, limit_usd, rel_tol=0.0, abs_tol=_EPS):
             raise ValueError(

--- a/src/floe_guard/store.py
+++ b/src/floe_guard/store.py
@@ -69,12 +69,15 @@ class SqliteStore:
         try:
             # WAL lets readers proceed while one writer commits, so the read-heavy
             # check()/advisory() paths don't queue behind a settling process. The
-            # mode is persisted on the file. Some network filesystems can't back
-            # WAL's shared memory — fall back to the default journal rather than
-            # failing to open the store.
+            # mode is persisted on the file. Some SQLite build/mount combinations
+            # can't back WAL's shared memory — catch the whole sqlite3.Error family
+            # (not just OperationalError; some raise DatabaseError) so the store
+            # falls back to the default journal instead of failing to open. The
+            # PRAGMA reports the mode actually in effect — fetch it so the fallback
+            # is observable rather than silently discarded.
             try:
-                connection.execute("PRAGMA journal_mode = WAL")
-            except sqlite3.OperationalError:
+                connection.execute("PRAGMA journal_mode = WAL").fetchone()
+            except sqlite3.Error:
                 pass
             connection.execute(
                 """

--- a/src/floe_guard/stream.py
+++ b/src/floe_guard/stream.py
@@ -83,7 +83,10 @@ class StreamGuard:
         self._guard = guard
         self._model = model
         self._prompt_tokens = max(0, int(prompt_tokens))
-        self._reserved = float(reserved)
+        # Preserve persistent handles' issuing-window provenance. They remain
+        # float-compatible, but coercing here would make a stream that crosses
+        # midnight settle against the new UTC day's empty reservation row.
+        self._reserved = reserved
         self._price = price
         self._label = label
         self._count = count_tokens or approx_tokens

--- a/tests/test_persistent_budget.py
+++ b/tests/test_persistent_budget.py
@@ -159,6 +159,26 @@ def test_persistence_configuration_is_explicit(tmp_path: Path) -> None:
         BudgetGuard(1.0, window="hour", store=store)  # type: ignore[arg-type]
 
 
+def test_persistence_is_usd_only_and_rejects_the_token_dimension(tmp_path: Path) -> None:
+    # Persistence is USD-only for now: it cannot compose with token_limit, step(),
+    # or a per-call token estimate — each is refused with a clear error rather than
+    # silently ignored (a persistent handle can't also carry a token hold).
+    def _fresh_store() -> SqliteStore:
+        return SqliteStore(tmp_path / "tok.sqlite3")
+
+    with pytest.raises(ValueError, match="token_limit is not supported"):
+        BudgetGuard(1.0, window="utc-day", store=_fresh_store(), token_limit=1000)
+
+    guard = BudgetGuard(1.0, window="utc-day", store=_fresh_store())
+    with pytest.raises(ValueError, match="estimated_tokens is not supported"):
+        guard.reserve(0.1, estimated_tokens=500)
+    with pytest.raises(ValueError, match="estimated_tokens is not supported"):
+        guard.check(estimated_tokens=500)
+    with pytest.raises(ValueError, match="step\\(\\) is not supported"):
+        with guard.step(max_usd=0.5):
+            pass
+
+
 def test_conflicting_limit_for_same_window_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "budget.sqlite3"
     BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))

--- a/tests/test_persistent_budget.py
+++ b/tests/test_persistent_budget.py
@@ -91,9 +91,17 @@ def test_utc_day_rollover_uses_a_fresh_window(
 
     current_day[0] = "2026-08-05"
     assert guard.remaining_usd == pytest.approx(1.0)
+    assert guard.advisory().expected_cost == 0.0
+    assert guard.tool_costs == {"day-one": pytest.approx(0.3)}
+    assert [event.model_or_tool for event in guard.spend_log] == ["day-one"]
     guard.record_tool("day-two", 0.1)
 
     assert guard.spent_usd == pytest.approx(0.1)
+    assert guard.tool_costs == {
+        "day-one": pytest.approx(0.3),
+        "day-two": pytest.approx(0.1),
+    }
+    assert [event.model_or_tool for event in guard.spend_log] == ["day-one", "day-two"]
     assert store.load("2026-08-04", 1.0) == pytest.approx((0.3, 0.0))
     assert store.load("2026-08-05", 1.0) == pytest.approx((0.1, 0.0))
 
@@ -197,6 +205,10 @@ def test_overlapping_processes_share_reservations_and_ceiling(tmp_path: Path) ->
     start.set()
     for process in processes:
         process.join(timeout=15)
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
 
     assert all(process.exitcode == 0 for process in processes)
     messages: list[str] = []
@@ -219,7 +231,7 @@ def test_no_store_keeps_the_in_memory_contract() -> None:
     guard = BudgetGuard(1.0)
     reserved = guard.reserve_tool(0.2)
 
-    assert isinstance(reserved, float)
+    assert type(reserved) is float
     assert guard.remaining_usd == pytest.approx(0.8)
     guard.release(reserved)
     assert guard.remaining_usd == pytest.approx(1.0)

--- a/tests/test_persistent_budget.py
+++ b/tests/test_persistent_budget.py
@@ -1,0 +1,225 @@
+"""UTC-day SQLite persistence and cross-process enforcement (issue #47)."""
+
+from __future__ import annotations
+
+import multiprocessing
+import pickle
+import queue
+import time
+from pathlib import Path
+
+import pytest
+
+import floe_guard.guard as guard_module
+from floe_guard import (
+    BudgetExceeded,
+    BudgetGuard,
+    ManualPrice,
+    SqliteStore,
+    StreamGuard,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+)
+
+_LIMIT = 0.05
+_HOLD = 0.02
+
+
+def _record_in_process(path: str) -> None:
+    guard = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    guard.record_tool("cron", 0.25)
+
+
+def _overlapping_worker(
+    path: str,
+    start: multiprocessing.synchronize.Event,
+    results: multiprocessing.queues.Queue,
+) -> None:
+    guard = BudgetGuard(
+        _LIMIT,
+        window="utc-day",
+        store=SqliteStore(path),
+        on_block=lambda *_: None,
+    )
+    start.wait(timeout=10)
+    try:
+        reserved = guard.reserve_tool(_HOLD)
+    except BudgetExceeded:
+        results.put("blocked")
+        return
+    results.put("reserved")
+    time.sleep(0.1)
+    guard.settle_tool("cron", _HOLD, reserved=reserved)
+    results.put("settled")
+
+
+def test_sequential_process_loads_previous_spend(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(target=_record_in_process, args=(str(path),))
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    guard = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    assert guard.spent_usd == pytest.approx(0.25)
+    assert guard.remaining_usd == pytest.approx(0.75)
+
+
+def test_reservation_survives_reconstruction_and_release(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    first = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    reserved = first.reserve_tool(0.4)
+
+    second = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    assert second.spent_usd == 0.0
+    assert second.remaining_usd == pytest.approx(0.6)
+
+    second.release(reserved)
+    assert second.remaining_usd == pytest.approx(1.0)
+    assert SqliteStore(path).load(guard_module._utc_day_window_id(), 1.0) == (0.0, 0.0)
+
+
+def test_utc_day_rollover_uses_a_fresh_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_day = ["2026-08-04"]
+    monkeypatch.setattr(guard_module, "_utc_day_window_id", lambda: current_day[0])
+    store = SqliteStore(tmp_path / "budget.sqlite3")
+    guard = BudgetGuard(1.0, window="utc-day", store=store)
+    guard.record_tool("day-one", 0.3)
+
+    current_day[0] = "2026-08-05"
+    assert guard.remaining_usd == pytest.approx(1.0)
+    guard.record_tool("day-two", 0.1)
+
+    assert guard.spent_usd == pytest.approx(0.1)
+    assert store.load("2026-08-04", 1.0) == pytest.approx((0.3, 0.0))
+    assert store.load("2026-08-05", 1.0) == pytest.approx((0.1, 0.0))
+
+
+def test_reservations_settle_and_release_against_their_issuing_day(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_day = ["2026-08-04"]
+    monkeypatch.setattr(guard_module, "_utc_day_window_id", lambda: current_day[0])
+    store = SqliteStore(tmp_path / "budget.sqlite3")
+    guard = BudgetGuard(1.0, window="utc-day", store=store)
+    settled = guard.reserve_tool(0.2)
+    released = pickle.loads(pickle.dumps(guard.reserve_tool(0.3)))
+
+    current_day[0] = "2026-08-05"
+    guard.record_tool("day-two", 0.1)
+    guard.settle_tool("cross-midnight", 0.2, reserved=settled)
+    assert guard.spent_usd == pytest.approx(0.1)
+    guard.release(released)
+    assert guard.spent_usd == pytest.approx(0.1)
+
+    assert store.load("2026-08-04", 1.0) == pytest.approx((0.2, 0.0))
+    assert store.load("2026-08-05", 1.0) == pytest.approx((0.1, 0.0))
+
+
+def test_stream_settles_against_its_reservation_day(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_day = ["2026-08-04"]
+    monkeypatch.setattr(guard_module, "_utc_day_window_id", lambda: current_day[0])
+    store = SqliteStore(tmp_path / "budget.sqlite3")
+    guard = BudgetGuard(1.0, window="utc-day", store=store)
+    reserved = guard.reserve(0.2)
+    stream = StreamGuard(
+        guard,
+        "manual",
+        reserved=reserved,
+        price=ManualPrice(input_cost_per_token=0.2, output_cost_per_token=0.0),
+    )
+
+    current_day[0] = "2026-08-05"
+    stream.finish(prompt_tokens=1, completion_tokens=0)
+
+    assert store.load("2026-08-04", 1.0) == pytest.approx((0.2, 0.0))
+    assert store.load("2026-08-05", 1.0) == pytest.approx((0.0, 0.0))
+
+
+def test_persistence_configuration_is_explicit(tmp_path: Path) -> None:
+    store = SqliteStore(tmp_path / "budget.sqlite3")
+    with pytest.raises(ValueError, match="window and store must be configured together"):
+        BudgetGuard(1.0, store=store)
+    with pytest.raises(ValueError, match="window and store must be configured together"):
+        BudgetGuard(1.0, window="utc-day")
+    with pytest.raises(ValueError, match="window must be 'utc-day' or None"):
+        BudgetGuard(1.0, window="hour", store=store)  # type: ignore[arg-type]
+
+
+def test_conflicting_limit_for_same_window_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+
+    with pytest.raises(ValueError, match="stored limit_usd"):
+        BudgetGuard(2.0, window="utc-day", store=SqliteStore(path))
+
+
+def test_record_paths_persist_atomically(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    first = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    first.record("manual", 1_000, 0, price=ManualPrice(0.0001, 0.0))
+    first.record_tool("search", 0.2)
+
+    second = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    assert second.spent_usd == pytest.approx(0.3)
+    assert second.remaining_usd == pytest.approx(0.7)
+
+
+def test_failed_settlement_releases_persisted_reservation(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    guard = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    reserved = guard.reserve_tool(0.4)
+
+    with pytest.warns(UnpriceableModelWarning):
+        with pytest.raises(UnpriceableModelError):
+            guard.settle("unknown-model", 1, 1, reserved=reserved)
+
+    reloaded = BudgetGuard(1.0, window="utc-day", store=SqliteStore(path))
+    assert reloaded.remaining_usd == pytest.approx(1.0)
+
+
+def test_overlapping_processes_share_reservations_and_ceiling(tmp_path: Path) -> None:
+    path = tmp_path / "budget.sqlite3"
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(target=_overlapping_worker, args=(str(path), start, results))
+        for _ in range(8)
+    ]
+    for process in processes:
+        process.start()
+    start.set()
+    for process in processes:
+        process.join(timeout=15)
+
+    assert all(process.exitcode == 0 for process in processes)
+    messages: list[str] = []
+    while True:
+        try:
+            messages.append(results.get_nowait())
+        except queue.Empty:
+            break
+
+    assert messages.count("reserved") == 2
+    assert messages.count("settled") == 2
+    assert messages.count("blocked") == 6
+    spent, reserved = SqliteStore(path).load(guard_module._utc_day_window_id(), _LIMIT)
+    assert spent == pytest.approx(0.04)
+    assert reserved == pytest.approx(0.0)
+    assert spent <= _LIMIT
+
+
+def test_no_store_keeps_the_in_memory_contract() -> None:
+    guard = BudgetGuard(1.0)
+    reserved = guard.reserve_tool(0.2)
+
+    assert isinstance(reserved, float)
+    assert guard.remaining_usd == pytest.approx(0.8)
+    guard.release(reserved)
+    assert guard.remaining_usd == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Adds optional persistent UTC-day budget enforcement for Python using the standard-library `sqlite3` module.

A shared SQLite store now allows sequential and overlapping processes—such as cron or serverless jobs—to use the same daily USD ceiling instead of resetting the budget whenever a process restarts.

## Changes

- Add public `StateStore` and `SqliteStore` APIs.
- Add `window="utc-day"` and `store=` options to `BudgetGuard`.
- Persist spend and active reservations using atomic SQLite transactions.
- Automatically select a fresh budget window at midnight UTC.
- Preserve reservation provenance when work crosses midnight.
- Keep existing in-memory behavior unchanged when persistence is not configured.
- Add multiprocessing, rollover, reconstruction, cleanup, and configuration tests.
- Document the feature and bump the Python package version to `0.12.0`.

## Scope and limitations

- Python only.
- Supports UTC calendar days only; arbitrary rolling windows are deferred.
- One SQLite file represents one logical shared budget.
- Spend and active reservations persist; logs, tool attribution, and next-call estimates remain process-local.
- Reservations left by a crashed process fail closed and require manual recovery.
- Enforcement retains the existing estimate-based reservation semantics.

## Testing

- `pytest -q` — 264 passed
- `ruff check .`
- Ruff formatting verified for changed Python files
- `git diff --check`
- Python and TypeScript cost maps confirmed unchanged

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SQLite-backed persistence for Python UTC-day USD budgets.
  * Budgets can now share spending and in-flight reservations across processes.
  * Added public `StateStore` and `SqliteStore` interfaces for persistent state management.
  * Added atomic reservation, settlement, and release handling with safe recovery behavior.

* **Documentation**
  * Documented persistence setup, supported limitations, and differences from hosted balance tracking.
  * Added unreleased changelog entries for Python 0.12.0 and JavaScript 0.9.0.

* **Chores**
  * Added the local virtual-environment directory to ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->