### PR TITLE
fix: single-source __version__ from package metadata (0.11.0 wheel reports 0.10.0)

### DIFF
--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -14,6 +14,9 @@ cross-vendor upgrade path (see the README).
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
+
 from .errors import (
     BudgetExceeded,
     DeadlineExceeded,
@@ -29,7 +32,13 @@ from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .stream import StreamGuard, guard_stream
 
-__version__ = "0.10.0"  # keep in lockstep with pyproject.toml
+# Single-sourced from the installed package metadata, which pyproject.toml
+# already fills in. The hand-maintained literal that used to live here drifted:
+# the published 0.11.0 wheel ships __version__ == "0.10.0".
+try:
+    __version__ = _package_version("floe-guard")
+except PackageNotFoundError:  # source tree with no install
+    __version__ = "0.0.0.dev0"
 
 __all__ = [
     "BudgetGuard",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -27,3 +27,23 @@ def test_version_matches_installed_package_metadata():
 def test_version_is_a_non_empty_string():
     assert isinstance(floe_guard.__version__, str)
     assert floe_guard.__version__
+
+
+def test_source_tree_fallback_when_metadata_is_missing(monkeypatch):
+    """A bare checkout with no install must still import.
+
+    Pinned explicitly because the non-empty-string test above would accept any
+    replacement for the sentinel.
+    """
+    import importlib
+
+    def raise_not_found(_name):
+        raise PackageNotFoundError(_name)
+
+    monkeypatch.setattr("importlib.metadata.version", raise_not_found)
+    try:
+        reloaded = importlib.reload(floe_guard)
+        assert reloaded.__version__ == "0.0.0.dev0"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(floe_guard)  # leave the real version in place

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,29 @@
+"""`floe_guard.__version__` must match what the package actually shipped as.
+
+The published 0.11.0 wheel reports `__version__ == "0.10.0"`, because the value
+was a hand-maintained literal that had to be bumped in lockstep with
+pyproject.toml and was missed. Anyone reading the version for a bug report, a
+telemetry tag or a compatibility check got the previous release.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+import pytest
+
+import floe_guard
+
+
+def test_version_matches_installed_package_metadata():
+    try:
+        installed = package_version("floe-guard")
+    except PackageNotFoundError:
+        pytest.skip("floe-guard is not installed; nothing to compare against")
+    assert floe_guard.__version__ == installed
+
+
+def test_version_is_a_non_empty_string():
+    assert isinstance(floe_guard.__version__, str)
+    assert floe_guard.__version__


### PR DESCRIPTION
`floe_guard.__version__` is wrong in the published 0.11.0 wheel — it reports `0.10.0`.

The value was a hand-maintained literal in `src/floe_guard/__init__.py:32`, carrying the comment "keep in lockstep with pyproject.toml", and 0.11.0 missed the bump.

## Verified against PyPI, not my working tree

Clean room, into an empty venv:

```
pip install floe-guard==0.11.0
python -c "import floe_guard, importlib.metadata as m; print(floe_guard.__version__, m.version('floe-guard'))"
# -> 0.10.0 0.11.0
```

And confirmed it is baked into the artifact rather than a build quirk:

```
pip download --no-deps floe-guard==0.11.0
unzip -p floe_guard-0.11.0-py3-none-any.whl floe_guard/__init__.py | grep __version__
# __version__ = "0.10.0"  # keep in lockstep with pyproject.toml
```

The 0.10.0 wheel says `0.10.0`, so the drift starts at 0.11.0. Anyone reading the version for a bug report, a telemetry tag or a compatibility check currently gets the previous release.

## The fix

Note the right-hand value in that first command: **`importlib.metadata` already returns the correct version.** So reading from it is a permanent fix, rather than bumping the literal again and drifting at 0.12.0. `pyproject.toml` stays the single source of truth.

It falls back to `0.0.0.dev0` when imported from a source tree with no install, so a bare checkout still imports cleanly.

## Checks

- `tests/test_version.py` pins the invariant. Confirmed non-vacuous: restoring the old literal makes it fail with `assert '0.10.0' == '0.11.0'`.
- Full suite: **216 passed, 8 skipped**.
- `ruff check .` and `ruff format --check` clean.

`CHANGELOG.md:11` also still reads Unreleased for that release, but I left it alone since it is a judgement call about how you track releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version information now reflects the installed package version instead of a hard-coded value.
  * Added a safe fallback version when package metadata is unavailable.

* **Tests**
  * Added coverage to verify that the reported version is present, non-empty, and matches installed package metadata when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->