### PR TITLE
docs: date 0.13.0/0.9.0 changelog entry, fix dead hosted-Floe anchors…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.13.0 / js 0.9.0
+## py 0.13.0 / js 0.9.0 — 2026-08-06
 
 ### Added (py)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,8 @@ imports nothing from `ai` (see `js/src/middleware.ts`) — keep it that way.
   integrations belong in `src/floe_guard/integrations/` behind an optional extra.
 - The cost map is vendored twice (`src/floe_guard/cost_map.json` and
   `js/src/cost_map.json`) and must stay byte-identical — CI fails on drift.
-  Refresh both together (`scripts/update-cost-map.mjs`).
+  Refresh both together (`scripts/update-cost-map.mjs`; `LITELLM_COST_MAP_URL`
+  overrides the upstream LiteLLM map URL it fetches from).
 - Prefer small, focused changes with tests that describe behavior.
 
 ## Areas we'd love help with

--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ adapter set like the Python package.
 **text-only**: it guards a wrapped `LanguageModel`, not a running STT → LLM → TTS
 session. A voice/telephony builder on a Node stack should either drive the LLM
 turn through the Vercel AI middleware and meter STT/TTS spend by hand via
-`recordTool`, or run the LLM leg through the **hosted [Floe proxy](#upgrade-to-hosted-floe)**
+`recordTool`, or run the LLM leg through the **hosted [Floe proxy](#when-you-outgrow-local-guardrails)**
 (un-bypassable, cross-vendor) — or use the Python Pipecat / LiveKit adapters
 above, which enforce the whole turn. No native TypeScript Pipecat/LiveKit voice
 adapter ships in this release.
@@ -802,7 +802,7 @@ metrics, no "zero defaults" claims — it's a free local stop, not a vault.
 floe-guard does **not** phone home. It sends no usage events, no install pings,
 no identifiers — nothing leaves your process at runtime except hosted-budget
 reads you explicitly opt into by setting `FLOE_API_KEY` (the
-[hosted Floe](#upgrade-to-hosted-floe) path) — never otherwise.
+[hosted Floe](#when-you-outgrow-local-guardrails) path) — never otherwise.
 
 This is a choice, not an oversight. A guardrail's whole value is trust: a
 library that silently exfiltrates usage from people's agents is the opposite of
@@ -819,6 +819,12 @@ enforcement server-side.
 | Runs | Locally, in your process | Server-side |
 | Scope | One process | Every vendor and agent |
 | Control | Hard stop at your cap | Kill switch + one unified ledger |
+
+Already on hosted Floe? The package's only network call is the opt-in hosted
+budget read: set `FLOE_API_KEY` (agent key `floe_…`) and `hosted_remaining_usd()`
+returns the server-side budget headroom via `GET /v1/agents/credit-remaining`.
+`FLOE_API_BASE_URL` overrides the API host (default
+`https://credit-api.floelabs.xyz`). Nothing runs unless the key is set.
 
 → [dev-dashboard.floelabs.xyz](https://dev-dashboard.floelabs.xyz/)
 


### PR DESCRIPTION
…, document FLOE_API_BASE_URL + LITELLM_COST_MAP_URL.

## Summary
  - Added guidance for opting into hosted budget readings, including configuration, endpoint details, API host overrides, and behavior without an API key.
  - Updated links to the current hosted Floe guidance.
  - Documented how to override the upstream cost-map URL.
- **Release**
  - Updated the changelog with the py 0.13.0 / js 0.9.0 release date.

## Testing
How was this tested?

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)