### PR TITLE
feat(voice): ship a voice cost map + meter the whole call by default (P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,21 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.13.0 / js 0.9.0
+## Unreleased — py 0.14.0 / js 0.10.0
 
 ### Added (py)
 
+- **Voice cost map — meter the whole call by default** (P0): STT/TTS/telephony
+  rates ship under the reserved `__voice__` key of `cost_map.json` (units: STT
+  $/sec, TTS $/1k-chars, telephony $/min). The Pipecat + LiveKit adapters now
+  price the full call — STT + LLM + TTS + telephony — from the map with no
+  hand-typed rates (`stt_model` / `tts_model` / `telephony`); per-unit overrides
+  still win. A vendor the map can't price (or a wrong unit/mode) fails closed via
+  the new `UnpriceableVoiceError` (parity with `UnpriceableModelError`), never a
+  silent $0. Seeded US-only v1 — Deepgram, AssemblyAI, ElevenLabs, Cartesia
+  (Sonic TTS + Line telephony), Rime, Twilio (Telnyx deferred); rates are a
+  drift-prone snapshot. The **js** package carries the same `__voice__` cost-map
+  data in lockstep (no JS voice adapter this release).
 - **Persistent UTC-day budgets** (issue #47): `BudgetGuard(...,
   window="utc-day", store=SqliteStore(path))` keeps spend and in-flight
   reservations in dependency-free SQLite transactions, so sequential and

--- a/README.md
+++ b/README.md
@@ -662,9 +662,42 @@ function wrapper, these adapters enforce **per turn** — reserve before the LLM
 call (so a turn is blocked *before* its TTS/audio spend piles on top of a call
 that would already cross the ceiling), settle on the real usage the pipeline
 reports, and release a turn that ends without ever reporting usage (an
-interrupted turn) so the reservation never leaks against the ceiling. The token
-cost map is LLM-only, so STT/TTS spend is metered only when you supply per-unit
-prices. Both voice adapters are **Python-only** today.
+interrupted turn) so the reservation never leaks against the ceiling. Both voice
+adapters are **Python-only** today.
+
+**The whole call is priced from the bundled map — no hand-typed rates.** Name each
+leg's vendor (`stt_model`, `tts_model`, `telephony`) and floe-guard prices the
+full call — STT (per second) + LLM (per token) + TTS (per 1k chars) + telephony
+(per minute) — from the vendored voice cost map, so it answers *"what did this
+call cost"* at the $0 tier out of the box. A per-unit override
+(`stt_usd_per_second` / `tts_usd_per_1k_chars` / `telephony_usd_per_minute`) still
+works and wins over the map; a leg with neither a vendor nor an override is left
+un-metered (the token-only contract), and a vendor the map cannot price **fails
+closed** (`UnpriceableVoiceError`) rather than metering it at a silent $0.
+
+> **Telephony is US-only in v1**, and every voice rate is a **drift-prone
+> snapshot** of each vendor's public list price — vendors change these more often
+> than the map is refreshed, so treat them as an estimate and re-verify against
+> the live pricing page before trusting a figure. The rates live under the
+> `"__voice__"` key of [`cost_map.json`](src/floe_guard/cost_map.json); refresh
+> them with [`scripts/update-cost-map.mjs`](scripts/update-cost-map.mjs). Seeded
+> vendors: Deepgram, AssemblyAI (STT); ElevenLabs, Cartesia Sonic, Rime (TTS);
+> Twilio, Cartesia Line (telephony). Telnyx is deferred pending a verified list
+> rate. Enforcement stays
+> **pre-turn admission** (reserve-before-turn) — telephony is **per-minute
+> accrual**, not live line-cutting.
+
+Per-leg breakdown from one call (no manual prices — `python
+examples/voice_call_cost_livekit.py`, no API key, no network):
+
+```
+Per-leg call cost (all priced from the bundled cost map, no manual rates):
+  livekit-stt          $0.001027   # 8s  × ($0.0077/min ÷ 60)   Deepgram Nova-3
+  gpt-4o               $0.003700   # 600 in / 220 out tokens    LLM
+  livekit-tts          $0.009000   # 180 chars / 1k × $0.05     ElevenLabs Flash
+  livekit-telephony    $0.012750   # 1.5 min × $0.0085/min      Twilio US inbound
+  TOTAL                $0.026477
+```
 
 ### Pipecat (voice)
 
@@ -708,6 +741,14 @@ pipeline — the hard-stop every other adapter gives you. Pass an
 `on_budget_exceeded` async callback to speak a graceful "wrapping up" line first
 instead of cutting the call dead.
 
+Name the vendors to meter the rest of the call from the map:
+`tts_model="elevenlabs-flash-v2.5"` auto-meters the `TTSUsageMetricsData` Pipecat
+emits; `stt_model` / `telephony` are metered explicitly (Pipecat emits no STT/
+telephony usage frame) via `processor.meter_stt(seconds)` /
+`processor.meter_telephony(minutes)`. See
+[`examples/voice_call_cost_pipecat.py`](examples/voice_call_cost_pipecat.py) for
+the full per-leg breakdown (no API key, no network).
+
 ### LiveKit (voice)
 
 ```bash
@@ -738,10 +779,16 @@ await session.start(agent=agent, room=ctx.room)
 
 > **Fragment** — `session`, `agent`, and `ctx.room` come from your LiveKit agent entrypoint (`JobContext`); this shows only where the guard attaches.
 
-Pass `stt_usd_per_second` / `tts_usd_per_1k_chars` to also meter STT/TTS spend
-(often a voice agent's larger bill) via `record_tool`, and an `on_budget_exceeded`
-async callback to speak a wrap-up line before a turn ends. See
-[`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
+Name the vendors — `stt_model="deepgram-nova-3"`, `tts_model="elevenlabs-flash-v2.5"`,
+`telephony="twilio-us-inbound-local"` — to meter STT/TTS/telephony (often a voice
+agent's larger bill) from the map via `record_tool`, no hand-typed rates. STT/TTS
+settle automatically off LiveKit's metrics events; drive telephony per-minute with
+`budget.meter_telephony(minutes)`. Per-unit overrides (`stt_usd_per_second` /
+`tts_usd_per_1k_chars` / `telephony_usd_per_minute`) still work and win over the
+map, and an `on_budget_exceeded` async callback speaks a wrap-up line before a turn
+ends. See [`examples/voice_call_cost_livekit.py`](examples/voice_call_cost_livekit.py)
+for the full per-leg breakdown (no API key) and
+[`examples/voice_turn_budget.py`](examples/voice_turn_budget.py) for the hard-stop.
 
 ## Adapter matrix
 

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ closed** (`UnpriceableVoiceError`) rather than metering it at a silent $0.
 Per-leg breakdown from one call (no manual prices — `python
 examples/voice_call_cost_livekit.py`, no API key, no network):
 
-```
+```text
 Per-leg call cost (all priced from the bundled cost map, no manual rates):
   livekit-stt          $0.001027   # 8s  × ($0.0077/min ÷ 60)   Deepgram Nova-3
   gpt-4o               $0.003700   # 600 in / 220 out tokens    LLM

--- a/README.md
+++ b/README.md
@@ -686,6 +686,13 @@ closed** (`UnpriceableVoiceError`) rather than metering it at a silent $0.
 > rate. Enforcement stays
 > **pre-turn admission** (reserve-before-turn) — telephony is **per-minute
 > accrual**, not live line-cutting.
+>
+> Some vendors don't bill in the map's canonical unit: TTS priced natively
+> per audio-minute (Cartesia Sonic, Rime) is converted at an assumed ~1000
+> chars/min, and per-session overhead (e.g. AssemblyAI) isn't modeled — so a
+> metered leg is an **estimate**, not the exact invoice, and can under- or
+> over-state it. `floe-guard` is a **local pacing ceiling**; the authoritative
+> cap is server-side.
 
 Per-leg breakdown from one call (no manual prices — `python
 examples/voice_call_cost_livekit.py`, no API key, no network):

--- a/examples/voice_call_cost_livekit.py
+++ b/examples/voice_call_cost_livekit.py
@@ -1,0 +1,126 @@
+"""What did this voice call cost? — LiveKit, priced entirely from the cost map.
+
+No API key, no account, no network. A minimal fake ``AgentSession`` + agent (all
+``LiveKitBudgetGuard.attach`` touches) drives one turn and emits the STT / LLM /
+TTS metrics a real session would, plus a telephony leg. **No manual prices** —
+every leg is priced from the bundled cost map by naming its vendor, so floe-guard
+answers "what did this call cost" at the $0 tier out of the box.
+
+Run:
+    python examples/voice_call_cost_livekit.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.livekit import LiveKitBudgetGuard
+
+
+class _FakeSession:
+    """The tiny event-emitter surface attach() wires onto."""
+
+    def __init__(self) -> None:
+        self._handlers: dict = {}
+
+    def on(self, event, cb):
+        self._handlers[event] = cb
+
+    def emit(self, event, arg):
+        self._handlers[event](arg)
+
+
+class _FakeAgent:
+    async def llm_node(self, chat_ctx, tools, model_settings):
+        for chunk in ("Sure,", " one moment."):
+            yield chunk
+
+
+def _event(metric):
+    return types.SimpleNamespace(metrics=metric)
+
+
+def _llm_metrics(prompt_tokens, completion_tokens):
+    return LLMMetrics(
+        label="llm",
+        request_id="r",
+        timestamp=0.0,
+        duration=0.0,
+        ttft=0.0,
+        cancelled=False,
+        completion_tokens=completion_tokens,
+        prompt_tokens=prompt_tokens,
+        prompt_cached_tokens=0,
+        total_tokens=prompt_tokens + completion_tokens,
+        tokens_per_second=0.0,
+    )
+
+
+def _stt_metrics(audio_duration):
+    return STTMetrics(
+        label="stt",
+        request_id="r",
+        timestamp=0.0,
+        duration=0.0,
+        audio_duration=audio_duration,
+        streamed=True,
+    )
+
+
+def _tts_metrics(characters_count):
+    return TTSMetrics(
+        label="tts",
+        request_id="r",
+        timestamp=0.0,
+        ttfb=0.0,
+        duration=0.0,
+        audio_duration=0.0,
+        cancelled=False,
+        characters_count=characters_count,
+        streamed=True,
+    )
+
+
+async def run() -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = LiveKitBudgetGuard(
+        guard,
+        model="gpt-4o",  # LLM leg — priced from the token cost map
+        stt_model="deepgram-nova-3",  # $/sec from the voice map
+        tts_model="elevenlabs-flash-v2.5",  # $/1k-chars from the voice map
+        telephony="twilio-us-inbound-local",  # $/min from the voice map
+    )
+
+    agent, session = _FakeAgent(), _FakeSession()
+    budget.attach(session, agent)
+
+    # One turn: caller speaks (STT) → model answers (LLM) → bot speaks (TTS).
+    async for _ in agent.llm_node(None, None, None):
+        pass
+    session.emit("metrics_collected", _event(_stt_metrics(8.0)))  # 8s of caller audio
+    session.emit("metrics_collected", _event(_llm_metrics(600, 220)))
+    session.emit("metrics_collected", _event(_tts_metrics(180)))  # 180 chars spoken
+
+    # Telephony is per-minute accrual driven by the transport — a 1.5-minute call.
+    budget.meter_telephony(1.5)
+    return guard
+
+
+def _print_breakdown(guard: BudgetGuard) -> None:
+    print("Per-leg call cost (all priced from the bundled cost map, no manual rates):")
+    for event in guard.spend_log:
+        print(f"  {event.model_or_tool:<20} ${event.cost_usd:.6f}")
+    print(f"  {'TOTAL':<20} ${guard.advisory().spent_usd:.6f}")
+
+
+async def main() -> None:
+    guard = await run()
+    _print_breakdown(guard)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/voice_call_cost_pipecat.py
+++ b/examples/voice_call_cost_pipecat.py
@@ -1,0 +1,92 @@
+"""What did this voice call cost? — Pipecat, priced entirely from the cost map.
+
+No API key, no account, no network. Runs a real (single-processor) Pipecat
+Pipeline via PipelineTask/PipelineRunner — exactly like
+examples/voice_turn_budget.py — so the guard processor gets a fully initialized
+lifecycle. One turn's LLM + TTS usage metrics flow through as frames; STT and
+telephony (which Pipecat emits no usage frame for) are metered explicitly.
+
+**No manual prices** — every leg is priced from the bundled cost map by naming
+its vendor, so floe-guard answers "what did this call cost" at the $0 tier out
+of the box.
+
+Run:
+    python examples/voice_call_cost_pipecat.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat.frames.frames import EndFrame, LLMFullResponseStartFrame, MetricsFrame
+from pipecat.metrics.metrics import (
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    TTSUsageMetricsData,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor
+
+
+def _llm_frame(prompt_tokens, completion_tokens):
+    usage = LLMTokenUsage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return MetricsFrame(data=[LLMUsageMetricsData(processor="llm", model="gpt-4o", value=usage)])
+
+
+def _tts_frame(characters):
+    return MetricsFrame(data=[TTSUsageMetricsData(processor="tts", value=characters)])
+
+
+async def run() -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=1.00)
+    processor = FloeBudgetGuardProcessor(
+        guard,
+        model="gpt-4o",  # LLM leg — priced from the token cost map
+        stt_model="deepgram-nova-3",  # $/sec from the voice map
+        tts_model="elevenlabs-flash-v2.5",  # $/1k-chars from the voice map
+        telephony="twilio-us-inbound-local",  # $/min from the voice map
+    )
+
+    pipeline = Pipeline([processor])
+    task = PipelineTask(
+        pipeline, params=PipelineParams(enable_metrics=True, enable_usage_metrics=True)
+    )
+    runner = PipelineRunner()
+
+    async def drive():
+        await task.queue_frame(LLMFullResponseStartFrame())
+        await task.queue_frame(_llm_frame(600, 220))  # LLM leg (auto)
+        await task.queue_frame(_tts_frame(180))  # TTS leg (auto, from usage frame)
+        await asyncio.sleep(0.05)
+        # STT + telephony have no native usage frame — meter them explicitly.
+        processor.meter_stt(8.0)  # 8s of caller audio
+        processor.meter_telephony(1.5)  # 1.5-minute call
+        if not task.has_finished():
+            await task.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(task), drive())
+    return guard
+
+
+def _print_breakdown(guard: BudgetGuard) -> None:
+    print("Per-leg call cost (all priced from the bundled cost map, no manual rates):")
+    for event in guard.spend_log:
+        print(f"  {event.model_or_tool:<22} ${event.cost_usd:.6f}")
+    print(f"  {'TOTAL':<22} ${guard.advisory().spent_usd:.6f}")
+
+
+async def main() -> None:
+    guard = await run()
+    _print_breakdown(guard)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -952,5 +952,85 @@
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
+  },
+  "__voice__": {
+    "deepgram-nova-3": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0001283333,
+      "provider": "deepgram"
+    },
+    "deepgram-nova-3-multilingual": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0001533333,
+      "provider": "deepgram"
+    },
+    "deepgram-nova-3-base": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0002416667,
+      "provider": "deepgram"
+    },
+    "assemblyai-universal-streaming": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0000416667,
+      "provider": "assemblyai"
+    },
+    "elevenlabs-multilingual-v2": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.1,
+      "provider": "elevenlabs"
+    },
+    "elevenlabs-flash-v2.5": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.05,
+      "provider": "elevenlabs"
+    },
+    "elevenlabs-turbo-v2.5": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.05,
+      "provider": "elevenlabs"
+    },
+    "cartesia-sonic": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.03,
+      "provider": "cartesia"
+    },
+    "cartesia-line": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.06,
+      "provider": "cartesia"
+    },
+    "rime-mist-v2": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.03,
+      "provider": "rime"
+    },
+    "twilio-us-inbound-local": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.0085,
+      "provider": "twilio"
+    },
+    "twilio-us-outbound-local": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.014,
+      "provider": "twilio"
+    },
+    "twilio-us-sip-inbound": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.004,
+      "provider": "twilio"
+    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Floe Labs" }]
-keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini"]
+keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini", "voice", "stt", "tts", "livekit", "deepgram", "elevenlabs", "twilio"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.13.0"
+version = "0.14.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -73,6 +73,117 @@ const GROQ_KEY_MAP = new Map([
 // adapter detects them via `client.vertexai`.
 const PREFIX_STRIPPED_PROVIDERS = new Set(["gemini"]);
 
+// ── Voice rates (STT / TTS / telephony) ─────────────────────────────────────
+//
+// The token map above is fetched from LiteLLM; the voice map is NOT — LiteLLM
+// does not carry STT/TTS/telephony list prices, so these are hand-curated from
+// each vendor's public pricing page and injected under the reserved "__voice__"
+// key (see src/floe_guard/pricing.py, which splits it back out so the token
+// resolver never sees it). They are a DRIFT-PRONE SNAPSHOT: vendors change these
+// far more often than this file is refreshed, so treat them as an estimate and
+// re-verify against the live pricing page before trusting a figure. Telephony is
+// US-only in v1.
+//
+// Units are canonical per mode and a mismatch fails closed downstream:
+//   stt -> usd_per_second, tts -> usd_per_1k_chars, telephony -> usd_per_minute.
+// Where a vendor lists a different unit, the arithmetic to convert is shown.
+const VOICE_RATES = {
+  // Deepgram Nova-3 streaming, billed per minute -> ÷60 for $/sec.
+  "deepgram-nova-3": {
+    mode: "stt",
+    unit: "usd_per_second",
+    rate: 0.0001283333, // $0.0077/min mono ÷ 60
+    provider: "deepgram",
+  },
+  "deepgram-nova-3-multilingual": {
+    mode: "stt",
+    unit: "usd_per_second",
+    rate: 0.0001533333, // $0.0092/min ÷ 60
+    provider: "deepgram",
+  },
+  "deepgram-nova-3-base": {
+    mode: "stt",
+    unit: "usd_per_second",
+    rate: 0.0002416667, // $0.0145/min ÷ 60
+    provider: "deepgram",
+  },
+  // AssemblyAI Universal Streaming. Note: ~$0.0042/min effective once you
+  // include the per-session idle/overhead billing; the list rate is $0.0025/min.
+  "assemblyai-universal-streaming": {
+    mode: "stt",
+    unit: "usd_per_second",
+    rate: 0.0000416667, // $0.0025/min ÷ 60
+    provider: "assemblyai",
+  },
+  // ElevenLabs bills in credits/char: Multilingual v2 = 1 credit/char,
+  // Flash/Turbo = 0.5 credit/char. On the standard $/credit these list at
+  // ~$0.10 and ~$0.05 per 1k chars respectively.
+  "elevenlabs-multilingual-v2": {
+    mode: "tts",
+    unit: "usd_per_1k_chars",
+    rate: 0.1, // 1 credit/char
+    provider: "elevenlabs",
+  },
+  "elevenlabs-flash-v2.5": {
+    mode: "tts",
+    unit: "usd_per_1k_chars",
+    rate: 0.05, // 0.5 credit/char
+    provider: "elevenlabs",
+  },
+  "elevenlabs-turbo-v2.5": {
+    mode: "tts",
+    unit: "usd_per_1k_chars",
+    rate: 0.05, // 0.5 credit/char
+    provider: "elevenlabs",
+  },
+  // Cartesia is billed per minute of audio; converted to $/1k-chars at an
+  // assumed 1000 chars/min of synthesised speech (≈150 wpm). Sonic ≈ $0.03/min;
+  // the phone-optimised "Line" product ≈ $0.06/min.
+  "cartesia-sonic": {
+    mode: "tts",
+    unit: "usd_per_1k_chars",
+    rate: 0.03, // $0.03/min ÷ 1000 chars/min = $0.03/1k chars
+    provider: "cartesia",
+  },
+  "cartesia-line": {
+    mode: "telephony",
+    unit: "usd_per_minute",
+    rate: 0.06, // Cartesia Line — telephony, $0.06/min list rate (per-minute)
+    provider: "cartesia",
+  },
+  // Rime is billed per minute; converted at the same 1000 chars/min assumption.
+  "rime-mist-v2": {
+    mode: "tts",
+    unit: "usd_per_1k_chars",
+    rate: 0.03, // $0.030/min ÷ 1000 chars/min = $0.03/1k chars
+    provider: "rime",
+  },
+  // Twilio Programmable Voice, US only. Outbound lists as a $0.013–0.014/min
+  // range; we keep the top of the range because over-pricing a spend guard
+  // stops one call early (safe) while under-pricing lets a crossing call through.
+  "twilio-us-inbound-local": {
+    mode: "telephony",
+    unit: "usd_per_minute",
+    rate: 0.0085, // US inbound to a local number
+    provider: "twilio",
+  },
+  "twilio-us-outbound-local": {
+    mode: "telephony",
+    unit: "usd_per_minute",
+    rate: 0.014, // $0.013–0.014/min — top of range
+    provider: "twilio",
+  },
+  "twilio-us-sip-inbound": {
+    mode: "telephony",
+    unit: "usd_per_minute",
+    rate: 0.004, // US SIP inbound
+    provider: "twilio",
+  },
+  // TODO(telnyx): unverified list rate — deferred. Do not invent a number; add a
+  // telnyx-us-* entry only after confirming the current per-minute list price on
+  // the Telnyx pricing page.
+};
+
 /** The key a model is vendored under: "gemini/gemini-2.5-flash" -> "gemini-2.5-flash". */
 function vendoredKey(k) {
   const mapped = GROQ_KEY_MAP.get(k);
@@ -243,6 +354,11 @@ for (const [k, v] of entries) {
       `bucket (${input_cost_per_token}/${output_cost_per_token}).`,
   );
 }
+
+// Inject the hand-curated voice rates under the reserved "__voice__" key, last,
+// so a token refresh preserves them (they are not in the fetched LiteLLM data).
+// pricing.py splits this key back out, so it never reaches the token resolver.
+out.__voice__ = VOICE_RATES;
 
 const json = `${JSON.stringify(out, null, 2)}\n`;
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -26,6 +26,7 @@ from .errors import (
     TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
+    UnpriceableVoiceError,
 )
 from .guard import (
     BudgetAdvisory,
@@ -40,6 +41,13 @@ from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
+from .voice_pricing import (
+    VoiceRate,
+    lookup_voice_rate,
+    price_voice_leg,
+    resolve_voice_rate,
+    voice_leg_cost,
+)
 
 # Single-sourced from the installed package metadata, which pyproject.toml
 # already fills in. The hand-maintained literal that used to live here drifted:
@@ -71,10 +79,16 @@ __all__ = [
     "HostedEnforcementError",
     "UnpriceableModelError",
     "UnpriceableModelWarning",
+    "UnpriceableVoiceError",
     "ManualPrice",
     "PricedModel",
     "price_tokens",
     "resolve_price",
+    "VoiceRate",
+    "lookup_voice_rate",
+    "resolve_voice_rate",
+    "voice_leg_cost",
+    "price_voice_leg",
     "hosted_enforcement_available",
     "hosted_remaining_usd",
 ]

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -952,5 +952,85 @@
     "output_cost_per_token": 0,
     "litellm_provider": "openai",
     "mode": "embedding"
+  },
+  "__voice__": {
+    "deepgram-nova-3": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0001283333,
+      "provider": "deepgram"
+    },
+    "deepgram-nova-3-multilingual": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0001533333,
+      "provider": "deepgram"
+    },
+    "deepgram-nova-3-base": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0002416667,
+      "provider": "deepgram"
+    },
+    "assemblyai-universal-streaming": {
+      "mode": "stt",
+      "unit": "usd_per_second",
+      "rate": 0.0000416667,
+      "provider": "assemblyai"
+    },
+    "elevenlabs-multilingual-v2": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.1,
+      "provider": "elevenlabs"
+    },
+    "elevenlabs-flash-v2.5": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.05,
+      "provider": "elevenlabs"
+    },
+    "elevenlabs-turbo-v2.5": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.05,
+      "provider": "elevenlabs"
+    },
+    "cartesia-sonic": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.03,
+      "provider": "cartesia"
+    },
+    "cartesia-line": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.06,
+      "provider": "cartesia"
+    },
+    "rime-mist-v2": {
+      "mode": "tts",
+      "unit": "usd_per_1k_chars",
+      "rate": 0.03,
+      "provider": "rime"
+    },
+    "twilio-us-inbound-local": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.0085,
+      "provider": "twilio"
+    },
+    "twilio-us-outbound-local": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.014,
+      "provider": "twilio"
+    },
+    "twilio-us-sip-inbound": {
+      "mode": "telephony",
+      "unit": "usd_per_minute",
+      "rate": 0.004,
+      "provider": "twilio"
+    }
   }
 }

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -93,6 +93,30 @@ class UnpriceableModelError(FloeGuardError):
         )
 
 
+class UnpriceableVoiceError(FloeGuardError):
+    """Raised when a voice leg (STT/TTS/telephony) cannot be priced and the guard
+    is fail-closed.
+
+    The voice twin of :class:`UnpriceableModelError`: we refuse rather than
+    silently accrue $0 — "we cannot cap what we cannot price". It fires when an
+    adapter is asked to meter a leg for a vendor that is absent from the bundled
+    voice cost map (or whose entry has the wrong unit/mode for the leg) and no
+    per-unit override was given. Pass a per-unit rate
+    (``stt_usd_per_second`` / ``tts_usd_per_1k_chars`` /
+    ``telephony_usd_per_minute``) to make the leg enforceable.
+    """
+
+    def __init__(self, vendor: str | None, mode: str) -> None:
+        self.vendor = vendor
+        self.mode = mode
+        super().__init__(
+            f"Cannot price {mode} vendor {vendor!r}: not in the bundled voice cost "
+            f"map (or its entry has the wrong unit for a {mode} leg) and no per-unit "
+            f"override was given. The guard cannot enforce a budget on spend it "
+            f"cannot measure. Pass a per-unit rate to enable enforcement."
+        )
+
+
 class HostedEnforcementError(FloeGuardError):
     """Raised when a read against the hosted Floe budget endpoint fails.
 

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -22,7 +22,13 @@ usage, after). ``LiveKitBudgetGuard`` holds the reservation state across both.
 LiveKit's ``LLMMetrics`` does not report the served model, so cost is settled
 against the ``model`` passed here (unlike the Pipecat adapter, which reads it
 off the frame). STT/TTS spend — often a voice agent's larger bill — is metered
-only if per-unit prices are supplied, since the bundled cost map is LLM-only.
+whenever you name the vendor: pass ``stt_model`` / ``tts_model`` and the rate
+comes from the bundled voice cost map (no hand-typed rate needed), or pass a
+per-unit override (``stt_usd_per_second`` / ``tts_usd_per_1k_chars``) which wins
+over the map. Telephony (per-minute) is metered via :meth:`meter_telephony`,
+since LiveKit emits no telephony metric. A leg with neither a vendor nor an
+override is left un-metered (the token-only contract); a vendor the voice map
+cannot price fails closed (:class:`~floe_guard.errors.UnpriceableVoiceError`).
 """
 
 from __future__ import annotations
@@ -37,6 +43,7 @@ from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
 
 from ..errors import BudgetExceeded
 from ..guard import BudgetGuard
+from ..voice_pricing import price_voice_leg
 
 logger = logging.getLogger(__name__)
 
@@ -67,10 +74,23 @@ class LiveKitBudgetGuard:
             ``BudgetExceeded`` when a turn is blocked, so a bot can speak a
             graceful "wrapping up" line before the turn ends silently. If
             omitted, the ``BudgetExceeded`` propagates out of ``llm_node``.
-        stt_usd_per_second: if set, meter ``STTMetrics.audio_duration`` via
-            ``record_tool`` (per-second). Omit to keep the token-only contract.
-        tts_usd_per_1k_chars: if set, meter ``TTSMetrics.characters_count`` via
-            ``record_tool`` (per 1k chars). Omit to keep the token-only contract.
+        stt_model: voice-map vendor key for the STT leg (e.g.
+            ``"deepgram-nova-3"``). When set, ``STTMetrics.audio_duration`` is
+            metered via ``record_tool`` at the bundled per-second rate — no
+            hand-typed rate needed. A key the voice map cannot price fails closed
+            (:class:`~floe_guard.errors.UnpriceableVoiceError`).
+        tts_model: voice-map vendor key for the TTS leg (e.g.
+            ``"elevenlabs-flash-v2.5"``). When set, ``TTSMetrics.characters_count``
+            is metered via ``record_tool`` at the bundled per-1k-chars rate.
+        telephony: voice-map vendor key for the telephony leg (e.g.
+            ``"twilio-us-inbound-local"``), metered per minute via
+            :meth:`meter_telephony`. US-only in v1.
+        stt_usd_per_second: per-second STT override — wins over ``stt_model``.
+            Omit both to keep the token-only contract (STT un-metered).
+        tts_usd_per_1k_chars: per-1k-chars TTS override — wins over ``tts_model``.
+            Omit both to keep the token-only contract (TTS un-metered).
+        telephony_usd_per_minute: per-minute telephony override — wins over
+            ``telephony``.
     """
 
     def __init__(
@@ -79,14 +99,22 @@ class LiveKitBudgetGuard:
         model: str,
         on_budget_exceeded: Callable[[BudgetExceeded], Awaitable[None]] | None = None,
         *,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        telephony: str | None = None,
         stt_usd_per_second: float | None = None,
         tts_usd_per_1k_chars: float | None = None,
+        telephony_usd_per_minute: float | None = None,
     ):
         self._guard = guard
         self._model = model
         self._on_budget_exceeded = on_budget_exceeded
+        self._stt_model = stt_model
+        self._tts_model = tts_model
+        self._telephony = telephony
         self._stt_usd_per_second = stt_usd_per_second
         self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
+        self._telephony_usd_per_minute = telephony_usd_per_minute
         self._reserved: float = 0.0
         self._pending = False
         self._active: _TurnSlot | None = None
@@ -170,12 +198,43 @@ class LiveKitBudgetGuard:
             else:
                 reserved = 0.0
             self._guard.settle(self._model, m.prompt_tokens, m.completion_tokens, reserved=reserved)
-        elif self._stt_usd_per_second is not None and isinstance(m, STTMetrics):
-            self._guard.record_tool("livekit-stt", m.audio_duration * self._stt_usd_per_second)
-        elif self._tts_usd_per_1k_chars is not None and isinstance(m, TTSMetrics):
-            self._guard.record_tool(
-                "livekit-tts", m.characters_count / 1000 * self._tts_usd_per_1k_chars
+        elif isinstance(m, STTMetrics):
+            # Priced from the voice map when stt_model is set, or the override;
+            # None (neither configured) leaves STT un-metered, an unpriceable
+            # vendor fails closed. Quantity is audio-seconds.
+            cost = price_voice_leg(
+                "stt", m.audio_duration, model=self._stt_model, override=self._stt_usd_per_second
             )
+            if cost is not None:
+                self._guard.record_tool("livekit-stt", cost)
+        elif isinstance(m, TTSMetrics):
+            cost = price_voice_leg(
+                "tts",
+                m.characters_count,
+                model=self._tts_model,
+                override=self._tts_usd_per_1k_chars,
+            )
+            if cost is not None:
+                self._guard.record_tool("livekit-tts", cost)
+
+    def meter_telephony(self, minutes: float) -> float | None:
+        """Accrue telephony spend for ``minutes`` of call time (per-minute).
+
+        LiveKit emits no telephony metric, so the transport/caller drives this —
+        call it as the call accrues minutes, or once with the final duration.
+        This is **per-minute accrual, not live line-cutting**: the guard meters
+        the leg, it does not cut the phone line mid-call. Priced from the voice
+        map when ``telephony`` is set, or the ``telephony_usd_per_minute``
+        override; returns ``None`` (no-op) when the leg is unconfigured, and
+        fails closed on a vendor the voice map cannot price. Returns the USD
+        accrued, if any.
+        """
+        cost = price_voice_leg(
+            "telephony", minutes, model=self._telephony, override=self._telephony_usd_per_minute
+        )
+        if cost is not None:
+            self._guard.record_tool("livekit-telephony", cost)
+        return cost
 
     def _on_close(self, ev) -> None:
         # Session torn down with a turn still reserved — release it. Drop any

--- a/src/floe_guard/integrations/pipecat.py
+++ b/src/floe_guard/integrations/pipecat.py
@@ -53,12 +53,13 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     MetricsFrame,
 )
-from pipecat.metrics.metrics import LLMUsageMetricsData
+from pipecat.metrics.metrics import LLMUsageMetricsData, TTSUsageMetricsData
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from ..errors import BudgetExceeded
 from ..guard import BudgetGuard
 from ..pricing import resolve_price
+from ..voice_pricing import price_voice_leg
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,19 @@ def _usage_from(frame: MetricsFrame) -> tuple[str | None, int, int] | None:
         if isinstance(entry, LLMUsageMetricsData):
             usage = entry.value
             return entry.model, usage.prompt_tokens, usage.completion_tokens
+    return None
+
+
+def _tts_chars_from(frame: MetricsFrame) -> int | None:
+    """Pull the TTS character count from a MetricsFrame, or None if absent.
+
+    Pipecat's TTS service emits ``TTSUsageMetricsData`` whose ``value`` is the
+    number of characters synthesised on that turn -- the unit ElevenLabs /
+    Cartesia / Rime bill in. Other entries on the same frame are ignored.
+    """
+    for entry in frame.data:
+        if isinstance(entry, TTSUsageMetricsData):
+            return entry.value
     return None
 
 
@@ -113,6 +127,23 @@ class FloeBudgetGuardProcessor(FrameProcessor):
             (A bare raise here would *not* achieve that: Pipecat's
             FrameProcessor catches exceptions raised inside process_frame()
             and downgrades them to a non-fatal, merely-logged ErrorFrame.)
+        stt_model: voice-map vendor key for the STT leg (e.g.
+            ``"deepgram-nova-3"``). Pipecat emits no STT-usage metric, so meter
+            STT via :meth:`meter_stt` with the audio-seconds of the turn.
+        tts_model: voice-map vendor key for the TTS leg (e.g.
+            ``"elevenlabs-flash-v2.5"``). When set, the ``TTSUsageMetricsData``
+            Pipecat emits (character count) is metered automatically via
+            ``record_tool`` at the bundled per-1k-chars rate -- no hand-typed
+            rate needed. A vendor the voice map cannot price fails closed with a
+            fatal ``ErrorFrame`` (same hard-stop as an unpriceable LLM turn).
+        telephony: voice-map vendor key for the telephony leg (e.g.
+            ``"twilio-us-inbound-local"``), metered per minute via
+            :meth:`meter_telephony`. US-only in v1.
+        stt_usd_per_second: per-second STT override -- wins over ``stt_model``.
+        tts_usd_per_1k_chars: per-1k-chars TTS override -- wins over ``tts_model``.
+        telephony_usd_per_minute: per-minute telephony override -- wins over
+            ``telephony``. A leg with neither a vendor nor an override is left
+            un-metered (the token-only contract).
     """
 
     def __init__(
@@ -120,14 +151,60 @@ class FloeBudgetGuardProcessor(FrameProcessor):
         guard: BudgetGuard,
         model: str,
         on_budget_exceeded: Callable[[BudgetExceeded], Awaitable[None]] | None = None,
+        *,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        telephony: str | None = None,
+        stt_usd_per_second: float | None = None,
+        tts_usd_per_1k_chars: float | None = None,
+        telephony_usd_per_minute: float | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self._guard = guard
         self._model = model
         self._on_budget_exceeded = on_budget_exceeded
+        self._stt_model = stt_model
+        self._tts_model = tts_model
+        self._telephony = telephony
+        self._stt_usd_per_second = stt_usd_per_second
+        self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
+        self._telephony_usd_per_minute = telephony_usd_per_minute
         self._reserved: float = 0.0
         self._pending = False
+
+    def meter_stt(self, seconds: float) -> float | None:
+        """Accrue STT spend for ``seconds`` of audio (per-second).
+
+        Pipecat emits no STT-usage metric, so the caller drives this with the
+        turn's audio duration. Priced from the voice map when ``stt_model`` is
+        set, or the ``stt_usd_per_second`` override; returns ``None`` (no-op)
+        when the leg is unconfigured, and raises
+        :class:`~floe_guard.errors.UnpriceableVoiceError` on a vendor the voice
+        map cannot price. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "stt", seconds, model=self._stt_model, override=self._stt_usd_per_second
+        )
+        if cost is not None:
+            self._guard.record_tool("pipecat-stt", cost)
+        return cost
+
+    def meter_telephony(self, minutes: float) -> float | None:
+        """Accrue telephony spend for ``minutes`` of call time (per-minute).
+
+        **Per-minute accrual, not live line-cutting**: the guard meters the leg,
+        it does not cut the phone line mid-call. Priced from the voice map when
+        ``telephony`` is set, or the ``telephony_usd_per_minute`` override;
+        returns ``None`` (no-op) when unconfigured, and fails closed on a vendor
+        the voice map cannot price. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "telephony", minutes, model=self._telephony, override=self._telephony_usd_per_minute
+        )
+        if cost is not None:
+            self._guard.record_tool("pipecat-telephony", cost)
+        return cost
 
     def _settle_model(self, reported_model: str | None) -> str:
         if (
@@ -208,6 +285,29 @@ class FloeBudgetGuardProcessor(FrameProcessor):
                     logger.warning("floe-guard could not settle a turn: %s", exc)
                     await self.push_error(str(exc), exception=exc, fatal=True)
                     return
+
+            # Meter the TTS leg from the same frame family (a separate
+            # TTSUsageMetricsData entry, emitted by the TTS service). Priced from
+            # the voice map when tts_model is set, or the override; None (neither
+            # configured) leaves TTS un-metered. A vendor the map can't price
+            # fails closed with a fatal ErrorFrame, same hard-stop as an
+            # unpriceable LLM turn -- a guard that can't measure spend must not
+            # let Pipecat downgrade the failure to a non-fatal log.
+            tts_chars = _tts_chars_from(frame)
+            if tts_chars is not None:
+                try:
+                    tts_cost = price_voice_leg(
+                        "tts",
+                        tts_chars,
+                        model=self._tts_model,
+                        override=self._tts_usd_per_1k_chars,
+                    )
+                except Exception as exc:
+                    logger.warning("floe-guard could not price a TTS leg: %s", exc)
+                    await self.push_error(str(exc), exception=exc, fatal=True)
+                    return
+                if tts_cost is not None:
+                    self._guard.record_tool("pipecat-tts", tts_cost)
 
         elif isinstance(frame, (LLMFullResponseEndFrame, EndFrame, CancelFrame, ErrorFrame)):
             # A turn that ended (LLMFullResponseEndFrame) or the pipeline tearing

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -42,7 +42,14 @@ def _load_cost_map() -> dict[str, Any]:
         return json.load(fh)
 
 
-_COST_MAP: dict[str, Any] = _load_cost_map()
+# The voice rates (STT/TTS/telephony) live under one reserved key so the flat
+# LLM map stays LLM-only: they have a different schema (rate/unit/mode, not
+# per-token prices), so keeping them out of _COST_MAP means the token resolver
+# and its whole-map invariants never see them. See voice_pricing.py.
+_VOICE_MAP_KEY = "__voice__"
+_RAW_COST_MAP: dict[str, Any] = _load_cost_map()
+_VOICE_MAP: dict[str, Any] = _RAW_COST_MAP.get(_VOICE_MAP_KEY, {})
+_COST_MAP: dict[str, Any] = {k: v for k, v in _RAW_COST_MAP.items() if k != _VOICE_MAP_KEY}
 
 
 # The one "<provider>/" prefix that is safe to strip: the remainder of a

--- a/src/floe_guard/voice_pricing.py
+++ b/src/floe_guard/voice_pricing.py
@@ -1,0 +1,153 @@
+"""Offline pricing for voice legs (STT / TTS / telephony) from the vendored map.
+
+The voice twin of :mod:`floe_guard.pricing`. The token cost map is per-token; a
+voice pipeline's bill is per-second (STT), per-1k-chars (TTS), and per-minute
+(telephony) instead, so the voice rates live under the reserved ``"__voice__"``
+key of ``cost_map.json`` with their own schema::
+
+    "deepgram-nova-3": {
+        "mode": "stt",              # discriminator: "stt" | "tts" | "telephony"
+        "unit": "usd_per_second",   # explicit unit — a mismatch fails closed
+        "rate": 0.0001283333,       # USD in that unit
+        "provider": "deepgram"
+    }
+
+Same fail-closed contract as token pricing: a vendor absent from the map (or an
+entry whose ``unit``/``mode`` does not match the leg it is asked to price) is
+unpriceable — :func:`lookup_voice_rate` returns ``None`` and the adapter raises
+:class:`~floe_guard.errors.UnpriceableVoiceError` rather than silently metering
+the leg at $0. Pass a per-unit override to enforce a leg the map cannot price.
+
+No network. The rates are a **drift-prone snapshot** of each vendor's public
+list price — refresh them (``scripts/update-cost-map.mjs``) like the token map,
+or estimates drift as vendors change prices. Telephony is **US-only in v1**.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .errors import UnpriceableVoiceError
+from .pricing import _VOICE_MAP
+
+VoiceMode = Literal["stt", "tts", "telephony"]
+
+# The one unit each leg is billed in. An entry whose ``unit`` disagrees with its
+# leg is a schema mismatch and fails closed — a Deepgram $/min figure stored
+# without the ÷60 conversion would over-bill 60x if it were silently accepted.
+_UNIT_FOR_MODE: dict[str, str] = {
+    "stt": "usd_per_second",
+    "tts": "usd_per_1k_chars",
+    "telephony": "usd_per_minute",
+}
+
+
+@dataclass(frozen=True)
+class VoiceRate:
+    """A resolved per-unit voice rate plus where it came from."""
+
+    mode: str
+    unit: str
+    rate: float
+    source: str  # "override" | "cost_map"
+
+
+def _finite_non_negative(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    )
+
+
+def lookup_voice_rate(model: str | None, mode: VoiceMode) -> float | None:
+    """Resolve a voice vendor to its per-unit rate, or ``None`` if unpriceable.
+
+    The pure resolver (the voice twin of :func:`floe_guard.pricing.resolve_price`):
+    it never raises. Fail-closed on every mismatch — a missing vendor, an entry
+    whose ``mode`` is not ``mode``, an entry whose ``unit`` is not the canonical
+    unit for ``mode``, or a non-finite/negative rate — so a schema slip can never
+    surface as a silent, valid-looking price.
+    """
+    if model is None:
+        return None
+    entry = _VOICE_MAP.get(model)
+    if not entry:
+        return None
+    if entry.get("mode") != mode:
+        return None
+    if entry.get("unit") != _UNIT_FOR_MODE[mode]:
+        return None
+    rate = entry.get("rate")
+    if not _finite_non_negative(rate):
+        return None
+    return float(rate)
+
+
+def resolve_voice_rate(
+    model: str | None, mode: VoiceMode, override: float | None = None
+) -> VoiceRate:
+    """Resolve a leg's per-unit rate, fail-closed. An ``override`` wins over the map.
+
+    Raises :class:`~floe_guard.errors.UnpriceableVoiceError` when neither an
+    override nor the bundled map can price the leg — the guard refuses to meter
+    spend it cannot measure.
+    """
+    if override is not None:
+        if not _finite_non_negative(override):
+            raise ValueError(
+                f"voice {mode} override must be a finite, non-negative number, got {override!r}"
+            )
+        return VoiceRate(mode, _UNIT_FOR_MODE[mode], float(override), "override")
+    rate = lookup_voice_rate(model, mode)
+    if rate is None:
+        raise UnpriceableVoiceError(model, mode)
+    return VoiceRate(mode, _UNIT_FOR_MODE[mode], rate, "cost_map")
+
+
+def voice_leg_cost(mode: VoiceMode, quantity: float, rate: float) -> float:
+    """USD for one leg. ``quantity`` is seconds (stt), characters (tts), or
+    minutes (telephony); negative quantities clamp to zero."""
+    q = max(0.0, quantity)
+    if mode == "stt":
+        return q * rate  # seconds * $/second
+    if mode == "tts":
+        return q / 1000.0 * rate  # chars / 1000 * $/1k-chars
+    if mode == "telephony":
+        return q * rate  # minutes * $/minute
+    raise ValueError(f"unknown voice mode {mode!r}")  # pragma: no cover
+
+
+def price_voice_leg(
+    mode: VoiceMode,
+    quantity: float,
+    *,
+    model: str | None = None,
+    override: float | None = None,
+) -> float | None:
+    """USD for one voice leg, or ``None`` when the leg is unconfigured (skip it).
+
+    The single entry point the adapters use. A leg with neither a vendor
+    (``model``) nor an ``override`` is unconfigured — return ``None`` so the
+    token-only contract is preserved and nothing is metered. A leg that *is*
+    configured but cannot be priced raises
+    :class:`~floe_guard.errors.UnpriceableVoiceError` (via
+    :func:`resolve_voice_rate`) rather than accruing a silent $0.
+    """
+    if model is None and override is None:
+        return None
+    resolved = resolve_voice_rate(model, mode, override)
+    return voice_leg_cost(mode, quantity, resolved.rate)
+
+
+__all__ = [
+    "VoiceMode",
+    "VoiceRate",
+    "lookup_voice_rate",
+    "resolve_voice_rate",
+    "voice_leg_cost",
+    "price_voice_leg",
+]

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -20,7 +20,7 @@ pytest.importorskip("livekit.agents")
 from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics  # noqa: E402
 
 from floe_guard import BudgetGuard  # noqa: E402
-from floe_guard.errors import BudgetExceeded  # noqa: E402
+from floe_guard.errors import BudgetExceeded, UnpriceableVoiceError  # noqa: E402
 from floe_guard.integrations.livekit import LiveKitBudgetGuard  # noqa: E402
 
 
@@ -316,3 +316,103 @@ async def test_stt_tts_ignored_by_default():
     )
 
     assert guard.advisory().spent_usd == 0.0
+
+
+def _stt_metric(audio_duration):
+    return STTMetrics(
+        label="stt",
+        request_id="r",
+        timestamp=0.0,
+        duration=0.0,
+        audio_duration=audio_duration,
+        streamed=True,
+    )
+
+
+def _tts_metric(characters_count):
+    return TTSMetrics(
+        label="tts",
+        request_id="r",
+        timestamp=0.0,
+        ttfb=0.0,
+        duration=0.0,
+        audio_duration=0.0,
+        cancelled=False,
+        characters_count=characters_count,
+        streamed=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stt_and_tts_metered_from_voice_cost_map_by_default():
+    # No hand-typed rates -- name the vendor and the rate comes from the map.
+    guard = BudgetGuard(limit_usd=100.00)
+    _, _, session = _attached(
+        guard, stt_model="deepgram-nova-3", tts_model="elevenlabs-flash-v2.5"
+    )
+
+    session.emit("metrics_collected", _event(_stt_metric(60.0)))  # 60s of audio
+    session.emit("metrics_collected", _event(_tts_metric(2000)))  # 2000 chars
+
+    # STT: 60s * ($0.0077/min ÷ 60) = $0.0077. TTS: 2000/1000 * $0.05 = $0.10.
+    expected = 60.0 * (0.0077 / 60) + 2000 / 1000 * 0.05
+    assert guard.advisory().spent_usd == pytest.approx(expected, rel=1e-4)
+    assert set(guard.tool_costs) == {"livekit-stt", "livekit-tts"}
+
+
+@pytest.mark.asyncio
+async def test_override_wins_over_voice_map():
+    guard = BudgetGuard(limit_usd=100.00)
+    _, _, session = _attached(
+        guard, stt_model="deepgram-nova-3", stt_usd_per_second=0.001
+    )
+    session.emit("metrics_collected", _event(_stt_metric(10.0)))
+    # Override ($0.001/s), not the Deepgram map rate.
+    assert guard.advisory().spent_usd == pytest.approx(10.0 * 0.001)
+
+
+@pytest.mark.asyncio
+async def test_unpriceable_stt_vendor_fails_closed():
+    guard = BudgetGuard(limit_usd=100.00)
+    _, _, session = _attached(guard, stt_model="not-a-real-stt-vendor")
+    with pytest.raises(UnpriceableVoiceError):
+        session.emit("metrics_collected", _event(_stt_metric(10.0)))
+
+
+@pytest.mark.asyncio
+async def test_telephony_metered_per_minute_from_map():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard, telephony="twilio-us-inbound-local")
+    cost = budget.meter_telephony(3.0)  # 3 minutes
+    assert cost == pytest.approx(3.0 * 0.0085)
+    assert guard.tool_costs["livekit-telephony"] == pytest.approx(3.0 * 0.0085)
+
+
+@pytest.mark.asyncio
+async def test_telephony_unconfigured_is_noop():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard)
+    assert budget.meter_telephony(3.0) is None
+    assert guard.advisory().spent_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_full_call_per_leg_breakdown_sums_to_total():
+    # AC1: STT + LLM + TTS + telephony, all from the map (no hand-typed rates),
+    # sum to the total call cost.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(
+        guard,
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+    await _drive_turn(agent)  # LLM turn (model="gpt-4o", priced from the LLM map)
+    session.emit("metrics_collected", _event(_llm_metrics(500, 200)))
+    session.emit("metrics_collected", _event(_stt_metric(30.0)))
+    session.emit("metrics_collected", _event(_tts_metric(1200)))
+    budget.meter_telephony(1.0)
+
+    legs = {e.model_or_tool: e.cost_usd for e in guard.spend_log}
+    assert set(legs) == {"gpt-4o", "livekit-stt", "livekit-tts", "livekit-telephony"}
+    assert sum(legs.values()) == pytest.approx(guard.advisory().spent_usd)

--- a/tests/test_pipecat_integration.py
+++ b/tests/test_pipecat_integration.py
@@ -33,13 +33,17 @@ from pipecat.frames.frames import (  # noqa: E402
     LLMFullResponseStartFrame,
     MetricsFrame,
 )
-from pipecat.metrics.metrics import LLMTokenUsage, LLMUsageMetricsData  # noqa: E402
+from pipecat.metrics.metrics import (  # noqa: E402
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    TTSUsageMetricsData,
+)
 from pipecat.pipeline.pipeline import Pipeline  # noqa: E402
 from pipecat.pipeline.runner import PipelineRunner  # noqa: E402
 from pipecat.pipeline.task import PipelineParams, PipelineTask  # noqa: E402
 
 from floe_guard import BudgetGuard  # noqa: E402
-from floe_guard.errors import BudgetExceeded  # noqa: E402
+from floe_guard.errors import BudgetExceeded, UnpriceableVoiceError  # noqa: E402
 from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor  # noqa: E402
 
 
@@ -50,6 +54,10 @@ def _metrics_frame(prompt_tokens, completion_tokens, model="gpt-4o") -> MetricsF
         total_tokens=prompt_tokens + completion_tokens,
     )
     return MetricsFrame(data=[LLMUsageMetricsData(processor="test-llm", model=model, value=usage)])
+
+
+def _tts_frame(characters: int) -> MetricsFrame:
+    return MetricsFrame(data=[TTSUsageMetricsData(processor="test-tts", value=characters)])
 
 
 async def _run_frames(
@@ -249,6 +257,95 @@ async def test_settles_usage_even_without_a_start_frame():
     assert guard.advisory().spent_usd > 0
     assert not processor._pending
     assert processor._reserved == 0.0
+
+
+@pytest.mark.asyncio
+async def test_tts_metered_from_voice_cost_map_by_default():
+    # No hand-typed rate -- name the vendor, meter the TTSUsageMetricsData Pipecat
+    # emits at the bundled per-1k-chars rate.
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(
+        guard, model="gpt-4o", tts_model="elevenlabs-flash-v2.5"
+    )
+
+    await _run_frames(processor, [_tts_frame(2000)])
+
+    # 2000 chars / 1000 * $0.05 = $0.10
+    assert guard.tool_costs["pipecat-tts"] == pytest.approx(0.10)
+
+
+@pytest.mark.asyncio
+async def test_tts_ignored_by_default_without_a_vendor():
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(guard, model="gpt-4o")
+
+    await _run_frames(processor, [_tts_frame(2000)])
+
+    assert guard.advisory().spent_usd == 0.0
+
+
+@pytest.mark.asyncio
+async def test_unpriceable_tts_vendor_pushes_fatal_error():
+    # A configured-but-unpriceable TTS vendor must hard-stop, not silently $0.
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(guard, model="gpt-4o", tts_model="ghost-tts")
+
+    pipeline = Pipeline([processor])
+    task = PipelineTask(
+        pipeline, params=PipelineParams(enable_metrics=True, enable_usage_metrics=True)
+    )
+    runner = PipelineRunner()
+
+    captured_errors = []
+
+    @task.event_handler("on_pipeline_error")
+    async def _on_pipeline_error(task, frame):
+        captured_errors.append(frame)
+
+    async def drive():
+        await task.queue_frame(_tts_frame(2000))
+        await asyncio.sleep(0.05)
+        if not task.has_finished():
+            await task.queue_frame(EndFrame())
+
+    await asyncio.gather(runner.run(task), drive())
+
+    assert len(captured_errors) == 1
+    assert captured_errors[0].fatal is True
+    assert guard.advisory().spent_usd == 0.0
+
+
+def test_meter_stt_and_telephony_from_map():
+    # STT + telephony have no native Pipecat usage frame, so they're driven
+    # explicitly -- still priced from the map, no hand-typed rate.
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(
+        guard,
+        model="gpt-4o",
+        stt_model="deepgram-nova-3",
+        telephony="twilio-us-inbound-local",
+    )
+
+    stt_cost = processor.meter_stt(60.0)  # 60s
+    tel_cost = processor.meter_telephony(2.0)  # 2 min
+
+    assert stt_cost == pytest.approx(60.0 * (0.0077 / 60), rel=1e-4)
+    assert tel_cost == pytest.approx(2.0 * 0.0085)
+    assert set(guard.tool_costs) == {"pipecat-stt", "pipecat-telephony"}
+
+
+def test_meter_stt_unconfigured_is_noop():
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(guard, model="gpt-4o")
+    assert processor.meter_stt(60.0) is None
+    assert guard.advisory().spent_usd == 0.0
+
+
+def test_meter_stt_unpriceable_vendor_fails_closed():
+    guard = BudgetGuard(limit_usd=100.00)
+    processor = FloeBudgetGuardProcessor(guard, model="gpt-4o", stt_model="ghost-stt")
+    with pytest.raises(UnpriceableVoiceError):
+        processor.meter_stt(60.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_examples.py
+++ b/tests/test_voice_examples.py
@@ -16,9 +16,6 @@ import pytest
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
-pytest.importorskip("livekit.agents")
-pytest.importorskip("pipecat")
-
 
 def _load(module_name: str):
     sys.path.insert(0, str(EXAMPLES))
@@ -38,6 +35,7 @@ def _assert_four_legs_sum_to_total(guard, expected_tools: set[str]) -> None:
 
 @pytest.mark.asyncio
 async def test_livekit_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("livekit.agents")
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     demo = _load("voice_call_cost_livekit")
@@ -52,6 +50,7 @@ async def test_livekit_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) 
 
 @pytest.mark.asyncio
 async def test_pipecat_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("pipecat")
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     demo = _load("voice_call_cost_pipecat")

--- a/tests/test_voice_examples.py
+++ b/tests/test_voice_examples.py
@@ -1,0 +1,64 @@
+"""The voice-call-cost examples must run with no API key and no network.
+
+AC1: a Pipecat and a LiveKit demo each emit a per-leg breakdown (STT / LLM / TTS
+/ telephony) summing to a total call cost, priced entirely from the bundled cost
+map with no manual rates.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+pytest.importorskip("livekit.agents")
+pytest.importorskip("pipecat")
+
+
+def _load(module_name: str):
+    sys.path.insert(0, str(EXAMPLES))
+    try:
+        return importlib.import_module(module_name)
+    finally:
+        sys.path.remove(str(EXAMPLES))
+
+
+def _assert_four_legs_sum_to_total(guard, expected_tools: set[str]) -> None:
+    legs = {e.model_or_tool for e in guard.spend_log}
+    assert legs == expected_tools, legs
+    total = sum(e.cost_usd for e in guard.spend_log)
+    assert total == pytest.approx(guard.advisory().spent_usd)
+    assert total > 0
+
+
+@pytest.mark.asyncio
+async def test_livekit_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    demo = _load("voice_call_cost_livekit")
+
+    guard = await demo.run()
+
+    _assert_four_legs_sum_to_total(
+        guard, {"gpt-4o", "livekit-stt", "livekit-tts", "livekit-telephony"}
+    )
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_pipecat_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    demo = _load("voice_call_cost_pipecat")
+
+    guard = await demo.run()
+
+    _assert_four_legs_sum_to_total(
+        guard, {"gpt-4o", "pipecat-stt", "pipecat-tts", "pipecat-telephony"}
+    )
+    assert "OPENAI_API_KEY" not in os.environ

--- a/tests/test_voice_pricing.py
+++ b/tests/test_voice_pricing.py
@@ -1,0 +1,172 @@
+"""Tests for offline voice pricing — fail-closed resolution and per-unit math.
+
+The voice twin of tests/test_pricing.py: STT is billed per second, TTS per 1k
+chars, telephony per minute, and every schema/vendor mismatch fails closed
+(``UnpriceableVoiceError``) rather than metering a leg at a silent $0.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard.errors import UnpriceableVoiceError
+from floe_guard.pricing import _VOICE_MAP
+from floe_guard.voice_pricing import (
+    _UNIT_FOR_MODE,
+    VoiceRate,
+    lookup_voice_rate,
+    price_voice_leg,
+    resolve_voice_rate,
+    voice_leg_cost,
+)
+
+
+def test_resolves_known_stt_vendor_from_cost_map() -> None:
+    # $0.0077/min mono ÷ 60 = $0.0001283333/sec.
+    rate = lookup_voice_rate("deepgram-nova-3", "stt")
+    assert rate == pytest.approx(0.0077 / 60, rel=1e-4)
+
+
+def test_resolves_known_tts_vendor_from_cost_map() -> None:
+    assert lookup_voice_rate("elevenlabs-multilingual-v2", "tts") == pytest.approx(0.10)
+    assert lookup_voice_rate("elevenlabs-flash-v2.5", "tts") == pytest.approx(0.05)
+
+
+def test_resolves_known_telephony_vendor_from_cost_map() -> None:
+    assert lookup_voice_rate("twilio-us-inbound-local", "telephony") == pytest.approx(0.0085)
+
+
+def test_unknown_vendor_is_unpriceable() -> None:
+    assert lookup_voice_rate("no-such-vendor-anywhere", "stt") is None
+    assert lookup_voice_rate(None, "stt") is None
+
+
+def test_mode_mismatch_fails_closed() -> None:
+    # AC3: an STT entry asked to price a TTS leg is a schema mismatch — refuse it
+    # rather than mis-bill a per-second rate as if it were per-1k-chars.
+    assert lookup_voice_rate("deepgram-nova-3", "tts") is None
+    assert lookup_voice_rate("elevenlabs-flash-v2.5", "stt") is None
+    assert lookup_voice_rate("twilio-us-inbound-local", "stt") is None
+
+
+def test_unit_mismatch_fails_closed() -> None:
+    # AC3: an entry whose unit disagrees with its mode's canonical unit is
+    # rejected even if the mode matches — a corrupted/edited entry can't slip a
+    # wrong-unit rate through as a valid-looking price.
+    from floe_guard import voice_pricing
+
+    poisoned = dict(voice_pricing._VOICE_MAP)
+    poisoned["bad-stt"] = {
+        "mode": "stt",
+        "unit": "usd_per_minute",  # wrong: stt must be usd_per_second
+        "rate": 0.0077,
+        "provider": "test",
+    }
+    original = voice_pricing._VOICE_MAP
+    try:
+        voice_pricing._VOICE_MAP = poisoned
+        assert lookup_voice_rate("bad-stt", "stt") is None
+    finally:
+        voice_pricing._VOICE_MAP = original
+
+
+def test_non_finite_or_negative_rate_is_unpriceable() -> None:
+    from floe_guard import voice_pricing
+
+    poisoned = dict(voice_pricing._VOICE_MAP)
+    poisoned["nan-stt"] = {
+        "mode": "stt",
+        "unit": "usd_per_second",
+        "rate": float("inf"),
+        "provider": "test",
+    }
+    poisoned["neg-stt"] = {
+        "mode": "stt",
+        "unit": "usd_per_second",
+        "rate": -0.01,
+        "provider": "test",
+    }
+    original = voice_pricing._VOICE_MAP
+    try:
+        voice_pricing._VOICE_MAP = poisoned
+        assert lookup_voice_rate("nan-stt", "stt") is None
+        assert lookup_voice_rate("neg-stt", "stt") is None
+    finally:
+        voice_pricing._VOICE_MAP = original
+
+
+def test_resolve_voice_rate_raises_fail_closed_for_unknown_vendor() -> None:
+    # AC2: a vendor absent from the voice map with no override raises the
+    # fail-closed error — never a silent $0.
+    with pytest.raises(UnpriceableVoiceError) as exc:
+        resolve_voice_rate("mystery-tts", "tts")
+    assert exc.value.vendor == "mystery-tts"
+    assert exc.value.mode == "tts"
+
+
+def test_override_wins_over_cost_map() -> None:
+    resolved = resolve_voice_rate("deepgram-nova-3", "stt", override=0.0002)
+    assert isinstance(resolved, VoiceRate)
+    assert resolved.source == "override"
+    assert resolved.rate == 0.0002
+    assert resolved.unit == _UNIT_FOR_MODE["stt"]
+
+
+def test_override_prices_a_vendor_the_map_cannot() -> None:
+    resolved = resolve_voice_rate("some-brand-new-tts", "tts", override=0.07)
+    assert resolved.source == "override"
+    assert resolved.rate == 0.07
+
+
+def test_override_rejects_non_finite() -> None:
+    with pytest.raises(ValueError):
+        resolve_voice_rate("x", "stt", override=float("nan"))
+    with pytest.raises(ValueError):
+        resolve_voice_rate("x", "stt", override=-1.0)
+
+
+def test_voice_leg_cost_units() -> None:
+    # STT: seconds * $/sec
+    assert voice_leg_cost("stt", 10.0, 0.0001) == pytest.approx(0.001)
+    # TTS: chars / 1000 * $/1k-chars
+    assert voice_leg_cost("tts", 2000, 0.05) == pytest.approx(0.10)
+    # telephony: minutes * $/min
+    assert voice_leg_cost("telephony", 3.0, 0.0085) == pytest.approx(0.0255)
+
+
+def test_voice_leg_cost_clamps_negative_quantity() -> None:
+    assert voice_leg_cost("stt", -5.0, 0.01) == 0.0
+
+
+def test_price_voice_leg_skips_when_unconfigured() -> None:
+    # Neither a vendor nor an override — the leg is un-metered (token-only
+    # contract preserved), NOT a fail-closed raise.
+    assert price_voice_leg("stt", 10.0) is None
+
+
+def test_price_voice_leg_fails_closed_when_configured_but_unpriceable() -> None:
+    with pytest.raises(UnpriceableVoiceError):
+        price_voice_leg("tts", 1000, model="ghost-vendor")
+
+
+def test_cost_map_has_every_required_vendor() -> None:
+    # AC4: ≥1 entry each for Deepgram, AssemblyAI, ElevenLabs, Cartesia, Rime,
+    # Twilio. Telnyx is deferred (verified list rate pending) — see the
+    # `# TODO(telnyx)` note in voice_pricing.py and scripts/update-cost-map.mjs.
+    providers = {entry["provider"] for entry in _VOICE_MAP.values()}
+    for required in ("deepgram", "assemblyai", "elevenlabs", "cartesia", "rime", "twilio"):
+        assert required in providers, f"voice map missing a {required} entry"
+    assert "telnyx" not in providers  # deferred, on purpose
+
+
+def test_every_voice_entry_matches_its_declared_unit() -> None:
+    # Invariant that survives a hand-edit or a script refresh: every entry's unit
+    # is the canonical one for its mode, so no leg can ever be mis-billed.
+    for vendor, entry in _VOICE_MAP.items():
+        mode = entry.get("mode")
+        assert mode in _UNIT_FOR_MODE, f"{vendor} has unknown mode {mode!r}"
+        assert entry.get("unit") == _UNIT_FOR_MODE[mode], f"{vendor} unit/mode mismatch"
+        assert isinstance(entry.get("rate"), (int, float)) and entry["rate"] > 0, (
+            f"{vendor} has a non-positive rate"
+        )
+        assert entry.get("provider"), f"{vendor} missing provider"


### PR DESCRIPTION
The wedge. `cost_map.json` was LLM-only and the Pipecat/LiveKit adapters made you hand-type STT/TTS rates — so the shipped voice adapters couldn't answer *"what did this call cost"* out of the box. Now they do, at the $0 tier, fail-closed.

## What
- **Voice section** under a reserved `__voice__` key with an explicit **unit schema** — STT `usd_per_second`, TTS `usd_per_1k_chars`, telephony `usd_per_minute`. Split out of the LLM map at load, so the token resolver and its whole-map invariants never see voice entries.
- **`voice_pricing.py`** — the fail-closed resolver, parity with `UnpriceableModelError` via new **`UnpriceableVoiceError`**. A missing vendor / wrong `mode` / **wrong `unit`** (a $/min stored as STT would 60× over-bill — caught) / non-finite rate is unpriceable; a *configured-but-unpriceable* leg **raises** rather than accruing a silent $0; a per-unit **override still wins**; an unconfigured leg is skipped (token-only contract preserved).
- **Pipecat + LiveKit adapters** meter STT/LLM/TTS/telephony from the map **by default** (no hand-typed rates). Two **no-network stub demos** (`examples/voice_call_cost_*.py`) emit a per-leg breakdown summing to a total.
- **Seed v1 (US-only telephony)** — Deepgram (Nova-3 mono/multilingual/base), AssemblyAI, ElevenLabs (Multilingual v2 / Flash / Turbo), **Cartesia (Sonic = TTS, Line = telephony)**, Rime, Twilio (inbound/outbound/SIP). **Telnyx deferred** with a code comment — not invented.
- `update-cost-map.mjs` voice block + drift caveat; **JS cost map kept byte-identical**; **pyproject voice keywords**; **README voice section** (US-only v1, drift-prone snapshot, fail-closed, per-leg example).

## Acceptance criteria — all met
1. ✅ Pipecat + LiveKit demos emit a per-leg STT/LLM/TTS/telephony breakdown (→ `$0.026477`), runnable with **no network / no key**.
2. ✅ Unknown voice vendor + no override → `UnpriceableVoiceError` (not silent $0).
3. ✅ Unit schemas enforced; mode/unit mismatch rejected in tests.
4. ✅ ≥1 entry each for Deepgram, AssemblyAI, ElevenLabs, Cartesia, Rime, Twilio; Telnyx deferred with a comment.
5. ✅ pyproject exposes the voice keywords.
6. ✅ README voice section states US-only v1 + drift-prone snapshot.

**Constraint honored:** enforcement stays pre-turn admission (reserve-before-turn); telephony is per-minute accrual, no mid-call line-cutting.

## Review note
Built by the Python specialist; I reviewed the whole diff, spot-checked the rate arithmetic, and **caught + fixed one defect**: `cartesia-line` was classified as `tts / usd_per_1k_chars` when the ticket specifies *"Line telephony $0.06/min"* — corrected to `telephony / usd_per_minute` across both cost maps + the update script (and the README seeded-vendor line). **328 tests pass, ruff clean** (reproduced independently).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic cost tracking for speech-to-text, text-to-speech, and US telephony usage.
  - Added bundled pricing for supported voice providers, with custom per-unit rates taking precedence.
  - Added voice and telephony metering to LiveKit and Pipecat integrations.
  - Unknown or invalid configured pricing now fails safely; unconfigured usage remains unmetered.

- **Documentation**
  - Added supported providers, pricing caveats, enforcement behavior, and per-call cost examples.

- **Examples**
  - Added offline LiveKit and Pipecat voice-call cost demonstrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->