### PR TITLE
docs(readme): voice-forward hero to match shipped 0.13.0 voice adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@
 [![CI](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**A local budget guardrail for AI agents.** It hard-stops your agent *before its
-next LLM or paid tool call* when it would cross a spend ceiling — tokens and
-tool calls under **one local ceiling**, so a runaway loop dies at $0.10 instead
-of $4,000. No account, no signup, no network, **no telemetry**. Runs in your
-process.
+**A local budget guardrail for AI agents — including voice.** It hard-stops your
+agent *before its next turn or LLM call* when it would cross a spend ceiling:
+**per-turn enforcement for [Pipecat](#pipecat-voice) and [LiveKit](#livekit-voice)**
+voice pipelines, and a hard stop for runaway LLM loops — a loop dies at $0.10
+instead of $4,000. No account, no signup, no network, **no telemetry**. Runs in
+your process.
 
-Works with [CrewAI](#crewai) · [LiteLLM](#litellm) · [LangChain](#langchain) ·
-[LangGraph](#langgraph) · [OpenAI](#openai) · [Anthropic](#anthropic) ·
-[Gemini](#google-gemini) · [Vercel AI SDK](#vercel-ai-sdk) — and voice pipelines
-via [Pipecat](#pipecat-voice) · [LiveKit](#livekit-voice) — or any stack, via
-plain `check()` / `record()`. See the [adapter matrix](#adapter-matrix) for what
-ships in Python vs TypeScript.
+**Voice:** [Pipecat](#pipecat-voice) · [LiveKit](#livekit-voice) — reserve before
+each turn, settle on real usage, so a turn that would cross the ceiling never
+starts. **Any agent:** [CrewAI](#crewai) · [LiteLLM](#litellm) ·
+[LangChain](#langchain) · [LangGraph](#langgraph) · [OpenAI](#openai) ·
+[Anthropic](#anthropic) · [Gemini](#google-gemini) · [Vercel AI SDK](#vercel-ai-sdk)
+— or any stack, via plain `check()` / `record()`. See the
+[adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
 The hard-stop is contract-based: gate each call through the guard — adapters do
 it for LLM calls; for paid tools, [`reserve_tool()` / `settle_tool()`](#tool-spend-under-the-same-ceiling)
 block *before* the call runs (`record_tool()` alone meters a call after the


### PR DESCRIPTION
Part of the "fix the shop window" ticket. Grounding correction first: **`main`'s README is not 0.9-era** — it already has the full **Voice adapters (STT→LLM→TTS)** section, **Pipecat** + **LiveKit** subsections, the **adapter matrix**, `guard_stream`, `LatencyBudget`, `step()`, UTC-day persistence, the Beta classifier, and `pipecat`/`livekit` extras. So AC1 ("lists the adapters + matrix, not LLM-only") was substantially already met.

The one real gap: the **hero led LLM-first** ("before its next LLM or paid tool call… a runaway loop dies at $0.10"), with voice a secondary "and also." This foregrounds voice — per-turn enforcement for Pipecat/LiveKit — in the hero and the capability line.

**Honest to 0.13.0, no overclaim:** it says *per-turn enforcement* (which the Python adapters do today), **not** "meters the whole call from a cost map" (that's the unreleased 0.14 / PR #70) and **not** TS voice adapters (none exist). Hero-only change (lines ~10–21), so it doesn't collide with #70's voice-section edits.

The external distribution ACs (Pipecat COMMUNITY_INTEGRATIONS PR, LiveKit ecosystem listing, Discord post) are handled separately — submission-ready drafts, since posting to Discord / submitting to their surfaces isn't something I can do directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to highlight voice support as a primary feature.
  * Added details on per-turn budget enforcement for voice pipelines.
  * Clarified budget reservation, usage settlement, interruption handling, and optional speech-to-text/text-to-speech metering.
  * Distinguished voice adapters from general agent integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->