### PR TITLE
feat(hosted): one-line upgrade — BudgetGuard.from_floe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   the un-bypassable, cross-vendor cap. Zero-telemetry invariant preserved (no
   network unless a key is set) and fail-closed (a failed read raises
   `HostedEnforcementError`, or degrades to a `fallback_limit_usd` local ceiling
-  with a loud warning). The advisory-symmetry claim (`advisory()` shape ==
-  hosted's `X-Floe-Budget-Advisory` header, so taper logic ports unchanged) is now
-  in the README's core pitch.
+  with a loud warning). The README core pitch now documents the shared near-limit
+  signal (`near_limit` + `used_bps`) between local `advisory()` and hosted's
+  `X-Floe-Budget-Advisory` header, so tapering logic carries over — the header
+  nests it under `tightest` with raw amounts, a light field remap, not an
+  identical shape.
 
 - **Voice cost map — meter the whole call by default** (P0): STT/TTS/telephony
   rates ship under the reserved `__voice__` key of `cost_map.json` (units: STT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,22 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.14.0 / js 0.10.0
+## Unreleased — py 0.15.0 / js 0.10.0
 
 ### Added (py)
+
+- **One line to hosted — `BudgetGuard.from_floe(api_key=…)`**: constructs a guard
+  whose local ceiling is read from your **server-side budget headroom** (the min
+  of auto-borrow headroom and session spend remaining, via
+  `hosted_remaining_usd()`), so the free→hosted upgrade is a one-line constructor
+  swap with no other code changes. Budget, not balance: the read is a headroom
+  signal and enforcement stays local — hosted Floe remains the source of truth for
+  the un-bypassable, cross-vendor cap. Zero-telemetry invariant preserved (no
+  network unless a key is set) and fail-closed (a failed read raises
+  `HostedEnforcementError`, or degrades to a `fallback_limit_usd` local ceiling
+  with a loud warning). The advisory-symmetry claim (`advisory()` shape ==
+  hosted's `X-Floe-Budget-Advisory` header, so taper logic ports unchanged) is now
+  in the README's core pitch.
 
 - **Voice cost map — meter the whole call by default** (P0): STT/TTS/telephony
   rates ship under the reserved `__voice__` key of `cost_map.json` (units: STT

--- a/README.md
+++ b/README.md
@@ -73,6 +73,32 @@ This rigs a loop against a **stub LLM** — no real API key, no account, no netw
 It prices each fake `gpt-4o` call offline and the guard halts the loop after a few
 iterations. This is the reproducible "stop the loop" demo.
 
+## One line to hosted
+
+Already on hosted Floe? Keep every line of your code — swap the constructor.
+`from_floe` reads your **server-side budget headroom** and uses it as the local
+ceiling, so the free→hosted upgrade is one line:
+
+```python
+from floe_guard import BudgetGuard
+
+guard = BudgetGuard.from_floe(api_key="floe_…")   # ceiling = your hosted headroom
+guard.check()                                     # everything else is unchanged
+response = call_your_llm(...)
+guard.record("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens)
+```
+
+Budget, not balance: the read is a *headroom* signal and enforcement stays
+**local** — [hosted Floe](#when-you-outgrow-local-guardrails) remains the source
+of truth for the un-bypassable, cross-vendor cap. No key set → no network (the
+[zero-telemetry](#no-telemetry) invariant holds); a failed read fails closed
+(pass `fallback_limit_usd=` to degrade to a local ceiling instead).
+
+The taper logic ports for free, too: the `advisory()` you read locally is the
+**same shape** hosted Floe returns on every proxied call (the
+`X-Floe-Budget-Advisory` header), so code that tapers as you near the limit works
+unchanged against server-truth headroom across *every* vendor and cap.
+
 ## Why floe-guard?
 
 You can already *see* what your agent spends — the problem is seeing it too late.
@@ -246,12 +272,10 @@ what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
 `withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
 for a no-network demo.
 
-This is the **same advisory shape** hosted Floe returns on every proxied call
-(the `X-Floe-Budget-Advisory` header), so the logic you write here ports
-unchanged — hosted just answers across *every* vendor and cap with server-truth
-balances and arbitrary rolling-window timing, which a local UTC-day budget can't
-know.
-The TS package exposes the identical `guard.advisory()`.
+The taper logic you just wrote ports to hosted unchanged — same `advisory()`
+shape, answered across *every* vendor and cap with server-truth headroom; see
+[One line to hosted](#one-line-to-hosted). The TS package exposes the identical
+`guard.advisory()`.
 
 ## Per-call spend log
 
@@ -881,6 +905,9 @@ budget read: set `FLOE_API_KEY` (agent key `floe_…`) and `hosted_remaining_usd
 returns the server-side budget headroom via `GET /v1/agents/credit-remaining`.
 `FLOE_API_BASE_URL` overrides the API host (default
 `https://credit-api.floelabs.xyz`). Nothing runs unless the key is set.
+The [one-line upgrade](#one-line-to-hosted) is `BudgetGuard.from_floe(api_key=…)`,
+which uses that headroom as the local ceiling — budget, not balance, and
+enforcement stays local.
 
 → [dev-dashboard.floelabs.xyz](https://dev-dashboard.floelabs.xyz/)
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,13 @@ of truth for the un-bypassable, cross-vendor cap. No key set → no network (the
 [zero-telemetry](#no-telemetry) invariant holds); a failed read fails closed
 (pass `fallback_limit_usd=` to degrade to a local ceiling instead).
 
-The taper logic ports for free, too: the `advisory()` you read locally is the
-**same shape** hosted Floe returns on every proxied call (the
-`X-Floe-Budget-Advisory` header), so code that tapers as you near the limit works
-unchanged against server-truth headroom across *every* vendor and cap.
+Your tapering logic carries over, too: local `advisory()` and hosted's
+`X-Floe-Budget-Advisory` header expose the same **near-limit signal**
+(`near_limit` + `used_bps` utilization), so the "near the cap? taper now"
+decision you branch on is the same. The wire shapes differ — the hosted header
+nests the tightest cap under `tightest` with raw-integer amounts, so field access
+is a light remap — but it answers that signal across *every* vendor and cap, not
+just the one you instrumented locally.
 
 ## Why floe-guard?
 
@@ -272,8 +275,10 @@ what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
 `withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
 for a no-network demo.
 
-The taper logic you just wrote ports to hosted unchanged — same `advisory()`
-shape, answered across *every* vendor and cap with server-truth headroom; see
+The taper logic you just wrote carries over to hosted — the same near-limit
+signal (`near_limit` + `used_bps`), answered across *every* vendor and cap; the
+hosted `X-Floe-Budget-Advisory` header nests it under `tightest` with raw-integer
+amounts, so field access is a light remap. See
 [One line to hosted](#one-line-to-hosted). The TS package exposes the identical
 `guard.advisory()`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.14.0"
+version = "0.15.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -42,6 +42,7 @@ from typing import Literal, NoReturn
 
 from .errors import (
     BudgetExceeded,
+    HostedEnforcementError,
     TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
@@ -363,6 +364,89 @@ class BudgetGuard:
         if self._store is not None:
             with self._lock:
                 self._refresh_persistent_state_locked()
+
+    # ── hosted upgrade ────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_floe(
+        cls,
+        api_key: str | None = None,
+        *,
+        base_url: str | None = None,
+        fallback_limit_usd: float | None = None,
+        timeout: float = 10.0,
+        **guard_kwargs: object,
+    ) -> BudgetGuard:
+        """Build a guard whose local ceiling is set from your hosted Floe headroom.
+
+        The one-line upgrade from a hand-picked ``limit_usd`` to a ceiling that
+        tracks server-side headroom: reads
+        :func:`~floe_guard.hosted.hosted_remaining_usd` once (the **minimum** of
+        auto-borrow headroom and session spend remaining) and constructs a
+        :class:`BudgetGuard` with that number as ``limit_usd``. Everything else —
+        ``check`` / ``record`` / ``reserve`` / ``advisory`` — is unchanged.
+
+        Budget, not balance. The hosted read is a *headroom / budget* signal, not
+        an account balance, and this guard still enforces **locally**. Hosted Floe
+        remains the source of truth for the un-bypassable, cross-vendor cap; the
+        local ceiling is a fresh per-process budget bounded by what the server
+        currently allows.
+
+        Refresh policy: headroom is read **once, at construction**. It moves as you
+        borrow/repay, so to re-read later either call ``from_floe`` again or set
+        ``guard.limit_usd = hosted_remaining_usd(api_key)`` on a schedule you own.
+
+        Zero-telemetry invariant: no network call happens unless a key is supplied
+        (via ``api_key=`` or ``FLOE_API_KEY``). With no key the hosted read raises
+        before touching the network.
+
+        Fail-closed: a failed hosted read (missing/invalid key, 401/403/404,
+        network/timeout) raises
+        :class:`~floe_guard.errors.HostedEnforcementError` — the guard is *not*
+        silently built with an unknown or unbounded ceiling. Pass
+        ``fallback_limit_usd`` to instead degrade to a known local ceiling (with a
+        loud warning), so a transient blip falls back to local enforcement rather
+        than crashing the agent.
+
+        Args:
+            api_key: Floe agent key (``floe_<hex>``). Defaults to ``FLOE_API_KEY``.
+            base_url: API base. Defaults to ``FLOE_API_BASE_URL``, else production.
+            fallback_limit_usd: local ceiling to use if the hosted read fails.
+                ``None`` (default) re-raises the error (fail closed).
+            timeout: socket timeout for the hosted read, in seconds.
+            **guard_kwargs: any other :class:`BudgetGuard` option (``fail_closed``,
+                ``on_block``, ``near_limit_bps``, ``price_overrides``,
+                ``token_limit``, ``window`` / ``store``, …). ``limit_usd`` is
+                derived from headroom and must not be passed here.
+
+        Raises:
+            HostedEnforcementError: the hosted read failed and no
+                ``fallback_limit_usd`` was given.
+            TypeError: ``limit_usd`` was passed in ``guard_kwargs``.
+        """
+        if "limit_usd" in guard_kwargs:
+            raise TypeError(
+                "from_floe derives limit_usd from hosted headroom; pass "
+                "fallback_limit_usd= for the offline fallback instead."
+            )
+        # Local import: hosted.py is a leaf module, but importing it at the top of
+        # guard.py would couple the core guard to the network client for no gain.
+        from .hosted import hosted_remaining_usd
+
+        try:
+            ceiling = hosted_remaining_usd(api_key, base_url=base_url, timeout=timeout)
+        except HostedEnforcementError:
+            if fallback_limit_usd is None:
+                raise
+            fallback = float(fallback_limit_usd)
+            warnings.warn(
+                "floe-guard: could not read hosted Floe headroom; falling back to "
+                f"a local ceiling of ${fallback:.2f}. Enforcement is local-only "
+                "until the hosted read succeeds.",
+                stacklevel=2,
+            )
+            ceiling = fallback
+        return cls(limit_usd=ceiling, **guard_kwargs)  # type: ignore[arg-type]
 
     # ── enforcement ───────────────────────────────────────────────────────────
 

--- a/tests/test_from_floe.py
+++ b/tests/test_from_floe.py
@@ -1,0 +1,117 @@
+"""``BudgetGuard.from_floe`` sets the local ceiling from hosted Floe headroom.
+
+The one-line upgrade: reads server-side headroom once and enforces it locally.
+These tests never hit the network — ``urllib.request.urlopen`` is mocked, so they
+exercise the real ``hosted_remaining_usd`` read end to end.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from floe_guard import BudgetGuard
+from floe_guard.errors import HostedEnforcementError
+
+
+def _ok_response(payload: dict[str, object]) -> mock.MagicMock:
+    body = json.dumps(payload).encode()
+    resp = mock.MagicMock()
+    resp.read.return_value = body
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _http_error(code: int, payload: dict[str, object] | None = None) -> urllib.error.HTTPError:
+    body = json.dumps(payload).encode() if payload is not None else b""
+    return urllib.error.HTTPError(
+        url="https://credit-api.floelabs.xyz/v1/agents/credit-remaining",
+        code=code,
+        msg="error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+# ── ceiling reflects server headroom ──────────────────────────────────────────
+
+
+def test_ceiling_is_server_headroom() -> None:
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": None}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        guard = BudgetGuard.from_floe(api_key="floe_abc")
+    assert guard.limit_usd == 5.0
+    # A working guard: spend accrues and the ceiling holds.
+    guard.check()
+    assert guard.remaining_usd == 5.0
+
+
+def test_ceiling_takes_min_of_headroom_and_session() -> None:
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": "2000000"}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        guard = BudgetGuard.from_floe(api_key="floe_abc")
+    assert guard.limit_usd == 2.0
+
+
+def test_forwards_guard_options() -> None:
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": None}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        guard = BudgetGuard.from_floe(api_key="floe_abc", near_limit_bps=5000)
+    assert guard.near_limit_bps == 5000
+
+
+# ── zero-telemetry + fail-closed ──────────────────────────────────────────────
+
+
+def test_no_key_fails_closed_without_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Zero-telemetry invariant: with no key, from_floe raises BEFORE any network
+    # call — nothing leaves the process.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(HostedEnforcementError, match="No Floe API key"):
+            BudgetGuard.from_floe()
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("code", [401, 403, 404])
+def test_invalid_key_fails_closed(code: int) -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=_http_error(code, {"error": "x"})):
+        with pytest.raises(HostedEnforcementError, match=str(code)):
+            BudgetGuard.from_floe(api_key="floe_bad")
+
+
+def test_network_error_fails_closed() -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("down")):
+        with pytest.raises(HostedEnforcementError, match="Could not reach"):
+            BudgetGuard.from_floe(api_key="floe_abc")
+
+
+# ── opt-in fallback degrades to local enforcement ─────────────────────────────
+
+
+def test_fallback_used_on_failed_read_with_warning() -> None:
+    with mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("down")):
+        with pytest.warns(UserWarning, match="falling back to a local ceiling"):
+            guard = BudgetGuard.from_floe(api_key="floe_abc", fallback_limit_usd=1.50)
+    assert guard.limit_usd == 1.50
+
+
+def test_fallback_ignored_when_read_succeeds() -> None:
+    payload = {"headroomToAutoBorrow": "5000000", "sessionSpendRemaining": None}
+    with mock.patch("urllib.request.urlopen", return_value=_ok_response(payload)):
+        guard = BudgetGuard.from_floe(api_key="floe_abc", fallback_limit_usd=1.50)
+    assert guard.limit_usd == 5.0
+
+
+# ── guard rails ───────────────────────────────────────────────────────────────
+
+
+def test_limit_usd_in_kwargs_is_rejected() -> None:
+    # limit_usd comes from headroom; passing one is a mistake, not a silent override.
+    with pytest.raises(TypeError, match="fallback_limit_usd"):
+        BudgetGuard.from_floe(api_key="floe_abc", limit_usd=10.0)


### PR DESCRIPTION
## The one-line upgrade

`hosted.py` was 90% built and 0% connected. This wires it into the guard.

```python
guard = BudgetGuard.from_floe(api_key="floe_…")   # ceiling = your hosted headroom
```

`from_floe` reads server-side **budget headroom** (min of auto-borrow headroom and session spend remaining) once at construction and uses it as the local ceiling. Everything else — `check` / `record` / `reserve` / `advisory` — is unchanged, so the free→hosted path is a one-line constructor swap.

## Hard constraint honored — budget ≠ balance

The hosted read is a **headroom/budget** signal, never a balance. It's stored as `limit_usd` (a ceiling), enforcement stays **local**, and hosted Floe remains the source of truth for the un-bypassable, cross-vendor cap. Copy says so in the docstring, CHANGELOG, and README; the old "server-truth **balances**" wording in the deep advisory paragraph is scrubbed.

## Fail-closed + zero-telemetry

- No key set (via `api_key=` or `FLOE_API_KEY`) → the read raises **before any socket** — zero-telemetry invariant preserved (test asserts `urlopen.assert_not_called()`).
- Failed read (missing/invalid key, 401/403/404, network/timeout) → raises `HostedEnforcementError`. The guard is *not* silently built with an unknown ceiling.
- Opt-in `fallback_limit_usd=` degrades to a known local ceiling with a loud warning, so a transient blip falls back to local enforcement instead of crashing the agent.
- `limit_usd=` in kwargs is rejected (`TypeError`) — the ceiling comes from headroom, not a silent override.

## README — advisory-symmetry promoted to the core pitch

New **## One line to hosted** section (right before "Why floe-guard?") carries both the one-liner and the advisory portability note: local `advisory()` and hosted's `X-Floe-Budget-Advisory` header share the **near-limit signal** (`near_limit` + `used_bps`), so tapering logic carries over — the hosted header nests it under `tightest` with raw-integer amounts (a light field remap), not an identical shape. The deep paragraph is trimmed to a back-reference.

## Acceptance criteria

- [x] `from_floe(api_key=…)` returns a working guard; mocked endpoint → local ceiling reflects server headroom
- [x] Missing/invalid key covered by tests, fails closed with a documented error
- [x] README core shows the one-line upgrade + advisory-symmetry; no headroom-as-balance conflation
- [x] Zero-telemetry preserved: no network unless `FLOE_API_KEY` explicitly set

## Tests

11 new in `tests/test_from_floe.py` (all mocked at `urllib.request.urlopen`, no network). Full suite **339 passed**, ruff clean. py `0.14.0 → 0.15.0` (js untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `BudgetGuard.from_floe()` to initialize a local spending ceiling from hosted budget headroom.
  - Preserves local enforcement and zero-telemetry behavior.
  - Supports optional fallback limits with warnings when hosted access fails.
  - Rejects conflicting explicit local limits.

- **Documentation**
  - Added usage guidance, hosted upgrade details, retry information, and comparison updates.

- **Bug Fixes**
  - Improved handling of missing credentials, invalid access, and network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
