### PR TITLE
feat(voice): per-call budgets, $/min burn rate, pre-call admission gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,28 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.15.0 / js 0.10.0
+## Unreleased — py 0.16.0 / js 0.10.0
 
 ### Added (py)
+
+- **Voice-native primitives — per-call budgets, $/min burn rate, pre-call gates**
+  (P1):
+  - `guard.step(max_usd=…)` is now documented as the **per-call budget** primitive
+    (per-call cap, `advisory().step_remaining_usd` headroom, `est_calls_remaining`)
+    — voice budgets are per-call, not per-day.
+  - `advisory().burn_rate_usd_per_min` — the $/min spend rate voice teams watch,
+    derived from spend ÷ minutes since the guard was created (one guard per
+    call/turn ⇒ a per-call rate).
+  - `floe_guard.gates` — **pre-call admission** gates returning each provider's
+    exact inbound-webhook shape, so a local user rejects a call on budget
+    exhaustion with the same contract the hosted gateway serves: `gates.retell()`
+    → `{"call_inbound": {"reject": true}}` (only the boolean rejects; phone/SMS
+    inbound, 10s/3-retry); `gates.vapi()` → `{"error": …}` reject vs
+    `{"assistant"|"assistantId": …}` admit (~7.5s deadline); `gates.pre_call()` /
+    `gates.budget_exhausted()` for Pipecat/custom. **Pre-call admission only** — no
+    mid-call intervention. Bland's *Send Call* metadata field name is an open
+    verification item and is **not** invented (use `gates.pre_call`). US-only v1.
+    Budget, not balance.
 
 - **One line to hosted — `BudgetGuard.from_floe(api_key=…)`**: constructs a guard
   whose local ceiling is read from your **server-side budget headroom** (the min

--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ guard.record(model, response.usage.prompt_tokens, response.usage.completion_toke
 `remaining_usd`, and the budget totals. It also reports `expected_cost` (the
 guard's own next-call estimate) and `est_calls_remaining` (how many more calls
 the remaining budget buys, `None` until the first call is recorded) — call
-headroom, not just dollars. It's a **soft** signal — the model may
+headroom, not just dollars. For voice, it also reports `burn_rate_usd_per_min`
+(spend ÷ minutes since the guard was created — the $/min voice teams watch;
+make one guard per call/turn for a per-call rate, `None` before any time
+elapses). It's a **soft** signal — the model may
 ignore it; `check()` is what enforces the ceiling. See
 [`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
 (no API key).
@@ -827,6 +830,47 @@ map, and an `on_budget_exceeded` async callback speaks a wrap-up line before a t
 ends. See [`examples/voice_call_cost_livekit.py`](examples/voice_call_cost_livekit.py)
 for the full per-leg breakdown (no API key) and
 [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py) for the hard-stop.
+
+## Voice admission gates (pre-call)
+
+The adapters above meter a call that's already running. `floe_guard.gates` is the
+step *before* that: at the call boundary, **admit or reject** an inbound call from
+the budget left — and it returns the exact JSON shape each orchestrator's inbound
+webhook expects, so the same reject contract you serve locally is the one hosted
+Floe serves. The paid upgrade is a URL swap, not a rewrite.
+
+```python
+from floe_guard import BudgetGuard, gates
+
+guard = BudgetGuard.from_floe(api_key="floe_…")   # or a local BudgetGuard(limit_usd=…)
+
+# Retell inbound webhook — only the boolean `true` rejects:
+gates.retell(guard)
+#  budget left → {"call_inbound": {}}          (admit; pass admit={"dynamic_variables": …})
+#  exhausted   → {"call_inbound": {"reject": True}}
+
+# Vapi assistant-request webhook — respond within ~7.5s:
+gates.vapi(guard, assistant_id="asst_…")
+#  budget left → {"assistantId": "asst_…"}     (or assistant={…} for an inline assistant)
+#  exhausted   → {"error": "Sorry, this agent is out of budget right now."}
+
+# Pipecat / custom / Bland — the provider-agnostic decision:
+if not gates.pre_call(guard):
+    ...  # reject at your call boundary
+```
+
+Pass `estimated_call_usd=` to reject when the remaining budget can't cover the
+next call (e.g. `$/min × expected minutes`), not just when it's fully spent.
+
+**Pre-call admission only.** A gate decides whether a call *starts*; it does not
+intervene mid-call. Once admitted, a call runs to completion — nothing here cuts
+one off partway. (`guard_stream` can stop a single LLM *generation*, which is not
+call-level intervention.) Budget, not balance. US-only telephony, v1.
+
+> **Verification notes.** Retell's inbound webhook fires for inbound **phone/SMS**
+> calls (not dial-to-sip); its web-call behaviour isn't documented. Bland's *Send
+> Call* metadata field name is unconfirmed, so there's no `gates.bland()` yet — use
+> `gates.pre_call(guard)` and wire the reject into Bland's Pathway Webhook node.
 
 ## Adapter matrix
 

--- a/README.md
+++ b/README.md
@@ -862,6 +862,12 @@ if not gates.pre_call(guard):
 Pass `estimated_call_usd=` to reject when the remaining budget can't cover the
 next call (e.g. `$/min × expected minutes`), not just when it's fully spent.
 
+**Non-binding preflight.** A gate *reads* the remaining budget; it does not
+reserve it, so under concurrent inbound calls it can admit more than the budget
+strictly covers. It's coarse admission control — the binding, atomic money-gate
+stays the in-call guard (`check` / `reserve` while the call runs), same as hosted
+Floe's check-only pre-dial gate.
+
 **Pre-call admission only.** A gate decides whether a call *starts*; it does not
 intervene mid-call. Once admitted, a call runs to completion — nothing here cuts
 one off partway. (`guard_stream` can stop a single LLM *generation*, which is not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.15.0"
+version = "0.16.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _package_version
 
+from . import gates
 from .errors import (
     BudgetExceeded,
     DeadlineExceeded,
@@ -91,4 +92,5 @@ __all__ = [
     "price_voice_leg",
     "hosted_enforcement_available",
     "hosted_remaining_usd",
+    "gates",
 ]

--- a/src/floe_guard/gates.py
+++ b/src/floe_guard/gates.py
@@ -1,0 +1,109 @@
+"""Pre-call admission gates for voice orchestrators.
+
+These decide **at the call boundary** whether to *admit* or *reject* an incoming
+call, from the guard's remaining budget. They return the exact JSON shape each
+provider's inbound webhook expects, so a free/local user can reject a call on
+budget exhaustion with the **same contract** the hosted gateway serves — the paid
+upgrade is a URL swap, not a rewrite.
+
+Scope — strictly pre-call. A gate answers one question: *given the budget left,
+do we let this call start?* It does **not** intervene mid-call. Once a call is
+admitted it runs to completion; nothing here cuts a call off partway. (The
+``guard_stream`` helper can stop a single LLM *generation*, which is not
+call-level intervention and must not be described as one.)
+
+Budget, not balance: admission reads the guard's local *remaining budget*, a
+ceiling signal — not an account balance. US-only telephony, v1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .guard import BudgetGuard
+
+__all__ = ["budget_exhausted", "pre_call", "retell", "vapi"]
+
+
+def budget_exhausted(guard: BudgetGuard, *, estimated_call_usd: float = 0.0) -> bool:
+    """True when there isn't budget left to admit one more call.
+
+    With ``estimated_call_usd`` (a per-minute × expected-length estimate, say), the
+    call is rejected when the remaining budget can't cover it; with the default
+    ``0.0`` it's rejected only once the budget is fully spent (``remaining_usd`` at
+    or below zero). Reads the guard's ``remaining_usd`` (net of in-flight
+    reservations) — a local budget signal, not a balance.
+    """
+    return guard.remaining_usd <= estimated_call_usd
+
+
+def pre_call(guard: BudgetGuard, *, estimated_call_usd: float = 0.0) -> bool:
+    """Generic pre-call admission decision: ``True`` = admit, ``False`` = reject.
+
+    The provider-agnostic gate for Pipecat, custom telephony, or any inbound hook
+    without a first-class helper below. Wire the ``False`` case into your
+    provider's reject path.
+
+    Bland: Bland's *Send Call* metadata field name is an OPEN VERIFICATION ITEM
+    (pending confirmation) — this package does not invent it. Use ``pre_call`` to
+    get the admit/reject decision and map ``False`` onto Bland's Pathway Webhook
+    node once the field name is confirmed.
+    """
+    return not budget_exhausted(guard, estimated_call_usd=estimated_call_usd)
+
+
+def retell(
+    guard: BudgetGuard,
+    *,
+    estimated_call_usd: float = 0.0,
+    admit: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Response for Retell's inbound-call webhook — reject or admit the call.
+
+    On budget exhaustion returns ``{"call_inbound": {"reject": True}}``; otherwise
+    ``{"call_inbound": {...}}`` carrying any ``admit`` overrides you pass
+    (``dynamic_variables``, ``metadata``, ``override_agent_id``, …).
+
+    Retell contract (verified against docs.retellai.com/features/inbound-call-webhook):
+    **only the boolean ``true`` rejects** — any other value is ignored. The webhook
+    fires for inbound **phone and SMS** calls (not dial-to-sip); its behaviour for
+    web calls is not documented, so treat this as phone/SMS-only. 10s timeout, up to
+    3 retries.
+    """
+    if budget_exhausted(guard, estimated_call_usd=estimated_call_usd):
+        return {"call_inbound": {"reject": True}}
+    return {"call_inbound": dict(admit or {})}
+
+
+def vapi(
+    guard: BudgetGuard,
+    *,
+    assistant: dict[str, Any] | None = None,
+    assistant_id: str | None = None,
+    error_message: str = "Sorry, this agent is out of budget right now.",
+    estimated_call_usd: float = 0.0,
+) -> dict[str, Any]:
+    """Response for Vapi's ``assistant-request`` webhook — reject or admit the call.
+
+    On budget exhaustion returns ``{"error": error_message}`` (Vapi speaks it, then
+    ends the call). Otherwise admits with ``{"assistantId": assistant_id}`` if given,
+    else ``{"assistant": assistant}``.
+
+    Vapi has **no** ``reject: true`` boolean — rejection *is* returning an error, and
+    admission *is* returning an assistant. Respond within **~7.5 s** or the call may
+    fail (verified against docs.vapi.ai/server-url/spam-call-rejection).
+
+    Raises:
+        ValueError: admitted (budget available) but neither ``assistant`` nor
+            ``assistant_id`` was provided — there'd be nothing to hand Vapi.
+    """
+    if budget_exhausted(guard, estimated_call_usd=estimated_call_usd):
+        return {"error": error_message}
+    if assistant_id is not None:
+        return {"assistantId": assistant_id}
+    if assistant is not None:
+        return {"assistant": assistant}
+    raise ValueError(
+        "vapi() admitted the call but has nothing to return: pass assistant= or "
+        "assistant_id= for the admit path."
+    )

--- a/src/floe_guard/gates.py
+++ b/src/floe_guard/gates.py
@@ -18,6 +18,7 @@ ceiling signal — not an account balance. US-only telephony, v1.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from .guard import BudgetGuard
@@ -28,13 +29,33 @@ __all__ = ["budget_exhausted", "pre_call", "retell", "vapi"]
 def budget_exhausted(guard: BudgetGuard, *, estimated_call_usd: float = 0.0) -> bool:
     """True when there isn't budget left to admit one more call.
 
-    With ``estimated_call_usd`` (a per-minute × expected-length estimate, say), the
-    call is rejected when the remaining budget can't cover it; with the default
-    ``0.0`` it's rejected only once the budget is fully spent (``remaining_usd`` at
-    or below zero). Reads the guard's ``remaining_usd`` (net of in-flight
-    reservations) — a local budget signal, not a balance.
+    A **non-binding preflight read**: it checks the guard's ``remaining_usd`` but
+    does *not* reserve anything, so under concurrent inbound calls it can admit
+    more than the budget strictly covers (two calls may see the same headroom and
+    both pass). It is coarse admission control — the binding, atomic hard-stop is
+    the in-call guard (``check`` / ``reserve`` while the call runs). This mirrors
+    the hosted pre-dial gate, which is likewise check-only.
+
+    With the default ``estimated_call_usd=0.0`` a call is rejected only once the
+    budget is fully spent (``remaining_usd`` at or below zero). Pass an estimate
+    (e.g. ``$/min × expected minutes``) to reject earlier, when the remaining
+    budget can't cover it; an estimate that *exactly* equals the remaining budget
+    still admits (inclusive ceiling, matching ``BudgetGuard.reserve``). Budget
+    signal, not a balance.
+
+    Raises:
+        ValueError: ``estimated_call_usd`` is negative or non-finite — a bad
+            estimate must not silently admit an exhausted guard (NaN/negative
+            comparisons are always false, the same trap ``BudgetGuard`` rejects for
+            ``limit_usd``).
     """
-    return guard.remaining_usd <= estimated_call_usd
+    if not math.isfinite(estimated_call_usd) or estimated_call_usd < 0.0:
+        raise ValueError(
+            "estimated_call_usd must be a finite, non-negative number, "
+            f"got {estimated_call_usd!r}"
+        )
+    remaining_usd = guard.remaining_usd
+    return remaining_usd <= 0.0 or remaining_usd < estimated_call_usd
 
 
 def pre_call(guard: BudgetGuard, *, estimated_call_usd: float = 0.0) -> bool:
@@ -86,8 +107,10 @@ def vapi(
     """Response for Vapi's ``assistant-request`` webhook — reject or admit the call.
 
     On budget exhaustion returns ``{"error": error_message}`` (Vapi speaks it, then
-    ends the call). Otherwise admits with ``{"assistantId": assistant_id}`` if given,
-    else ``{"assistant": assistant}``.
+    ends the call) — e.g. ``{"error": "No budget."}``. Otherwise admits with
+    ``{"assistantId": assistant_id}`` if given (``assistant_id`` takes precedence),
+    else ``{"assistant": assistant}`` — e.g.
+    ``{"assistant": {"model": {"provider": "openai", "model": "gpt-4o"}}}``.
 
     Vapi has **no** ``reject: true`` boolean — rejection *is* returning an error, and
     admission *is* returning an assistant. Respond within **~7.5 s** or the call may

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -170,6 +170,11 @@ class BudgetAdvisory:
     # one. None when no step is active or the dimension is uncapped.
     step_remaining_usd: float | None = None
     step_remaining_tokens: int | None = None
+    # Spend rate in USD per minute over this guard's lifetime (spent_usd ÷ minutes
+    # since the guard was created) — the number voice teams watch. None only when
+    # no wall-clock time has elapsed yet. Make one guard per call/turn for a
+    # per-call burn rate; a long-lived guard reports the session average.
+    burn_rate_usd_per_min: float | None = None
 
 
 @dataclass(frozen=True)
@@ -330,6 +335,9 @@ class BudgetGuard:
         self.fail_closed = fail_closed
         self._on_block = on_block or _default_on_block
         self.near_limit_bps = near_limit_bps
+        # Wall-clock start of this guard's spend window, for the $/min burn rate
+        # (advisory().burn_rate_usd_per_min). One guard per call/turn ⇒ per-call rate.
+        self._created_time = time.time()
         self.spent_usd = 0.0
         # Costs of the most recent priced LLM call and tool call, tracked
         # SEPARATELY: the default next-call prediction is the max of the two, so
@@ -915,7 +923,16 @@ class BudgetGuard:
     def step(
         self, *, max_usd: float | None = None, max_tokens: int | None = None
     ) -> Iterator[BudgetGuard]:
-        """Scope a per-step USD and/or token cap for a **sequential agent loop**.
+        """Scope a per-step USD and/or token cap — the **per-call budget** primitive.
+
+        Voice budgets are per-*call*, not per-day: wrap one call (or one turn) in a
+        ``step`` to cap that call independently of the guard's aggregate ceiling.
+        The step's headroom is ``advisory().step_remaining_usd``, and
+        ``advisory().est_calls_remaining`` reports how many more calls the budget
+        buys at the current per-call estimate::
+
+            with guard.step(max_usd=0.05) as call:    # this call's own $0.05 cap
+                call.check(); call.record("gpt-4o", ...)
 
         Push a step onto the guard's stack on enter, pop it on exit; the
         enforcement/accrual path honours the innermost active step *on top of*
@@ -1010,6 +1027,11 @@ class BudgetGuard:
         # +1e-9 absorbs float noise so e.g. 0.6/0.2 floors to 3 not 2 (same
         # epsilon rationale as used_bps above, and keeps JS Math.floor parity).
         est_calls_remaining = int(remaining / expected_cost + 1e-9) if expected_cost > 0.0 else None
+        # Burn rate: spend ÷ minutes elapsed since the guard was created. None until
+        # any wall-clock time has passed (avoids a divide-by-zero at t0); $0 spent
+        # over real elapsed time is a legitimate 0.0/min, not None.
+        elapsed_min = (time.time() - self._created_time) / 60.0
+        burn_rate_usd_per_min = spent_usd / elapsed_min if elapsed_min > 0.0 else None
         # Aggregate token utilization, mirroring used_bps. None (no signal) when
         # the token dimension is unset — an aggregate-only USD guard is unchanged.
         token_used_bps: int | None = None
@@ -1061,6 +1083,7 @@ class BudgetGuard:
             remaining_tokens=remaining_tokens,
             step_remaining_usd=step_remaining_usd,
             step_remaining_tokens=step_remaining_tokens,
+            burn_rate_usd_per_min=burn_rate_usd_per_min,
         )
 
     # ── internals ──────────────────────────────────────────────────────────────

--- a/tests/test_burn_rate.py
+++ b/tests/test_burn_rate.py
@@ -1,0 +1,35 @@
+"""advisory().burn_rate_usd_per_min — spend ÷ minutes since the guard was created.
+
+The window start (`_created_time`) is set directly and `time.time` is patched only
+for the advisory read, so each case asserts the rate from a known spend/elapsed pair.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import BudgetGuard
+
+
+def test_burn_rate_from_known_spend_and_elapsed(monkeypatch: pytest.MonkeyPatch) -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard._created_time = 100.0
+    guard.record_tool("api", 0.05)  # exact $0.05 spend
+    monkeypatch.setattr("floe_guard.guard.time.time", lambda: 130.0)  # +30s = 0.5 min
+    assert guard.advisory().burn_rate_usd_per_min == pytest.approx(0.10)  # 0.05 / 0.5
+
+
+def test_burn_rate_zero_when_nothing_spent(monkeypatch: pytest.MonkeyPatch) -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard._created_time = 100.0
+    monkeypatch.setattr("floe_guard.guard.time.time", lambda: 160.0)  # +60s
+    # $0 over real elapsed time is a legitimate 0.0/min, not "unknown".
+    assert guard.advisory().burn_rate_usd_per_min == 0.0
+
+
+def test_burn_rate_none_before_any_time_elapses(monkeypatch: pytest.MonkeyPatch) -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard._created_time = 100.0
+    guard.record_tool("api", 0.05)
+    monkeypatch.setattr("floe_guard.guard.time.time", lambda: 100.0)  # no elapsed
+    assert guard.advisory().burn_rate_usd_per_min is None

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -35,6 +35,27 @@ def test_estimated_call_usd_reserves_headroom() -> None:
     assert gates.pre_call(guard, estimated_call_usd=0.20) is True
 
 
+def test_estimate_exactly_equal_to_remaining_admits() -> None:
+    # Exact fit admits — inclusive ceiling, matching BudgetGuard.reserve().
+    guard = _spent(1.00, 0.50)  # $0.50 remaining
+    assert gates.budget_exhausted(guard, estimated_call_usd=0.50) is False
+    assert gates.budget_exhausted(guard, estimated_call_usd=0.5001) is True
+
+
+def test_fully_spent_is_exhausted_regardless_of_estimate() -> None:
+    guard = _spent(1.00, 1.00)  # $0 remaining
+    assert gates.budget_exhausted(guard) is True
+    assert gates.budget_exhausted(guard, estimated_call_usd=0.0) is True
+
+
+@pytest.mark.parametrize("bad", [-1.0, -0.01, float("nan"), float("inf")])
+def test_bad_estimate_raises_not_admits(bad: float) -> None:
+    # A negative/NaN/inf estimate must not silently admit an exhausted guard.
+    guard = _spent(1.00, 1.00)  # exhausted
+    with pytest.raises(ValueError, match="finite, non-negative"):
+        gates.budget_exhausted(guard, estimated_call_usd=bad)
+
+
 # ── Retell ────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,76 @@
+"""Pre-call admission gates return the exact provider inbound-webhook shapes.
+
+Reject on budget exhaustion, admit otherwise — same contract a free/local user
+serves as the hosted gateway. Pre-call only; no mid-call behaviour is exercised.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import BudgetGuard, gates
+
+
+def _spent(limit: float, spend: float) -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=limit)
+    if spend > 0:
+        guard.record_tool("api", spend)
+    return guard
+
+
+# ── generic decision ──────────────────────────────────────────────────────────
+
+
+def test_budget_exhausted_and_pre_call() -> None:
+    assert gates.budget_exhausted(_spent(1.00, 1.00)) is True
+    assert gates.budget_exhausted(_spent(1.00, 0.50)) is False
+    assert gates.pre_call(_spent(1.00, 0.50)) is True
+    assert gates.pre_call(_spent(1.00, 1.00)) is False
+
+
+def test_estimated_call_usd_reserves_headroom() -> None:
+    # $0.30 left, but a call is estimated to cost $0.50 → reject at admission.
+    guard = _spent(1.00, 0.70)
+    assert gates.pre_call(guard, estimated_call_usd=0.50) is False
+    assert gates.pre_call(guard, estimated_call_usd=0.20) is True
+
+
+# ── Retell ────────────────────────────────────────────────────────────────────
+
+
+def test_retell_rejects_on_exhaustion() -> None:
+    assert gates.retell(_spent(1.00, 1.00)) == {"call_inbound": {"reject": True}}
+
+
+def test_retell_admits_with_overrides_and_no_reject_key() -> None:
+    resp = gates.retell(_spent(1.00, 0.10), admit={"dynamic_variables": {"name": "Ada"}})
+    assert resp == {"call_inbound": {"dynamic_variables": {"name": "Ada"}}}
+    assert "reject" not in resp["call_inbound"]
+
+
+def test_retell_reject_is_the_boolean_true_not_a_string() -> None:
+    # Retell ignores any non-boolean-true value; assert we emit real `True`.
+    reject = gates.retell(_spent(1.00, 1.00))["call_inbound"]["reject"]
+    assert reject is True
+
+
+# ── Vapi ──────────────────────────────────────────────────────────────────────
+
+
+def test_vapi_rejects_with_error_shape() -> None:
+    resp = gates.vapi(_spent(1.00, 1.00), assistant_id="asst_1", error_message="No budget.")
+    assert resp == {"error": "No budget."}
+
+
+def test_vapi_admits_with_assistant_id() -> None:
+    assert gates.vapi(_spent(1.00, 0.10), assistant_id="asst_1") == {"assistantId": "asst_1"}
+
+
+def test_vapi_admits_with_inline_assistant() -> None:
+    assistant = {"model": {"provider": "openai", "model": "gpt-4o"}}
+    assert gates.vapi(_spent(1.00, 0.10), assistant=assistant) == {"assistant": assistant}
+
+
+def test_vapi_admit_without_target_raises() -> None:
+    with pytest.raises(ValueError, match="assistant"):
+        gates.vapi(_spent(1.00, 0.10))


### PR DESCRIPTION
Voice-native primitives (P1). Three things voice teams actually reach for, all local, all honest about their limits.

## What shipped

**1. `guard.step()` is the per-call budget** — documented as such (per-call cap, `advisory().step_remaining_usd` headroom, `est_calls_remaining`). Voice budgets are per-*call*, not per-day; `with guard.step(max_usd=0.05) as call:` caps one call. Docstring-only change — the primitive already existed, unbranded.

**2. `advisory().burn_rate_usd_per_min`** — the $/min spend rate voice teams watch, from `spent_usd ÷ minutes since the guard was created`. `None` before any time elapses (no divide-by-zero at t0); `$0` over real elapsed time is a legitimate `0.0/min`. One guard per call/turn ⇒ a per-call rate.

**3. `floe_guard.gates`** — pre-call admission gates returning each provider's exact inbound-webhook JSON, so a local user rejects a call on budget exhaustion with the **same contract** hosted Floe serves (paid upgrade = URL swap):

| Gate | Reject (exhausted) | Admit |
|---|---|---|
| `gates.retell(guard)` | `{"call_inbound": {"reject": true}}` | `{"call_inbound": {…overrides}}` |
| `gates.vapi(guard, assistant_id=…)` | `{"error": "…"}` | `{"assistantId": …}` / `{"assistant": {…}}` |
| `gates.pre_call(guard)` | `False` | `True` |

`estimated_call_usd=` reserves headroom for the next call instead of waiting for full exhaustion.

## Provider contracts — verified against live docs, not the ticket's word

Both reject/admit shapes go into public community snippets, so I confirmed them against source rather than trusting "verified":
- **Retell** ([docs](https://docs.retellai.com/features/inbound-call-webhook)): `{"call_inbound": {"reject": true}}` — *"only the boolean `true` rejects."* Fires for inbound **phone/SMS** (not dial-to-sip); web-call behaviour undocumented. 10s timeout, 3 retries.
- **Vapi** ([docs](https://docs.vapi.ai/server-url/spam-call-rejection)): reject = `{"error": …}` (spoken, then ends); admit = `{"assistant"|"assistantId": …}`; ~7.5s deadline.

## Honesty guardrails (per the ticket)

- **Pre-call admission only.** A gate decides whether a call *starts* — it does **not** intervene mid-call. Stated in the module docstring and README; grep confirms no mid-call/intervention claim anywhere except the disclaimers.
- **Bland's *Send Call* metadata field name is an open verification item** — not invented. No `gates.bland()`; use `gates.pre_call(guard)` behind a documented TODO until confirmed.
- **Budget ≠ balance**; US-only telephony v1.

## Acceptance criteria

- [x] `advisory()` exposes `$/min`; unit test asserts it from a known spend/elapsed pair
- [x] `gates.retell` emits `{"call_inbound":{"reject":true}}` on exhaustion, valid admit otherwise; test asserts the reject is the boolean `True`
- [x] `gates.vapi` returns error-shaped reject + assistant-shaped admit; docstring notes the ~7.5s deadline
- [x] Open-verification items labeled in code + docs (Bland field; Retell web-call firing); neither fabricated
- [x] Docs state gates are pre-call admission only; no mid-call intervention claim

## Tests

12 new (`tests/test_burn_rate.py`, `tests/test_gates.py`). Full suite **351 passed**, ruff clean. py `0.15.0 → 0.16.0` (js untouched, stays 0.10.0).

> Note: `0.16.0` rolls up the still-unpublished `0.15.0` (from_floe + voice map) since PyPI is at `0.13.0` — the next publish carries all of it. Say the word if you want them split into separate PyPI versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-call budget controls and estimated-cost admission checks.
  * Added pre-call voice admission gates for Retell, Vapi, and custom integrations.
  * Added voice burn-rate reporting based on spending per elapsed minute.
  * Added provider-specific admission and rejection responses.

* **Documentation**
  * Documented voice budgets, provider integrations, response formats, timing constraints, and limitations.
  * Updated the Python package version to 0.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->