### PR TITLE
feat(js): TS voice foundation — cost-map pricing, gates, burnRate parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.16.0 / js 0.10.0
+## Unreleased — py 0.16.0 / js 0.11.0
 
 ### Added (py)
 
@@ -57,6 +57,30 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   (Sonic TTS + Line telephony), Rime, Twilio (Telnyx deferred); rates are a
   drift-prone snapshot. The **js** package carries the same `__voice__` cost-map
   data in lockstep (no JS voice adapter this release).
+
+### Added (js)
+
+- **Voice foundation ported to TypeScript — cost-map pricing, pre-call gates,
+  $/min burn rate** (parity with py, no voice adapter yet):
+  - **Offline voice cost-map pricing** (`voice-pricing.ts`): `priceVoiceLeg` /
+    `resolveVoiceRate` / `lookupVoiceRate` / `voiceLegCost` price a leg from the
+    `__voice__` section of `cost_map.json` (STT $/sec, TTS $/1k-chars, telephony
+    $/min). A per-unit override wins over the map; a vendor the map can't price (or
+    a wrong unit/mode) fails closed via the new `UnpriceableVoiceError` (parity with
+    `UnpriceableModelError`), never a silent $0. An unconfigured leg (no vendor, no
+    override) returns `null` so the token-only contract is preserved.
+  - **`gates` — pre-call admission** (`gates.ts`, exported as the `gates`
+    namespace): `gates.retell()` → `{ call_inbound: { reject: true } }` (only the
+    boolean rejects; phone/SMS inbound, 10s/3-retry); `gates.vapi()` → `{ error }`
+    reject vs `{ assistantId | assistant }` admit (`assistantId` takes precedence;
+    ~7.5s deadline); `gates.preCall()` / `gates.budgetExhausted()` for
+    Pipecat/custom. A non-finite/negative estimate throws rather than silently
+    admitting. **Pre-call admission only** — no mid-call intervention. Bland's
+    *Send Call* metadata field name is an open verification item and is **not**
+    invented (use `gates.preCall`). US-only v1. Budget, not balance.
+  - **`advisory().burnRateUsdPerMin`** — the $/min spend rate voice teams watch,
+    spend ÷ minutes since the guard was created (`null` until wall-clock time has
+    elapsed; one guard per call/turn ⇒ a per-call rate).
 
 ## py 0.13.0 / js 0.9.0 — 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -899,15 +899,19 @@ adapter set like the Python package.
 
 ### TypeScript voice parity
 
-**This release ships no TypeScript voice adapter.** The JS package
-([`js/`](js/)) ships one surface — the Vercel AI SDK middleware — and it is
-**text-only**: it guards a wrapped `LanguageModel`, not a running STT → LLM → TTS
-session. A voice/telephony builder on a Node stack should either drive the LLM
-turn through the Vercel AI middleware and meter STT/TTS spend by hand via
-`recordTool`, or run the LLM leg through the **hosted [Floe proxy](#when-you-outgrow-local-guardrails)**
-(un-bypassable, cross-vendor) — or use the Python Pipecat / LiveKit adapters
-above, which enforce the whole turn. No native TypeScript Pipecat/LiveKit voice
-adapter ships in this release.
+**TypeScript ships the voice foundation — pricing and admission — not yet a
+full-session adapter.** The JS package ([`js/`](js/)) now prices voice legs
+offline (`priceVoiceLeg` — STT/TTS/telephony from the same `__voice__` cost map,
+fail-closed via `UnpriceableVoiceError`) and ships **pre-call admission gates**
+(`gates.retell` / `gates.vapi` / `gates.preCall`) that return each provider's
+exact reject/admit shape — the same contract as the Python `gates`. What it does
+**not** yet ship is a native STT → LLM → TTS *session* adapter (Vapi custom-LLM
+proxy / Retell WS / LiveKit Agents) that meters a whole running turn. Until then,
+drive the LLM turn through the Vercel AI SDK middleware and meter STT/TTS via
+`recordTool` (price the legs with `priceVoiceLeg`), run the LLM leg through the
+**hosted [Floe proxy](#when-you-outgrow-local-guardrails)** (un-bypassable,
+cross-vendor), or use the Python Pipecat / LiveKit adapters above, which enforce
+the whole turn.
 
 For wiring floe-guard into an existing voice pipeline, see the Floe docs:
 **[Add Floe to your existing pipeline](https://floe-labs.gitbook.io/docs/getting-started/integrate-existing-pipeline)**.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
   "type": "module",
   "license": "MIT",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -96,6 +96,38 @@ export class UnpriceableModelError extends FloeGuardError {
 }
 
 /**
+ * Thrown when a voice leg (STT/TTS/telephony) cannot be priced and the guard is
+ * fail-closed.
+ *
+ * The voice twin of {@link UnpriceableModelError}: we refuse rather than silently
+ * accrue $0 — "we cannot cap what we cannot price". It fires when an adapter is
+ * asked to meter a leg for a vendor that is absent from the bundled voice cost map
+ * (or whose entry has the wrong unit/mode for the leg) and no per-unit override was
+ * given. Pass a per-unit rate (`stt_usd_per_second` / `tts_usd_per_1k_chars` /
+ * `telephony_usd_per_minute`) to make the leg enforceable.
+ *
+ * Mirrors `UnpriceableVoiceError` in `src/floe_guard/errors.py`.
+ */
+export class UnpriceableVoiceError extends FloeGuardError {
+  readonly vendor: string | null;
+  readonly mode: string;
+
+  constructor(vendor: string | null, mode: string) {
+    // Match Python's `{vendor!r}`: a string is quoted, None renders as `None`.
+    const shown = vendor === null ? "None" : `'${vendor}'`;
+    super(
+      `Cannot price ${mode} vendor ${shown}: not in the bundled voice cost ` +
+        `map (or its entry has the wrong unit for a ${mode} leg) and no per-unit ` +
+        `override was given. The guard cannot enforce a budget on spend it ` +
+        `cannot measure. Pass a per-unit rate to enable enforcement.`,
+    );
+    this.name = "UnpriceableVoiceError";
+    this.vendor = vendor;
+    this.mode = mode;
+  }
+}
+
+/**
  * Thrown before a call whose projected duration would blow the SLA.
  *
  * The latency twin of {@link BudgetExceeded}: `LatencyBudget.check()` throws this

--- a/js/src/gates.ts
+++ b/js/src/gates.ts
@@ -43,7 +43,10 @@ export function budgetExhausted(
   guard: BudgetGuard,
   options: { estimatedCallUsd?: number } = {},
 ): boolean {
-  const estimatedCallUsd = options.estimatedCallUsd ?? 0;
+  // Default ONLY undefined — a `null` estimate is malformed input and must reach
+  // validation (below) rather than being silently coerced to 0 (which would admit
+  // the call with no intended headroom). Mirrors Python raising on a None estimate.
+  const estimatedCallUsd = options.estimatedCallUsd === undefined ? 0 : options.estimatedCallUsd;
   if (!Number.isFinite(estimatedCallUsd) || estimatedCallUsd < 0) {
     throw new RangeError(
       `estimatedCallUsd must be a finite, non-negative number, got ${estimatedCallUsd}`,
@@ -89,7 +92,12 @@ export function retell(
   if (budgetExhausted(guard, { estimatedCallUsd: options.estimatedCallUsd })) {
     return { call_inbound: { reject: true } };
   }
-  return { call_inbound: { ...(options.admit ?? {}) } };
+  // The gate's budget decision — not the caller's overrides — controls admission.
+  // Strip `reject` from admit overrides so an errant `admit: { reject: true }` on
+  // an available-budget call can't flip the response into Retell's reject shape.
+  const safeAdmit = { ...(options.admit ?? {}) };
+  delete safeAdmit.reject;
+  return { call_inbound: safeAdmit };
 }
 
 /**

--- a/js/src/gates.ts
+++ b/js/src/gates.ts
@@ -1,0 +1,137 @@
+/**
+ * Pre-call admission gates for voice orchestrators.
+ *
+ * These decide **at the call boundary** whether to *admit* or *reject* an incoming
+ * call, from the guard's remaining budget. They return the exact JSON shape each
+ * provider's inbound webhook expects, so a free/local user can reject a call on
+ * budget exhaustion with the **same contract** the hosted gateway serves — the paid
+ * upgrade is a URL swap, not a rewrite.
+ *
+ * Scope — strictly pre-call. A gate answers one question: *given the budget left,
+ * do we let this call start?* It does **not** intervene mid-call. Once a call is
+ * admitted it runs to completion; nothing here cuts a call off partway.
+ *
+ * Budget, not balance: admission reads the guard's local *remaining budget*, a
+ * ceiling signal — not an account balance. US-only telephony, v1.
+ *
+ * A faithful port of `src/floe_guard/gates.py`.
+ */
+
+import type { BudgetGuard } from "./guard.js";
+
+/**
+ * True when there isn't budget left to admit one more call.
+ *
+ * A **non-binding preflight read**: it checks the guard's `remainingUsd` but does
+ * *not* reserve anything, so under concurrent inbound calls it can admit more than
+ * the budget strictly covers (two calls may see the same headroom and both pass).
+ * It is coarse admission control — the binding, atomic hard-stop is the in-call
+ * guard (`check` / `reserve` while the call runs). This mirrors the hosted pre-dial
+ * gate, which is likewise check-only.
+ *
+ * With the default `estimatedCallUsd = 0` a call is rejected only once the budget
+ * is fully spent (`remainingUsd` at or below zero). Pass an estimate (e.g.
+ * `$/min × expected minutes`) to reject earlier, when the remaining budget can't
+ * cover it; an estimate that *exactly* equals the remaining budget still admits
+ * (inclusive ceiling, matching `BudgetGuard.reserve`). Budget signal, not a balance.
+ *
+ * @throws RangeError when `estimatedCallUsd` is negative or non-finite — a bad
+ *   estimate must not silently admit an exhausted guard (NaN/negative comparisons
+ *   are always false, the same trap `BudgetGuard` rejects for `limitUsd`).
+ */
+export function budgetExhausted(
+  guard: BudgetGuard,
+  options: { estimatedCallUsd?: number } = {},
+): boolean {
+  const estimatedCallUsd = options.estimatedCallUsd ?? 0;
+  if (!Number.isFinite(estimatedCallUsd) || estimatedCallUsd < 0) {
+    throw new RangeError(
+      `estimatedCallUsd must be a finite, non-negative number, got ${estimatedCallUsd}`,
+    );
+  }
+  const remainingUsd = guard.remainingUsd;
+  return remainingUsd <= 0 || remainingUsd < estimatedCallUsd;
+}
+
+/**
+ * Generic pre-call admission decision: `true` = admit, `false` = reject.
+ *
+ * The provider-agnostic gate for Pipecat, custom telephony, or any inbound hook
+ * without a first-class helper below. Wire the `false` case into your provider's
+ * reject path.
+ *
+ * TODO(bland): Bland's *Send Call* metadata field name is an OPEN VERIFICATION
+ * ITEM (pending confirmation) — this package does not invent it. Use `preCall` to
+ * get the admit/reject decision and map `false` onto Bland's Pathway Webhook node
+ * once the field name is confirmed.
+ */
+export function preCall(guard: BudgetGuard, options: { estimatedCallUsd?: number } = {}): boolean {
+  return !budgetExhausted(guard, options);
+}
+
+/**
+ * Response for Retell's inbound-call webhook — reject or admit the call.
+ *
+ * On budget exhaustion returns `{ call_inbound: { reject: true } }`; otherwise
+ * `{ call_inbound: {...} }` carrying any `admit` overrides you pass
+ * (`dynamic_variables`, `metadata`, `override_agent_id`, …).
+ *
+ * Retell contract (verified against docs.retellai.com/features/inbound-call-webhook):
+ * **only the boolean `true` rejects** — any other value is ignored. The webhook
+ * fires for inbound **phone and SMS** calls (not dial-to-sip); its behaviour for
+ * web calls is not documented, so treat this as phone/SMS-only. 10s timeout, up to
+ * 3 retries.
+ */
+export function retell(
+  guard: BudgetGuard,
+  options: { estimatedCallUsd?: number; admit?: Record<string, unknown> } = {},
+): { call_inbound: Record<string, unknown> } {
+  if (budgetExhausted(guard, { estimatedCallUsd: options.estimatedCallUsd })) {
+    return { call_inbound: { reject: true } };
+  }
+  return { call_inbound: { ...(options.admit ?? {}) } };
+}
+
+/**
+ * Response for Vapi's `assistant-request` webhook — reject or admit the call.
+ *
+ * On budget exhaustion returns `{ error: errorMessage }` (Vapi speaks it, then ends
+ * the call). Otherwise admits with `{ assistantId }` if given (`assistantId` takes
+ * precedence), else `{ assistant }`.
+ *
+ * Vapi has **no** `reject: true` boolean — rejection *is* returning an error, and
+ * admission *is* returning an assistant. Respond within **~7.5 s** or the call may
+ * fail (verified against docs.vapi.ai/server-url/spam-call-rejection).
+ *
+ * @throws RangeError when admitted (budget available) but neither `assistant` nor
+ *   `assistantId` was provided — there'd be nothing to hand Vapi.
+ */
+export function vapi(
+  guard: BudgetGuard,
+  options: {
+    assistant?: Record<string, unknown>;
+    assistantId?: string;
+    errorMessage?: string;
+    estimatedCallUsd?: number;
+  } = {},
+): Record<string, unknown> {
+  const {
+    assistant,
+    assistantId,
+    errorMessage = "Sorry, this agent is out of budget right now.",
+    estimatedCallUsd,
+  } = options;
+  if (budgetExhausted(guard, { estimatedCallUsd })) {
+    return { error: errorMessage };
+  }
+  if (assistantId !== undefined && assistantId !== null) {
+    return { assistantId };
+  }
+  if (assistant !== undefined && assistant !== null) {
+    return { assistant };
+  }
+  throw new RangeError(
+    "vapi() admitted the call but has nothing to return: pass assistant or " +
+      "assistantId for the admit path.",
+  );
+}

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -187,11 +187,25 @@ export interface BudgetAdvisory {
    */
   stepRemainingUsd?: number | null;
   stepRemainingTokens?: number | null;
+  /**
+   * Spend rate in USD per minute over this guard's lifetime (spentUsd ÷ minutes
+   * since the guard was created) — the number voice teams watch. null only when no
+   * wall-clock time has elapsed yet. Make one guard per call/turn for a per-call
+   * burn rate; a long-lived guard reports the session average. Optional for the
+   * same additive reason as the fields above; `advisory()` always sets it.
+   */
+  burnRateUsdPerMin?: number | null;
 }
 
 export class BudgetGuard {
   readonly limitUsd: number;
   spentUsd = 0;
+  /**
+   * Wall-clock start (ms since epoch) of this guard's spend window, for the $/min
+   * burn rate (advisory().burnRateUsdPerMin). One guard per call/turn ⇒ a per-call
+   * rate. Set at construction; tests set it directly to control elapsed time.
+   */
+  createdAtMs = Date.now();
   priceOverrides?: Record<string, ManualPrice>;
   failClosed: boolean;
   nearLimitBps: number;
@@ -861,6 +875,11 @@ export class BudgetGuard {
     // rationale as usedBps above, and keeps Python int() parity).
     const estCallsRemaining =
       expectedCost > 0 ? Math.floor(remainingUsd / expectedCost + 1e-9) : null;
+    // Burn rate: spend ÷ minutes elapsed since the guard was created. null until
+    // any wall-clock time has passed (avoids a divide-by-zero at t0); $0 spent over
+    // real elapsed time is a legitimate 0/min, not null.
+    const elapsedMin = (Date.now() - this.createdAtMs) / 60000;
+    const burnRateUsdPerMin = elapsedMin > 0 ? this.spentUsd / elapsedMin : null;
     // Aggregate token utilization, mirroring usedBps. null (no signal) when the
     // token dimension is unset — a pure USD guard's advisory is unchanged.
     let tokenUsedBps: number | null = null;
@@ -922,6 +941,7 @@ export class BudgetGuard {
       remainingTokens,
       stepRemainingUsd,
       stepRemainingTokens,
+      burnRateUsdPerMin,
     };
   }
 }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -25,6 +25,7 @@ export {
   TokenBudgetExceeded,
   DeadlineExceeded,
   UnpriceableModelError,
+  UnpriceableVoiceError,
 } from "./errors.js";
 export {
   budgetGuardMiddleware,
@@ -43,3 +44,16 @@ export {
 } from "./retry.js";
 
 export * as pricing from "./pricing.js";
+
+export {
+  type VoiceMode,
+  type VoiceRate,
+  lookupVoiceRate,
+  resolveVoiceRate,
+  voiceLegCost,
+  priceVoiceLeg,
+} from "./voice-pricing.js";
+
+// gates as a namespace, mirroring Python's `floe_guard.gates` — so
+// `import { gates } from "floe-guard"` reads like the Python package.
+export * as gates from "./gates.js";

--- a/js/src/voice-pricing.ts
+++ b/js/src/voice-pricing.ts
@@ -119,6 +119,12 @@ export function resolveVoiceRate(
  * (telephony); negative quantities clamp to zero.
  */
 export function voiceLegCost(mode: VoiceMode, quantity: number, rate: number): number {
+  // Reject non-finite quantities: Math.max(0, NaN) is NaN, so a NaN/Infinity
+  // quantity would return a non-finite USD amount that then poisons the guard's
+  // running total (NaN disables every ceiling comparison). Negatives still clamp.
+  if (!Number.isFinite(quantity)) {
+    throw new RangeError(`voice ${mode} quantity must be a finite number, got ${quantity}`);
+  }
   const q = Math.max(0, quantity);
   if (mode === "stt") return q * rate; // seconds * $/second
   if (mode === "tts") return (q / 1000) * rate; // chars / 1000 * $/1k-chars

--- a/js/src/voice-pricing.ts
+++ b/js/src/voice-pricing.ts
@@ -1,0 +1,148 @@
+/**
+ * Offline pricing for voice legs (STT / TTS / telephony) from the vendored map.
+ *
+ * The voice twin of `pricing.ts`. The token cost map is per-token; a voice
+ * pipeline's bill is per-second (STT), per-1k-chars (TTS), and per-minute
+ * (telephony) instead, so the voice rates live under the reserved `"__voice__"`
+ * key of `cost_map.json` with their own schema:
+ *
+ *     "deepgram-nova-3": {
+ *       "mode": "stt",              // discriminator: "stt" | "tts" | "telephony"
+ *       "unit": "usd_per_second",   // explicit unit — a mismatch fails closed
+ *       "rate": 0.0001283333,       // USD in that unit
+ *       "provider": "deepgram"
+ *     }
+ *
+ * Same fail-closed contract as token pricing: a vendor absent from the map (or an
+ * entry whose `unit`/`mode` does not match the leg it is asked to price) is
+ * unpriceable — {@link lookupVoiceRate} returns `null` and the adapter throws
+ * {@link UnpriceableVoiceError} rather than silently metering the leg at $0. Pass a
+ * per-unit override to enforce a leg the map cannot price.
+ *
+ * No network. The rates are a **drift-prone snapshot** of each vendor's public
+ * list price — refresh them (`scripts/update-cost-map.mjs`) like the token map, or
+ * estimates drift as vendors change prices. Telephony is **US-only in v1**.
+ *
+ * This is a faithful port of `src/floe_guard/voice_pricing.py`.
+ */
+
+import costMapJson from "./cost_map.json";
+import { UnpriceableVoiceError } from "./errors.js";
+
+export type VoiceMode = "stt" | "tts" | "telephony";
+
+interface VoiceMapEntry {
+  mode?: unknown;
+  unit?: unknown;
+  rate?: unknown;
+  provider?: unknown;
+}
+
+/** The vendored voice rates — the reserved `"__voice__"` section of the cost map. */
+const VOICE_MAP = ((costMapJson as Record<string, unknown>)["__voice__"] ?? {}) as Record<
+  string,
+  VoiceMapEntry
+>;
+
+/**
+ * The one unit each leg is billed in. An entry whose `unit` disagrees with its
+ * leg is a schema mismatch and fails closed — a Deepgram $/min figure stored
+ * without the ÷60 conversion would over-bill 60x if it were silently accepted.
+ */
+export const unitForMode: Record<VoiceMode, string> = {
+  stt: "usd_per_second",
+  tts: "usd_per_1k_chars",
+  telephony: "usd_per_minute",
+};
+
+/** A resolved per-unit voice rate plus where it came from. */
+export interface VoiceRate {
+  mode: string;
+  unit: string;
+  rate: number;
+  source: "override" | "cost_map";
+}
+
+function finiteNonNegative(value: unknown): value is number {
+  // typeof excludes booleans (Python's _finite_non_negative excludes bool too).
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Resolve a voice vendor to its per-unit rate, or `null` if unpriceable.
+ *
+ * The pure resolver (the voice twin of {@link resolvePrice}): it never throws.
+ * Fail-closed on every mismatch — a missing vendor, an entry whose `mode` is not
+ * `mode`, an entry whose `unit` is not the canonical unit for `mode`, or a
+ * non-finite/negative rate — so a schema slip can never surface as a silent,
+ * valid-looking price.
+ */
+export function lookupVoiceRate(model: string | null | undefined, mode: VoiceMode): number | null {
+  if (model === null || model === undefined) return null;
+  const entry = Object.prototype.hasOwnProperty.call(VOICE_MAP, model)
+    ? VOICE_MAP[model]
+    : undefined;
+  if (!entry) return null;
+  if (entry.mode !== mode) return null;
+  if (entry.unit !== unitForMode[mode]) return null;
+  const rate = entry.rate;
+  if (!finiteNonNegative(rate)) return null;
+  return rate;
+}
+
+/**
+ * Resolve a leg's per-unit rate, fail-closed. An `override` wins over the map.
+ *
+ * Throws {@link UnpriceableVoiceError} when neither an override nor the bundled
+ * map can price the leg — the guard refuses to meter spend it cannot measure.
+ */
+export function resolveVoiceRate(
+  model: string | null | undefined,
+  mode: VoiceMode,
+  override?: number | null,
+): VoiceRate {
+  if (override !== undefined && override !== null) {
+    if (!finiteNonNegative(override)) {
+      throw new RangeError(
+        `voice ${mode} override must be a finite, non-negative number, got ${override}`,
+      );
+    }
+    return { mode, unit: unitForMode[mode], rate: override, source: "override" };
+  }
+  const rate = lookupVoiceRate(model, mode);
+  if (rate === null) throw new UnpriceableVoiceError(model ?? null, mode);
+  return { mode, unit: unitForMode[mode], rate, source: "cost_map" };
+}
+
+/**
+ * USD for one leg. `quantity` is seconds (stt), characters (tts), or minutes
+ * (telephony); negative quantities clamp to zero.
+ */
+export function voiceLegCost(mode: VoiceMode, quantity: number, rate: number): number {
+  const q = Math.max(0, quantity);
+  if (mode === "stt") return q * rate; // seconds * $/second
+  if (mode === "tts") return (q / 1000) * rate; // chars / 1000 * $/1k-chars
+  if (mode === "telephony") return q * rate; // minutes * $/minute
+  throw new RangeError(`unknown voice mode ${mode}`);
+}
+
+/**
+ * USD for one voice leg, or `null` when the leg is unconfigured (skip it).
+ *
+ * The single entry point the adapters use. A leg with neither a vendor (`model`)
+ * nor an `override` is unconfigured — return `null` so the token-only contract is
+ * preserved and nothing is metered. A leg that *is* configured but cannot be
+ * priced throws {@link UnpriceableVoiceError} (via {@link resolveVoiceRate}) rather
+ * than accruing a silent $0.
+ */
+export function priceVoiceLeg(
+  mode: VoiceMode,
+  quantity: number,
+  options: { model?: string | null; override?: number | null } = {},
+): number | null {
+  const model = options.model ?? null;
+  const override = options.override ?? null;
+  if (model === null && override === null) return null;
+  const resolved = resolveVoiceRate(model, mode, override);
+  return voiceLegCost(mode, quantity, resolved.rate);
+}

--- a/js/test/burn-rate.test.ts
+++ b/js/test/burn-rate.test.ts
@@ -1,0 +1,42 @@
+/**
+ * advisory().burnRateUsdPerMin — spend ÷ minutes since the guard was created.
+ *
+ * The window start (`createdAtMs`) is set directly and `Date.now` is stubbed for
+ * the advisory read, so each case asserts the rate from a known spend/elapsed pair.
+ *
+ * Mirrors `tests/test_burn_rate.py`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BudgetGuard } from "../src/index.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("advisory().burnRateUsdPerMin", () => {
+  it("computes from a known spend and elapsed pair", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.createdAtMs = 100_000;
+    guard.recordTool("api", 0.05); // exact $0.05 spend
+    vi.spyOn(Date, "now").mockReturnValue(130_000); // +30_000ms = 0.5 min
+    expect(guard.advisory().burnRateUsdPerMin).toBeCloseTo(0.1, 9); // 0.05 / 0.5
+  });
+
+  it("is 0 when nothing has been spent over real elapsed time", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.createdAtMs = 100_000;
+    vi.spyOn(Date, "now").mockReturnValue(160_000); // +60_000ms = 1 min
+    // $0 over real elapsed time is a legitimate 0/min, not "unknown".
+    expect(guard.advisory().burnRateUsdPerMin).toBe(0);
+  });
+
+  it("is null before any wall-clock time elapses", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.createdAtMs = 100_000;
+    guard.recordTool("api", 0.05);
+    vi.spyOn(Date, "now").mockReturnValue(100_000); // no elapsed
+    expect(guard.advisory().burnRateUsdPerMin).toBeNull();
+  });
+});

--- a/js/test/gates.test.ts
+++ b/js/test/gates.test.ts
@@ -93,3 +93,19 @@ describe("gates — Vapi", () => {
     expect(() => gates.vapi(spent(1.0, 0.1))).toThrow(RangeError);
   });
 });
+
+describe("gates — input hardening", () => {
+  it("a null estimate throws rather than coercing to 0", () => {
+    // null is malformed input; it must reach validation, not silently admit.
+    expect(() =>
+      gates.budgetExhausted(spent(1.0, 1.0), { estimatedCallUsd: null as unknown as number }),
+    ).toThrow(RangeError);
+  });
+
+  it("a retell admit override cannot inject a reject on an available-budget call", () => {
+    const resp = gates.retell(spent(1.0, 0.1), {
+      admit: { reject: true, dynamic_variables: { name: "Ada" } },
+    });
+    expect(resp).toEqual({ call_inbound: { dynamic_variables: { name: "Ada" } } });
+  });
+});

--- a/js/test/gates.test.ts
+++ b/js/test/gates.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Pre-call admission gates return the exact provider inbound-webhook shapes.
+ *
+ * Reject on budget exhaustion, admit otherwise — the same contract a free/local
+ * user serves as the hosted gateway. Pre-call only; no mid-call behaviour here.
+ *
+ * Mirrors `tests/test_gates.py`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BudgetGuard, gates } from "../src/index.js";
+
+function spent(limit: number, spend: number): BudgetGuard {
+  const guard = new BudgetGuard(limit);
+  if (spend > 0) guard.recordTool("api", spend);
+  return guard;
+}
+
+describe("gates — generic decision", () => {
+  it("budgetExhausted and preCall", () => {
+    expect(gates.budgetExhausted(spent(1.0, 1.0))).toBe(true);
+    expect(gates.budgetExhausted(spent(1.0, 0.5))).toBe(false);
+    expect(gates.preCall(spent(1.0, 0.5))).toBe(true);
+    expect(gates.preCall(spent(1.0, 1.0))).toBe(false);
+  });
+
+  it("estimatedCallUsd reserves headroom", () => {
+    // $0.30 left, but a call estimated at $0.50 → reject at admission.
+    const guard = spent(1.0, 0.7);
+    expect(gates.preCall(guard, { estimatedCallUsd: 0.5 })).toBe(false);
+    expect(gates.preCall(guard, { estimatedCallUsd: 0.2 })).toBe(true);
+  });
+
+  it("an estimate exactly equal to remaining admits (inclusive ceiling)", () => {
+    const guard = spent(1.0, 0.5); // $0.50 remaining
+    expect(gates.budgetExhausted(guard, { estimatedCallUsd: 0.5 })).toBe(false);
+    expect(gates.budgetExhausted(guard, { estimatedCallUsd: 0.5001 })).toBe(true);
+  });
+
+  it("fully spent is exhausted regardless of estimate", () => {
+    const guard = spent(1.0, 1.0); // $0 remaining
+    expect(gates.budgetExhausted(guard)).toBe(true);
+    expect(gates.budgetExhausted(guard, { estimatedCallUsd: 0.0 })).toBe(true);
+  });
+
+  it("a negative/NaN/Infinity estimate throws instead of admitting", () => {
+    // A bad estimate must not silently admit an exhausted guard.
+    const guard = spent(1.0, 1.0); // exhausted
+    for (const bad of [-1.0, -0.01, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => gates.budgetExhausted(guard, { estimatedCallUsd: bad })).toThrow(RangeError);
+    }
+  });
+});
+
+describe("gates — Retell", () => {
+  it("rejects on exhaustion", () => {
+    expect(gates.retell(spent(1.0, 1.0))).toEqual({ call_inbound: { reject: true } });
+  });
+
+  it("admits with overrides and no reject key", () => {
+    const resp = gates.retell(spent(1.0, 0.1), { admit: { dynamic_variables: { name: "Ada" } } });
+    expect(resp).toEqual({ call_inbound: { dynamic_variables: { name: "Ada" } } });
+    expect("reject" in resp.call_inbound).toBe(false);
+  });
+
+  it("reject is the boolean true, not a string", () => {
+    const reject = gates.retell(spent(1.0, 1.0)).call_inbound.reject;
+    expect(reject).toBe(true);
+  });
+});
+
+describe("gates — Vapi", () => {
+  it("rejects with the error shape", () => {
+    const resp = gates.vapi(spent(1.0, 1.0), { assistantId: "asst_1", errorMessage: "No budget." });
+    expect(resp).toEqual({ error: "No budget." });
+  });
+
+  it("admits with assistantId (takes precedence over assistant)", () => {
+    const resp = gates.vapi(spent(1.0, 0.1), {
+      assistantId: "asst_1",
+      assistant: { model: { provider: "openai", model: "gpt-4o" } },
+    });
+    expect(resp).toEqual({ assistantId: "asst_1" });
+  });
+
+  it("admits with an inline assistant", () => {
+    const assistant = { model: { provider: "openai", model: "gpt-4o" } };
+    expect(gates.vapi(spent(1.0, 0.1), { assistant })).toEqual({ assistant });
+  });
+
+  it("admitting without a target throws", () => {
+    expect(() => gates.vapi(spent(1.0, 0.1))).toThrow(RangeError);
+  });
+});

--- a/js/test/voice-pricing.test.ts
+++ b/js/test/voice-pricing.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Offline voice pricing — fail-closed resolution and per-unit math.
+ *
+ * The voice twin of the token pricing tests: STT is billed per second, TTS per 1k
+ * chars, telephony per minute, and every schema/vendor mismatch fails closed
+ * (`UnpriceableVoiceError`) rather than metering a leg at a silent $0.
+ *
+ * Mirrors `tests/test_voice_pricing.py`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UnpriceableVoiceError } from "../src/index.js";
+import {
+  lookupVoiceRate,
+  priceVoiceLeg,
+  resolveVoiceRate,
+  unitForMode,
+  voiceLegCost,
+} from "../src/voice-pricing.js";
+
+describe("lookupVoiceRate — resolution", () => {
+  it("resolves a known STT vendor from the cost map", () => {
+    // $0.0077/min mono ÷ 60 = $0.0001283333/sec.
+    expect(lookupVoiceRate("deepgram-nova-3", "stt")).toBeCloseTo(0.0077 / 60, 7);
+  });
+
+  it("resolves known TTS vendors from the cost map", () => {
+    expect(lookupVoiceRate("elevenlabs-multilingual-v2", "tts")).toBeCloseTo(0.1, 9);
+    expect(lookupVoiceRate("elevenlabs-flash-v2.5", "tts")).toBeCloseTo(0.05, 9);
+  });
+
+  it("resolves a known telephony vendor from the cost map", () => {
+    expect(lookupVoiceRate("twilio-us-inbound-local", "telephony")).toBeCloseTo(0.0085, 9);
+  });
+
+  it("an unknown or null vendor is unpriceable (null, no throw)", () => {
+    expect(lookupVoiceRate("no-such-vendor-anywhere", "stt")).toBeNull();
+    expect(lookupVoiceRate(null, "stt")).toBeNull();
+    expect(lookupVoiceRate(undefined, "stt")).toBeNull();
+  });
+
+  it("a mode mismatch fails closed", () => {
+    // An STT entry asked to price a TTS leg is a schema mismatch — refuse rather
+    // than mis-bill a per-second rate as if it were per-1k-chars.
+    expect(lookupVoiceRate("deepgram-nova-3", "tts")).toBeNull();
+    expect(lookupVoiceRate("elevenlabs-flash-v2.5", "stt")).toBeNull();
+    expect(lookupVoiceRate("twilio-us-inbound-local", "stt")).toBeNull();
+  });
+});
+
+describe("resolveVoiceRate — fail-closed + overrides", () => {
+  it("throws the fail-closed error for an unknown vendor", () => {
+    let err: unknown;
+    try {
+      resolveVoiceRate("mystery-tts", "tts");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(UnpriceableVoiceError);
+    expect((err as UnpriceableVoiceError).vendor).toBe("mystery-tts");
+    expect((err as UnpriceableVoiceError).mode).toBe("tts");
+  });
+
+  it("an override wins over the cost map", () => {
+    const resolved = resolveVoiceRate("deepgram-nova-3", "stt", 0.0002);
+    expect(resolved.source).toBe("override");
+    expect(resolved.rate).toBe(0.0002);
+    expect(resolved.unit).toBe(unitForMode.stt);
+  });
+
+  it("an override prices a vendor the map cannot", () => {
+    const resolved = resolveVoiceRate("some-brand-new-tts", "tts", 0.07);
+    expect(resolved.source).toBe("override");
+    expect(resolved.rate).toBe(0.07);
+  });
+
+  it("a non-finite or negative override throws", () => {
+    expect(() => resolveVoiceRate("x", "stt", Number.NaN)).toThrow(RangeError);
+    expect(() => resolveVoiceRate("x", "stt", -1.0)).toThrow(RangeError);
+  });
+});
+
+describe("voiceLegCost — per-unit math", () => {
+  it("bills each unit correctly", () => {
+    expect(voiceLegCost("stt", 10.0, 0.0001)).toBeCloseTo(0.001, 9); // seconds * $/sec
+    expect(voiceLegCost("tts", 2000, 0.05)).toBeCloseTo(0.1, 9); // chars / 1000 * $/1k
+    expect(voiceLegCost("telephony", 3.0, 0.0085)).toBeCloseTo(0.0255, 9); // min * $/min
+  });
+
+  it("clamps a negative quantity to zero", () => {
+    expect(voiceLegCost("stt", -5.0, 0.01)).toBe(0);
+  });
+});
+
+describe("priceVoiceLeg — entry point", () => {
+  it("skips (null) when the leg is unconfigured", () => {
+    // Neither a vendor nor an override — the leg is un-metered (token-only
+    // contract preserved), NOT a fail-closed throw.
+    expect(priceVoiceLeg("stt", 10.0)).toBeNull();
+  });
+
+  it("fails closed when configured but unpriceable", () => {
+    expect(() => priceVoiceLeg("tts", 1000, { model: "ghost-vendor" })).toThrow(
+      UnpriceableVoiceError,
+    );
+  });
+
+  it("prices a configured, known leg", () => {
+    // deepgram STT over 60s ≈ 60 * (0.0077/60) = $0.0077.
+    expect(priceVoiceLeg("stt", 60, { model: "deepgram-nova-3" })).toBeCloseTo(0.0077, 6);
+  });
+});

--- a/js/test/voice-pricing.test.ts
+++ b/js/test/voice-pricing.test.ts
@@ -111,3 +111,14 @@ describe("priceVoiceLeg — entry point", () => {
     expect(priceVoiceLeg("stt", 60, { model: "deepgram-nova-3" })).toBeCloseTo(0.0077, 6);
   });
 });
+
+describe("voiceLegCost — non-finite quantities fail closed", () => {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "throws rather than returning a non-finite cost (%s)",
+    (q) => {
+      // A NaN/Infinity quantity would poison the guard's running total.
+      expect(() => voiceLegCost("stt", q, 0.0001)).toThrow(RangeError);
+      expect(() => priceVoiceLeg("stt", q, { model: "deepgram-nova-3" })).toThrow(RangeError);
+    },
+  );
+});


### PR DESCRIPTION
The **foundation** unit of the "TypeScript voice parity + adapters" ticket. Ships the TS pieces the voice adapters depend on — real, tested, no faked adapters.

## First: the ticket's core-parity premise doesn't hold

npm is **0.10.0** (not 0.9.0), and it **already** ships `advisory` / `step` / tool-spend (`reserveTool`/`settleTool`/`recordTool`) / token + latency budgets / `exportLog` — each with a dedicated test (`js/test/advisory.test.ts`, `token-step-budgets.test.ts`, `tool-costs.test.ts`, `latency.test.ts`, `spend-log.test.ts`, …). **AC#1 was essentially already met.** The genuinely-missing surface is **voice**, so that's where this PR goes.

## What shipped (JS-only, `0.10.0 → 0.11.0`)

- **`js/src/voice-pricing.ts`** — `priceVoiceLeg` / `resolveVoiceRate` / `lookupVoiceRate` / `voiceLegCost` price STT ($/sec) / TTS ($/1k-chars) / telephony ($/min) legs from the `__voice__` cost map (already in `js/src/cost_map.json`). Fail-closed via new `UnpriceableVoiceError`; unconfigured leg → `null`. Faithful port of `voice_pricing.py`.
- **`js/src/gates.ts`** — `gates.retell()` / `gates.vapi()` / `gates.preCall()` / `gates.budgetExhausted()`, exported as a `gates` namespace so `import { gates } from "floe-guard"` reads like Python's `floe_guard.gates`. Exact verified reject/admit shapes, non-binding preflight, inclusive-fit admission, `RangeError` on a bad estimate, `assistantId` precedence, **no `bland()`** (field unconfirmed). Faithful port of `gates.py`.
- **`advisory().burnRateUsdPerMin`** — closes today's advisory delta (`spentUsd ÷ minutes since created`; `null` before any elapsed).

Together these deliver the AC's "per-leg call cost **and** a pre-call admission decision" in TS.

## What I deliberately did NOT do

- **No voice adapter** (Vapi proxy / Retell WS / LiveKit shim) — those are real integration work, shipping as separate reviewable PRs.
- **Did NOT remove the "no TypeScript voice adapter" statement** — the README section is updated to reflect the shipped pricing + gates but *keeps* the honest "no full-session adapter yet." The AC to remove it is gated on the adapters actually shipping.

## Verification (run independently, not just the porting agent's word)

`tsc --noEmit` clean · `tsup` build ok · `vitest` **130 passed (130)**, 29 new tests (exact reject shapes incl. boolean-`true`, inclusive-fit admit, `RangeError` paths, burn rate from a known spend/elapsed pair, fail-closed `UnpriceableVoiceError`). No Python source touched.

## Next units (the actual adapters)

1. LiveKit Agents (Node) shim — recommend first (I have the Python `LiveKitBudgetGuard` reference)
2. Vapi custom-LLM proxy wrapper
3. Retell WS adapter

Each with a runnable stubbed no-key demo, then the cookbook guard lines + the docs "no adapter" removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline pricing for speech-to-text, text-to-speech, and US telephony usage, including rate overrides and clear errors for missing prices.
  - Added pre-call budget checks with generic decisions and Retell/Vapi-compatible admission responses.
  - Added burn-rate reporting showing spending per minute.
- **Documentation**
  - Updated voice parity documentation with the new pricing and admission capabilities.
- **Release**
  - Advanced the JavaScript package version to 0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->