### PR TITLE
fix: unblock PyPI publish (hatchling metadata pin) + gates/voice parity (0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,23 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.16.0 / js 0.10.0
+## Unreleased — py 0.16.1 / js 0.10.0
+
+### Fixed (py)
+
+- **Unblock PyPI publishing** — cap `hatchling<1.32` in `[build-system]`.
+  hatchling 1.32.0 bumped the emitted core-metadata to `Metadata-Version: 2.5`,
+  which the release action's twine (`pypa/gh-action-pypi-publish@v1.14.0`) rejects
+  (`InvalidDistribution: '2.5' is not a valid metadata version`) — that is why
+  PyPI froze at 0.13.0 (Aug 6) while the repo moved to 0.16.x. Pinning to the last
+  2.4-emitting hatchling restores a wheel both twine and PyPI accept (verified:
+  `Metadata-Version: 2.4`, `twine check` passes). Publishing 0.16.1 catches up
+  everything since 0.13.0.
+- **`gates` / voice-pricing input hardening** (parity with the JS fixes):
+  `gates.retell` strips `reject` from `admit` overrides so an errant
+  `admit={"reject": True}` on an available-budget call can't flip the response into
+  Retell's reject shape; `voice_leg_cost` raises on a non-finite `quantity`
+  (`max(0.0, nan)` is `nan`, which would poison the guard's running total).
 
 ### Added (py)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,16 @@
+# hatchling is capped below 1.32 on purpose: 1.32.0 bumped the emitted
+# core-metadata to `Metadata-Version: 2.5`, which the pinned
+# pypa/gh-action-pypi-publish@v1.14.0 (twine 6.1.0 + packaging 25.0) rejects
+# with "InvalidDistribution: '2.5' is not a valid metadata version". 1.31.0 is
+# the last release that emits 2.4, which both twine and PyPI accept. This is
+# why PyPI froze at 0.13.0 (Aug 6) while the repo moved to 0.16.x.
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.16.0"
+version = "0.16.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/gates.py
+++ b/src/floe_guard/gates.py
@@ -83,7 +83,9 @@ def retell(
 
     On budget exhaustion returns ``{"call_inbound": {"reject": True}}``; otherwise
     ``{"call_inbound": {...}}`` carrying any ``admit`` overrides you pass
-    (``dynamic_variables``, ``metadata``, ``override_agent_id``, …).
+    (``dynamic_variables``, ``metadata``, ``override_agent_id``, …). A top-level
+    ``reject`` key in ``admit`` is **ignored** — the gate's budget decision, not the
+    caller's overrides, controls admission.
 
     Retell contract (verified against docs.retellai.com/features/inbound-call-webhook):
     **only the boolean ``true`` rejects** — any other value is ignored. The webhook

--- a/src/floe_guard/gates.py
+++ b/src/floe_guard/gates.py
@@ -93,7 +93,12 @@ def retell(
     """
     if budget_exhausted(guard, estimated_call_usd=estimated_call_usd):
         return {"call_inbound": {"reject": True}}
-    return {"call_inbound": dict(admit or {})}
+    # The gate's budget decision — not the caller's overrides — controls admission.
+    # Strip ``reject`` from admit overrides so an errant ``admit={"reject": True}``
+    # on an available-budget call can't flip the response into Retell's reject shape.
+    overrides = dict(admit or {})
+    overrides.pop("reject", None)
+    return {"call_inbound": overrides}
 
 
 def vapi(

--- a/src/floe_guard/voice_pricing.py
+++ b/src/floe_guard/voice_pricing.py
@@ -111,6 +111,11 @@ def resolve_voice_rate(
 def voice_leg_cost(mode: VoiceMode, quantity: float, rate: float) -> float:
     """USD for one leg. ``quantity`` is seconds (stt), characters (tts), or
     minutes (telephony); negative quantities clamp to zero."""
+    # Reject non-finite quantities: max(0.0, nan) is nan, so a NaN/inf quantity
+    # would return a non-finite USD amount that then poisons the guard's running
+    # total (NaN disables every ceiling comparison). Negatives still clamp.
+    if not math.isfinite(quantity):
+        raise ValueError(f"voice {mode} quantity must be a finite number, got {quantity!r}")
     q = max(0.0, quantity)
     if mode == "stt":
         return q * rate  # seconds * $/second

--- a/src/floe_guard/voice_pricing.py
+++ b/src/floe_guard/voice_pricing.py
@@ -110,7 +110,12 @@ def resolve_voice_rate(
 
 def voice_leg_cost(mode: VoiceMode, quantity: float, rate: float) -> float:
     """USD for one leg. ``quantity`` is seconds (stt), characters (tts), or
-    minutes (telephony); negative quantities clamp to zero."""
+    minutes (telephony); negative quantities clamp to zero.
+
+    Raises:
+        ValueError: ``quantity`` is non-finite (NaN/inf) — a non-finite cost would
+            poison the guard's running total, so it fails closed.
+    """
     # Reject non-finite quantities: max(0.0, nan) is nan, so a NaN/inf quantity
     # would return a non-finite USD amount that then poisons the guard's running
     # total (NaN disables every ceiling comparison). Negatives still clamp.

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -95,3 +95,11 @@ def test_vapi_admits_with_inline_assistant() -> None:
 def test_vapi_admit_without_target_raises() -> None:
     with pytest.raises(ValueError, match="assistant"):
         gates.vapi(_spent(1.00, 0.10))
+
+
+def test_retell_admit_cannot_inject_reject() -> None:
+    # An errant admit override must not flip an available-budget call into a reject.
+    resp = gates.retell(
+        _spent(1.00, 0.10), admit={"reject": True, "dynamic_variables": {"name": "Ada"}}
+    )
+    assert resp == {"call_inbound": {"dynamic_variables": {"name": "Ada"}}}

--- a/tests/test_voice_pricing.py
+++ b/tests/test_voice_pricing.py
@@ -170,3 +170,12 @@ def test_every_voice_entry_matches_its_declared_unit() -> None:
             f"{vendor} has a non-positive rate"
         )
         assert entry.get("provider"), f"{vendor} missing provider"
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_voice_leg_cost_rejects_non_finite_quantity(bad: float) -> None:
+    # A NaN/inf quantity would poison the guard's running total — fail closed.
+    with pytest.raises(ValueError, match="finite"):
+        voice_leg_cost("stt", bad, 0.0001)
+    with pytest.raises(ValueError, match="finite"):
+        price_voice_leg("stt", bad, model="deepgram-nova-3")


### PR DESCRIPTION
## 1. The PyPI publish has been broken since Aug 6 — this fixes it 🔴

You flagged that the last PyPI release was Aug 6 (0.13.0) while the repo is at 0.16.x. **The publish workflow has failed on every run since.** Root cause, from the failed run logs:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`publish.yml` builds with **unpinned `hatchling`**. hatchling **1.32.0** bumped the emitted core-metadata to `Metadata-Version: 2.5`, which the twine bundled in `pypa/gh-action-pypi-publish@v1.14.0` rejects. The 0.13.0 build (Aug 6) predated that bump. npm publishes were unaffected — which is exactly why *only* PyPI froze.

**Fix:** cap `hatchling<1.32` (last 2.4-emitting release). **Verified locally** (not assumed):

| | Before (unpinned) | After (`hatchling<1.32`) |
|---|---|---|
| `Metadata-Version` | `2.5` (rejected) | **`2.4`** |
| `twine check` | — | **PASSED** |

Merging this lets the next CI-on-`main` run publish **0.16.1**, which catches up **everything** since 0.13.0 (0.14 voice map, 0.15 from_floe, 0.16 voice primitives) — the workflow skips already-published versions and publishes the current one.

## 2. Python parity for the JS CodeRabbit fixes (PR #74)

Two of the three CodeRabbit findings on #74 apply to the merged Python originals too:
- **`gates.retell`** strips `reject` from `admit` overrides — an errant `admit={"reject": True}` on an available-budget call can no longer flip the response into Retell's reject shape.
- **`voice_leg_cost`** raises `ValueError` on a non-finite `quantity` — `max(0.0, nan)` is `nan`, which would poison the guard's running total (NaN disables every ceiling comparison).

## Why combined

Both are 0.16.1 bugfixes that touch `pyproject.toml`; separate PRs would collide on the version bump, conflict on pyproject, and the packaging-only PR would trip version-guard. Bundling is the clean path and gets the urgent publish fix out fastest.

## Verification

`python -m build` → `Metadata-Version: 2.4` · `twine check` PASSED · full pytest **361 passed** · ruff clean. py `0.16.0 → 0.16.1`.

> Process note: I ran the publish diagnosis as a background agent that (correctly) isolated to its own git worktree; I folded its verified one-line pin into this PR and cleaned up the worktree. No stray branch left behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented admission overrides from forcing a rejection when the gate approves a request.
  * Added validation to reject invalid, non-finite voice-pricing quantities.
  * Negative pricing quantities continue to be handled safely as zero.

* **Release**
  * Updated the Python package to version 0.16.1.
  * Added release notes covering the latest Python and JavaScript updates, including JavaScript 0.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->