### PR TITLE
feat(js): voice adapters — LiveKit, Vapi, Retell (js 0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,33 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.16.1 / js 0.11.0
+## Unreleased — js 0.12.0
+
+### Added (js)
+
+- **Voice adapters — LiveKit, Vapi, Retell** (the Node voice glue): each wraps its
+  platform's model turn with reserve-before / settle-on-real-usage / release-on-
+  interrupt, meters STT/TTS/telephony legs from the `__voice__` cost map via
+  `priceVoiceLeg` (fail-closed), and answers the platform's inbound admission
+  webhook via `gates`. Pre-turn/pre-call admission + per-turn settlement only — no
+  mid-call cutoff.
+  - `floe-guard/adapters/livekit` → `LiveKitBudgetGuard.attach(session, agent)`:
+    reserves in the agent's `llmNode`, settles on the session's `metrics_collected`
+    (verified **not** deprecated in `@livekit/agents` 1.6.x, unlike Python 1.5.0),
+    releases on stream cancel / close. `@livekit/agents` is an optional peer.
+  - `floe-guard/adapters/vapi` → `VapiBudgetGuard`: `guardCompletion` (JSON) /
+    `guardStream` (SSE) reserve before the upstream call and settle on the real
+    OpenAI `usage`; `assistantRequest` wraps `gates.vapi`. A stream with no `usage`
+    (upstream missing `stream_options.include_usage`) throws `VapiUsageMissingError`
+    rather than metering a silent $0.
+  - `floe-guard/adapters/retell` → `RetellBudgetGuard`: `beginTurn` (returns an
+    admit/block decision) / `settleTurn` keyed by `response_id`, a newer id releases
+    the prior hold (barge-in); `admitCall` wraps `gates.retell`.
+  - Each ships a runnable **stubbed, no-key** demo (`js/examples/*_voice_cost.mjs`)
+    that prints a pre-call admission decision and a per-leg call-cost receipt.
+    Adapters are structurally typed — no hard runtime SDK dependency.
+
+## py 0.16.1 / js 0.11.0 — 2026-08-14
 
 ### Fixed (py)
 

--- a/README.md
+++ b/README.md
@@ -890,28 +890,46 @@ call-level intervention.) Budget, not balance. US-only telephony, v1.
 | CrewAI | ✅ | — |
 | LiteLLM | ✅ | — |
 | Vercel AI SDK | — | ✅ |
+| **LiveKit** (voice) | ✅ | ✅ |
+| **Vapi** (voice) | — | ✅ |
+| **Retell** (voice) | — | ✅ |
 | **Pipecat** (voice) | ✅ | — |
-| **LiveKit** (voice) | ✅ | — |
 
-The TypeScript package is a single Vercel AI SDK middleware that guards any model
-the AI SDK wraps (OpenAI, Anthropic, Gemini, …) — it is not a per-framework
-adapter set like the Python package.
+The TypeScript package started as a single Vercel AI SDK middleware; it now also
+ships **voice-leg pricing** (`priceVoiceLeg`), **pre-call admission gates**
+(`gates.retell` / `gates.vapi` / `gates.preCall`), and **native voice adapters**
+for LiveKit, Vapi, and Retell (below).
 
-### TypeScript voice parity
+### TypeScript voice adapters
 
-**TypeScript ships the voice foundation — pricing and admission — not yet a
-full-session adapter.** The JS package ([`js/`](js/)) now prices voice legs
-offline (`priceVoiceLeg` — STT/TTS/telephony from the same `__voice__` cost map,
-fail-closed via `UnpriceableVoiceError`) and ships **pre-call admission gates**
-(`gates.retell` / `gates.vapi` / `gates.preCall`) that return each provider's
-exact reject/admit shape — the same contract as the Python `gates`. What it does
-**not** yet ship is a native STT → LLM → TTS *session* adapter (Vapi custom-LLM
-proxy / Retell WS / LiveKit Agents) that meters a whole running turn. Until then,
-drive the LLM turn through the Vercel AI SDK middleware and meter STT/TTS via
-`recordTool` (price the legs with `priceVoiceLeg`), run the LLM leg through the
-**hosted [Floe proxy](#when-you-outgrow-local-guardrails)** (un-bypassable,
-cross-vendor), or use the Python Pipecat / LiveKit adapters above, which enforce
-the whole turn.
+TypeScript ships native STT → LLM → TTS session adapters for the three Node voice
+stacks. Each reserves before the model turn, settles on real usage, releases on
+interrupt, and meters STT/TTS/telephony legs from the `__voice__` cost map
+(fail-closed via `UnpriceableVoiceError`) — the same enforcement contract as the
+Python Pipecat / LiveKit adapters. **Pre-turn / pre-call admission plus per-turn
+settlement only; no mid-call cutoff.**
+
+```ts
+// LiveKit Agents (Node) — @livekit/agents is an optional peer
+import { LiveKitBudgetGuard } from "floe-guard/adapters/livekit";
+new LiveKitBudgetGuard(guard, { model, sttModel, ttsModel, telephony }).attach(session, agent);
+
+// Vapi custom-LLM proxy — wrap the /chat/completions turn
+import { VapiBudgetGuard } from "floe-guard/adapters/vapi";
+const budget = new VapiBudgetGuard(guard, { sttModel, ttsModel, telephony });
+const completion = await budget.guardCompletion(() => openai.chat.completions.create(req), { model });
+
+// Retell custom-LLM WebSocket — reserve on response_required, settle on content_complete
+import { RetellBudgetGuard } from "floe-guard/adapters/retell";
+const decision = budget.beginTurn(event);        // { admitted } — reserves before the LLM call
+budget.settleTurn(event.response_id, usage);     // settle real usage after content_complete
+```
+
+Each ships a runnable, no-key demo (`js/examples/*_voice_cost.mjs`) that prints a
+pre-call admission decision and a per-leg call-cost receipt; see the module
+docstrings for the full API. Pipecat's server pipeline is Python-only, so its
+budget processor lives in the Python package (`FloeBudgetGuardProcessor`) — there
+is no Node Pipecat server surface to adapt.
 
 For wiring floe-guard into an existing voice pipeline, see the Floe docs:
 **[Add Floe to your existing pipeline](https://floe-labs.gitbook.io/docs/getting-started/integrate-existing-pipeline)**.

--- a/README.md
+++ b/README.md
@@ -696,8 +696,10 @@ function wrapper, these adapters enforce **per turn** — reserve before the LLM
 call (so a turn is blocked *before* its TTS/audio spend piles on top of a call
 that would already cross the ceiling), settle on the real usage the pipeline
 reports, and release a turn that ends without ever reporting usage (an
-interrupted turn) so the reservation never leaks against the ceiling. Both voice
-adapters are **Python-only** today.
+interrupted turn) so the reservation never leaks against the ceiling. This
+section covers the **Python** Pipecat and LiveKit adapters; TypeScript ships
+native LiveKit / Vapi / Retell adapters too — see
+[TypeScript voice adapters](#typescript-voice-adapters).
 
 **The whole call is priced from the bundled map — no hand-typed rates.** Name each
 leg's vendor (`stt_model`, `tts_model`, `telephony`) and floe-guard prices the

--- a/js/examples/livekit_voice_cost.mjs
+++ b/js/examples/livekit_voice_cost.mjs
@@ -1,0 +1,118 @@
+/**
+ * LiveKitBudgetGuard demo — STUBBED, no keys, no network.
+ *
+ *   node examples/livekit_voice_cost.mjs   (run `npm run build` first)
+ *
+ * Fabricates a LiveKit-shaped session (a typed emitter) and agent (an `llmNode`),
+ * drives the adapter through one voice turn, and prints:
+ *   1. a pre-call admission decision (from the budget gate), and
+ *   2. a per-leg call-cost receipt (LLM tokens + STT + TTS + telephony).
+ *
+ * Scope is pre-call admission + per-turn settlement — nothing here cuts a turn off
+ * partway. Every rate is offline (the bundled voice cost map); no vendor is called.
+ */
+
+import { BudgetGuard } from "../dist/index.js";
+import { LiveKitBudgetGuard } from "../dist/adapters/livekit.js";
+
+// --- Fakes standing in for @livekit/agents (so this runs with zero credentials) ---
+
+/** Minimal typed-emitter stand-in for `AgentSession`. */
+class FakeSession {
+  #listeners = {};
+  on(event, listener) {
+    (this.#listeners[event] ??= []).push(listener);
+    return this;
+  }
+  emit(event, ev) {
+    for (const listener of this.#listeners[event] ?? []) listener(ev);
+  }
+}
+
+/** A web ReadableStream of chunks, as `Agent.llmNode` returns. */
+function streamOf(chunks) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+/** An agent whose `llmNode` returns a short reply stream. */
+const agent = {
+  async llmNode() {
+    return streamOf(["Sure, ", "here's ", "your ", "answer."]);
+  },
+};
+
+// --- Wiring ------------------------------------------------------------------
+
+const guard = new BudgetGuard(1.0, {
+  // gemini-2.0-flash isn't in the token map here, so price it explicitly.
+  priceOverrides: {
+    "gemini-2.0-flash": { inputCostPerToken: 0.3e-6, outputCostPerToken: 2.5e-6 },
+  },
+});
+
+const budget = new LiveKitBudgetGuard(guard, {
+  model: "gemini-2.0-flash",
+  sttModel: "deepgram-nova-3", // priced per second from the voice map
+  ttsModel: "elevenlabs-flash-v2.5", // priced per 1k characters
+  telephony: "twilio-us-inbound-local", // priced per minute
+});
+
+// 1) Pre-call admission — would we even start this call, given the budget left?
+const estimatedCallUsd = 0.25;
+const admit = budget.admitCall({ estimatedCallUsd });
+console.log("=== Pre-call admission ===");
+console.log(`  budget remaining : $${guard.remainingUsd.toFixed(6)}`);
+console.log(`  estimated call   : $${estimatedCallUsd.toFixed(6)}`);
+console.log(`  decision         : ${admit ? "ADMIT" : "REJECT"}`);
+console.log();
+
+const session = new FakeSession();
+budget.attach(session, agent);
+
+// --- One voice turn ----------------------------------------------------------
+
+// Reserve before the LLM turn, then run it (drain the reply stream).
+const stream = await agent.llmNode();
+await drain(stream);
+
+// Real usage lands after the turn — the non-deprecated `metrics_collected` event.
+session.emit("metrics_collected", {
+  metrics: { type: "llm_metrics", promptTokens: 1_200, completionTokens: 350 },
+});
+session.emit("metrics_collected", {
+  metrics: { type: "stt_metrics", audioDurationMs: 8_400 }, // 8.4 s of caller audio
+});
+session.emit("metrics_collected", {
+  metrics: { type: "tts_metrics", charactersCount: 240 }, // synthesized reply
+});
+
+// Telephony has no LiveKit metric — the transport meters it per minute.
+budget.meterTelephony(1.5);
+
+// --- Receipt -----------------------------------------------------------------
+
+const tools = guard.toolCosts;
+const toolTotal = Object.values(tools).reduce((a, b) => a + b, 0);
+const llmCost = guard.spentUsd - toolTotal;
+
+console.log("=== Call-cost receipt (all offline) ===");
+console.log(`  LLM (gemini-2.0-flash, 1200+350 tok) : $${llmCost.toFixed(6)}`);
+console.log(`  STT (deepgram-nova-3, 8.4 s)         : $${(tools["livekit-stt"] ?? 0).toFixed(6)}`);
+console.log(`  TTS (elevenlabs-flash-v2.5, 240 ch)  : $${(tools["livekit-tts"] ?? 0).toFixed(6)}`);
+console.log(`  Telephony (twilio inbound, 1.5 min)  : $${(tools["livekit-telephony"] ?? 0).toFixed(6)}`);
+console.log("  " + "-".repeat(44));
+console.log(`  TOTAL spent                          : $${guard.spentUsd.toFixed(6)}`);
+console.log(`  Budget remaining                     : $${guard.remainingUsd.toFixed(6)}`);

--- a/js/examples/retell_voice_cost.mjs
+++ b/js/examples/retell_voice_cost.mjs
@@ -1,0 +1,93 @@
+/**
+ * RetellBudgetGuard demo — STUBBED, no keys, no network, no WS server.
+ *
+ *   node examples/retell_voice_cost.mjs   (run `npm run build` first)
+ *
+ * Fabricates a Retell custom-LLM `response_required` interaction event plus fake LLM
+ * token usage, drives the adapter through one voice turn, and prints:
+ *   1. a pre-call admission decision (Retell's `call_inbound` webhook shape), and
+ *   2. a per-leg call-cost receipt (LLM tokens + STT + TTS + telephony).
+ *
+ * Scope is pre-call admission + per-turn settlement — nothing here cuts a turn off
+ * partway. Every rate is offline (the bundled voice cost map); no vendor is called.
+ */
+
+import { BudgetGuard } from "../dist/index.js";
+import { RetellBudgetGuard } from "../dist/adapters/retell.js";
+
+// --- Wiring ------------------------------------------------------------------
+
+const guard = new BudgetGuard(1.0, {
+  // gpt-4o-mini isn't in the token map here, so price it explicitly.
+  priceOverrides: {
+    "gpt-4o-mini": { inputCostPerToken: 0.15e-6, outputCostPerToken: 0.6e-6 },
+  },
+});
+
+const budget = new RetellBudgetGuard(guard, {
+  model: "gpt-4o-mini",
+  sttModel: "deepgram-nova-3", // priced per second from the voice map
+  ttsModel: "elevenlabs-flash-v2.5", // priced per 1k characters
+  telephony: "twilio-us-inbound-local", // priced per minute
+});
+
+// 1) Pre-call admission — Retell's inbound-call webhook. Would we even accept this
+//    call, given the budget left? (budget-exhausted -> { call_inbound: { reject: true } })
+const inbound = budget.admitCall({
+  estimatedCallUsd: 0.25,
+  admit: { dynamic_variables: { plan: "free" } },
+});
+console.log("=== Pre-call admission (Retell call_inbound webhook) ===");
+console.log(`  budget remaining : $${guard.remainingUsd.toFixed(6)}`);
+console.log(`  decision         : ${inbound.call_inbound.reject ? "REJECT" : "ADMIT"}`);
+console.log(`  webhook response : ${JSON.stringify(inbound)}`);
+console.log();
+
+// --- One voice turn ----------------------------------------------------------
+
+// Retell sends a `response_required` interaction event over the WS.
+const event = {
+  interaction_type: "response_required",
+  response_id: 1,
+  transcript: [{ role: "user", content: "What's my balance?" }],
+};
+
+// Reserve BEFORE the LLM call for this response_id.
+const turn = budget.beginTurn(event);
+if (!turn.admitted) {
+  // Budget spent — send a wrap-up response and hang up (no LLM call).
+  console.log("Turn blocked:", budget.response(event.response_id, "Out of budget.", {
+    complete: true,
+    endCall: true,
+  }));
+  process.exit(0);
+}
+
+// Your custom LLM streams a reply; we fake its text + real token usage.
+const reply = "Your balance is $42.00.";
+const usage = { promptTokens: 1_200, completionTokens: 350 };
+// (In a real server you'd `ws.send` each partial, ending with content_complete.)
+budget.response(event.response_id, reply, { complete: true });
+
+// Settle the turn's real token usage after content_complete.
+budget.settleTurn(event.response_id, usage);
+
+// The socket never sees STT / TTS / telephony — meter them explicitly.
+budget.meterStt(8.4); // 8.4 s of caller audio transcribed
+budget.meterTts(reply.length); // characters synthesized back
+budget.meterTelephony(1.5); // 1.5 min of call time
+
+// --- Receipt -----------------------------------------------------------------
+
+const tools = guard.toolCosts;
+const toolTotal = Object.values(tools).reduce((a, b) => a + b, 0);
+const llmCost = guard.spentUsd - toolTotal;
+
+console.log("=== Call-cost receipt (all offline) ===");
+console.log(`  LLM (gpt-4o-mini, 1200+350 tok)      : $${llmCost.toFixed(6)}`);
+console.log(`  STT (deepgram-nova-3, 8.4 s)         : $${(tools["retell-stt"] ?? 0).toFixed(6)}`);
+console.log(`  TTS (elevenlabs-flash-v2.5, ${String(reply.length).padStart(2)} ch)   : $${(tools["retell-tts"] ?? 0).toFixed(6)}`);
+console.log(`  Telephony (twilio inbound, 1.5 min)  : $${(tools["retell-telephony"] ?? 0).toFixed(6)}`);
+console.log("  " + "-".repeat(44));
+console.log(`  TOTAL spent                          : $${guard.spentUsd.toFixed(6)}`);
+console.log(`  Budget remaining                     : $${guard.remainingUsd.toFixed(6)}`);

--- a/js/examples/vapi_voice_cost.mjs
+++ b/js/examples/vapi_voice_cost.mjs
@@ -1,0 +1,90 @@
+/**
+ * VapiBudgetGuard demo — STUBBED, no keys, no network.
+ *
+ *   node examples/vapi_voice_cost.mjs   (run `npm run build` first)
+ *
+ * Fabricates a Vapi custom-LLM request and a fake upstream OpenAI SSE completion,
+ * drives the adapter through one model turn, and prints:
+ *   1. a pre-call admission decision (Vapi's assistant-request webhook shape), and
+ *   2. a per-leg call-cost receipt (LLM tokens + STT + TTS + telephony).
+ *
+ * Scope is pre-call admission + per-turn settlement — nothing here cuts a turn (or
+ * a stream) off partway. Every rate is offline (the bundled voice cost map); no
+ * vendor and no LLM is called.
+ */
+
+import { BudgetGuard } from "../dist/index.js";
+import { VapiBudgetGuard } from "../dist/adapters/vapi.js";
+
+// --- A fake upstream OpenAI SSE stream (what your /chat/completions would proxy) ---
+// Content chunks carry no usage; the FINAL empty-choices chunk carries usage, exactly
+// as stream_options:{ include_usage: true } produces. Without that flag there is no
+// usage chunk and the adapter fails loudly (VapiUsageMissingError) — never $0.
+async function* fakeUpstreamStream() {
+  for (const piece of ["Sure, ", "here's ", "your ", "answer."]) {
+    yield { choices: [{ delta: { content: piece } }] };
+  }
+  yield { choices: [], usage: { prompt_tokens: 1_200, completion_tokens: 350 } };
+}
+
+// --- Wiring ------------------------------------------------------------------
+
+const guard = new BudgetGuard(1.0, {
+  // gemini-2.0-flash isn't in the token map here, so price it explicitly.
+  priceOverrides: {
+    "gemini-2.0-flash": { inputCostPerToken: 0.3e-6, outputCostPerToken: 2.5e-6 },
+  },
+});
+
+const budget = new VapiBudgetGuard(guard, {
+  sttModel: "deepgram-nova-3", // priced per second from the voice map
+  ttsModel: "elevenlabs-flash-v2.5", // priced per 1k characters
+  telephony: "twilio-us-inbound-local", // priced per minute
+});
+
+// 1) Pre-call admission — Vapi's assistant-request webhook, answered from the budget.
+console.log("=== assistant-request admission (Vapi webhook shape) ===");
+const admit = budget.assistantRequest({
+  assistantId: "asst_demo_123",
+  estimatedCallUsd: 0.25,
+  errorMessage: "Sorry, this agent is out of budget right now.",
+});
+console.log(`  budget remaining : $${guard.remainingUsd.toFixed(6)}`);
+console.log(`  response         : ${JSON.stringify(admit)}`);
+console.log(`  decision         : ${"error" in admit ? "REJECT (spoken error)" : "ADMIT"}`);
+console.log();
+
+// --- One model turn via the custom-LLM proxy ---------------------------------
+
+// The Vapi request points at YOUR /chat/completions with { stream: true }. The
+// adapter reserves before the upstream call, forwards each chunk, and settles on
+// the real token usage carried by the final chunk.
+const model = "gemini-2.0-flash"; // Vapi sends the model in the request body
+const sse = budget.guardStream(() => fakeUpstreamStream(), { model });
+
+let text = "";
+for await (const chunk of sse) {
+  text += chunk.choices?.[0]?.delta?.content ?? "";
+}
+
+// The other legs never reach the custom-LLM proxy — meter them explicitly (as you
+// would from Vapi's end-of-call-report).
+budget.meterStt(8.4); // 8.4 s of caller audio
+budget.meterTts(240); // 240 synthesized characters
+budget.meterTelephony(1.5); // 1.5 min of call time
+
+// --- Receipt -----------------------------------------------------------------
+
+const tools = guard.toolCosts;
+const toolTotal = Object.values(tools).reduce((a, b) => a + b, 0);
+const llmCost = guard.spentUsd - toolTotal;
+
+console.log("=== Call-cost receipt (all offline) ===");
+console.log(`  assistant reply                      : "${text}"`);
+console.log(`  LLM (gemini-2.0-flash, 1200+350 tok) : $${llmCost.toFixed(6)}`);
+console.log(`  STT (deepgram-nova-3, 8.4 s)         : $${(tools["vapi-stt"] ?? 0).toFixed(6)}`);
+console.log(`  TTS (elevenlabs-flash-v2.5, 240 ch)  : $${(tools["vapi-tts"] ?? 0).toFixed(6)}`);
+console.log(`  Telephony (twilio inbound, 1.5 min)  : $${(tools["vapi-telephony"] ?? 0).toFixed(6)}`);
+console.log("  " + "-".repeat(44));
+console.log(`  TOTAL spent                          : $${guard.spentUsd.toFixed(6)}`);
+console.log(`  Budget remaining                     : $${guard.remainingUsd.toFixed(6)}`);

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "floe-guard",
-  "version": "0.8.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.8.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
+        "@livekit/agents": "^1.6.3",
         "ai": "^4.0.0",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
@@ -18,7 +19,13 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@livekit/agents": ">=1.5.0",
         "ai": ">=4.0.0 <6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@livekit/agents": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -94,6 +101,21 @@
       "peerDependencies": {
         "zod": "^3.23.8"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@datastructures-js/deque": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@datastructures-js/deque/-/deque-1.0.8.tgz",
+      "integrity": "sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@dmsnell/diff-match-patch": {
       "version": "1.1.0",
@@ -578,6 +600,544 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -617,6 +1177,575 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@livekit/agents": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@livekit/agents/-/agents-1.6.3.tgz",
+      "integrity": "sha512-15PTtmyP+fuUe3i83E2VOFW3pfeI/A+R7USqDVV83tc7O7Rd8XGizWob3zjUQ4cfhqrmR1ApYsDJjUgA/AIj4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@livekit/av": "^10.0.0",
+        "@livekit/local-inference": "^0.2.6",
+        "@livekit/mutex": "^1.1.1",
+        "@livekit/protocol": "^1.50.4",
+        "@livekit/throws-transformer": "0.1.8",
+        "@livekit/typed-emitter": "^3.0.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.220.0",
+        "@opentelemetry/core": "^2.8.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
+        "@opentelemetry/instrumentation-pino": "^0.66.0",
+        "@opentelemetry/otlp-exporter-base": "^0.220.0",
+        "@opentelemetry/resources": "^2.8.0",
+        "@opentelemetry/sdk-logs": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.8.0",
+        "@opentelemetry/sdk-trace-node": "^2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@types/pidusage": "^2.0.5",
+        "commander": "^12.0.0",
+        "fluent-ffmpeg": "^2.1.3",
+        "form-data": "^4.0.5",
+        "heap-js": "^2.6.0",
+        "json-schema": "^0.4.0",
+        "jsonrepair": "^3.14.0",
+        "livekit-server-sdk": "^2.14.1",
+        "ofetch": "^1.5.1",
+        "openai": "^6.8.1",
+        "pidusage": "^4.0.1",
+        "pino": "^8.19.0",
+        "pino-pretty": "^11.0.0",
+        "sharp": "0.35.3",
+        "ws": "^8.21.0",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "livekit-agents": "dist/bin/livekit-agents.js"
+      },
+      "peerDependencies": {
+        "@livekit/rtc-node": "^0.13.33",
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@livekit/agents/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@livekit/av": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av/-/av-10.0.0.tgz",
+      "integrity": "sha512-i39au9JY9qqZ9b0yKa5+2E3BQD9JtbGlCxqDbSvFjxprdHTdP96NgsLHOViwLk84J+eCLIyNzcGw5G3zIK2ZhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@livekit/av-darwin-arm64": "10.0.0",
+        "@livekit/av-darwin-x64": "10.0.0",
+        "@livekit/av-linux-arm64": "10.0.0",
+        "@livekit/av-linux-x64": "10.0.0",
+        "@livekit/av-win32-x64": "10.0.0"
+      }
+    },
+    "node_modules/@livekit/av-darwin-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av-darwin-arm64/-/av-darwin-arm64-10.0.0.tgz",
+      "integrity": "sha512-wf6C/eMKzZT88/4HvOlGZJMA/C5mewKlGG56HMJaAP6U/gUHRVDagDvce7+sZWz5RMsj2CAMUWZ+jiF1UgAAxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-2.1-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@livekit/av-darwin-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av-darwin-x64/-/av-darwin-x64-10.0.0.tgz",
+      "integrity": "sha512-Muw1jR+dpRHi0FLu8fHOCxDP/F/xGz1KOO9iIjAV+ObBCj0iPb1zXItWlpcVweU6JiaJpRN2HoI5FKpX+w0UeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-2.1-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@livekit/av-linux-arm64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av-linux-arm64/-/av-linux-arm64-10.0.0.tgz",
+      "integrity": "sha512-HVnzYLSKFrrR49epK37fV8eIbPuuWqbGoC7xXbmw0ziag1z0xUEZt072EEvmLcuCYMlX93At0se7Glh507751g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-2.1-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@livekit/av-linux-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av-linux-x64/-/av-linux-x64-10.0.0.tgz",
+      "integrity": "sha512-ZODmZ2bhfzjGrYF5KpwK7QHoaSVH96cX0o8sOGQT73VpgUCMDzcH+OSZWOlgFwUozk4jT/pjLfgGGPZtD2Dj7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-2.1-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@livekit/av-win32-x64": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/av-win32-x64/-/av-win32-x64-10.0.0.tgz",
+      "integrity": "sha512-zvgdIvuu8C5aM+rSkOTZLKqX0FsYaN5CXKysmkKLU+pEDz+pIzkFelxPYX7YreV111aTAY19Dzj2i0KGEFnOSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-2.1-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@livekit/local-inference": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference/-/local-inference-0.2.6.tgz",
+      "integrity": "sha512-HtA5tC+gdDHoWAkb0QJYVCIoLL6/53VGXVoRY68zIeTUik9kAW/EOuYirEqRuGlL2UCzjWRRhRSkxLleLyucmQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0 AND LicenseRef-LiveKit-Model",
+      "dependencies": {
+        "node-gyp-build": "^4.8.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@livekit/local-inference-darwin-arm64": "0.2.6",
+        "@livekit/local-inference-darwin-x64": "0.2.6",
+        "@livekit/local-inference-linux-arm64-gnu": "0.2.6",
+        "@livekit/local-inference-linux-x64-gnu": "0.2.6",
+        "@livekit/local-inference-win32-x64-msvc": "0.2.6"
+      }
+    },
+    "node_modules/@livekit/local-inference-darwin-arm64": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference-darwin-arm64/-/local-inference-darwin-arm64-0.2.6.tgz",
+      "integrity": "sha512-YdzE0eXgLpUfT0S6AcJ73BknX6fnHWqmH2AukNkO6IBmpth4dFnTvTpOrGWPunlbDJmXanCwdD+Bh9O4oQA+PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@livekit/local-inference-darwin-x64": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference-darwin-x64/-/local-inference-darwin-x64-0.2.6.tgz",
+      "integrity": "sha512-fSicCqoYA5iOtW2jZfB91RIcNafXs19xRNPH5QSHvrRXljvCn8WMh+7do1jEg1f2U98TDsyptZ91laiDSh8xNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@livekit/local-inference-linux-arm64-gnu": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference-linux-arm64-gnu/-/local-inference-linux-arm64-gnu-0.2.6.tgz",
+      "integrity": "sha512-XvLWw8IwiIimoQjivxelRdSz9uSenR7UJiw1KDL35qJd3ZrI3QMORnyx63s7TFgNNCoyJ2CBFBqs9k9pPuqkTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@livekit/local-inference-linux-x64-gnu": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference-linux-x64-gnu/-/local-inference-linux-x64-gnu-0.2.6.tgz",
+      "integrity": "sha512-L9MagQm/5tm0r82/GXecIZU8jz/2LY8DsMzRPlkz/2Et6qR4zz+8wEOUifuLC520L8MFN7HN6yf+PNbQnSfvWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@livekit/local-inference-win32-x64-msvc": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@livekit/local-inference-win32-x64-msvc/-/local-inference-win32-x64-msvc-0.2.6.tgz",
+      "integrity": "sha512-g3B10sLdIsE0du8xh8+oFAllvbKZBRcVUXf52HvtRwNVQ3OiodrRI/Ehyvy9C94rwKDI40Kk5ZWcPo7cTI68IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings/-/rtc-ffi-bindings-0.12.73.tgz",
+      "integrity": "sha512-ZxkCQlsfTG7Eqi6KBXulEWJBUxeRVRYqCc795CsmKsGfqmBX5gE5CnTiynN8fFdzSGwApaVogeGSB6JszCf/Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@livekit/rtc-ffi-bindings-darwin-arm64": "0.12.73",
+        "@livekit/rtc-ffi-bindings-darwin-x64": "0.12.73",
+        "@livekit/rtc-ffi-bindings-linux-arm64-gnu": "0.12.73",
+        "@livekit/rtc-ffi-bindings-linux-x64-gnu": "0.12.73",
+        "@livekit/rtc-ffi-bindings-win32-x64-msvc": "0.12.73"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings-darwin-arm64": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-darwin-arm64/-/rtc-ffi-bindings-darwin-arm64-0.12.73.tgz",
+      "integrity": "sha512-gIGftVyO1Jl266AZPRzoL6dxck969dmIiaut3+D1aCZRkDb/gLz98BEGRfOSU3X0LS4QBkmiaYWsjN9ot/zmwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings-darwin-x64": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-darwin-x64/-/rtc-ffi-bindings-darwin-x64-0.12.73.tgz",
+      "integrity": "sha512-esPwYCbUnDD/KxBo0YU8awTFglRG7SvOT/sfiP19KChS5SH8TgXc7JwfSvnjRx1PndUqHFzQAbQDcYaeL9PFTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings-linux-arm64-gnu": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-linux-arm64-gnu/-/rtc-ffi-bindings-linux-arm64-gnu-0.12.73.tgz",
+      "integrity": "sha512-2YBatXjuaumnaNVqRC63flX5XZTvHcQWRsABw6e2yp+Hlxl3ocjVVyk5PrAsRzCdeyxbHLduqV9ctqGbpTA27Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings-linux-x64-gnu": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-linux-x64-gnu/-/rtc-ffi-bindings-linux-x64-gnu-0.12.73.tgz",
+      "integrity": "sha512-BrP3IyNkcjldeO+SbnF0hX2mipst8aHiBIiGJcQCd8HEjsaabfkYk4Y5uoNsTVMrUSyrNrJte2itAhuxP9FCSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-ffi-bindings-win32-x64-msvc": {
+      "version": "0.12.73",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-ffi-bindings-win32-x64-msvc/-/rtc-ffi-bindings-win32-x64-msvc-0.12.73.tgz",
+      "integrity": "sha512-2RnKXMTnNfvjJ3kbuhE1jqFNAQNmqSrxy3GlEnByY61tbtY14QPFn8X/0lh+Mjst8pZdfxkXvtbRyPt5KYHvMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-node": {
+      "version": "0.13.33",
+      "resolved": "https://registry.npmjs.org/@livekit/rtc-node/-/rtc-node-0.13.33.tgz",
+      "integrity": "sha512-NL9CxiscU4uL4+r2Ym675j5nIOw3XOy1YXiYH4oA9RftZTFFsU4+nvuvqYDWC9JWsOFFoin4hNdmqrDiRnvSuA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@datastructures-js/deque": "1.0.8",
+        "@livekit/mutex": "^1.0.0",
+        "@livekit/rtc-ffi-bindings": "0.12.73",
+        "@livekit/typed-emitter": "^3.0.0",
+        "pino": "^9.0.0",
+        "pino-pretty": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/fast-copy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+      "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@livekit/rtc-node/node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@livekit/rtc-node/node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@livekit/rtc-node/node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@livekit/rtc-node/node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@livekit/rtc-node/node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/@livekit/throws-transformer": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@livekit/throws-transformer/-/throws-transformer-0.1.8.tgz",
+      "integrity": "sha512-AaSwQfIaG6YArKOCO+5/DgI8HfL19oHdrkyI0LJJVCqGeZXzPsZIO/Nm/SKUHbT1ERGhF5c34X8CcVWeOePpIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "glob": "^13.0.0"
+      },
+      "bin": {
+        "throws-check": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@livekit/typed-emitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@livekit/typed-emitter/-/typed-emitter-3.0.0.tgz",
+      "integrity": "sha512-9bl0k4MgBPZu3Qu3R3xy12rmbW17e3bE9yf4YY85gJIQ3ezLEj/uzpKHWBsLaDoL5Mozz8QCgggwIBudYQWeQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -646,6 +1775,478 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.220.0.tgz",
+      "integrity": "sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/sdk-logs": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.220.0.tgz",
+      "integrity": "sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pino": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.66.0.tgz",
+      "integrity": "sha512-RMAtAYuyouaMbHkQG8E97nJfwHftxmCbOURdD3n5s2Yd5zctLNudXB5hAfW18lsfUbePwQCND6QUXZixFN92Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.220.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/semantic-conventions": "^1.41.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -655,6 +2256,14 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -1313,6 +2922,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/pidusage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pidusage/-/pidusage-2.0.5.tgz",
+      "integrity": "sha512-MIiyZI4/MK9UGUXWt0jJcCZhVw7YdhBuTOuqP/BjuLDLZ2PmmViMIQgZiWxtaMicQfAz/kMrZ5T7PKxFSkTeUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -1426,6 +3042,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1483,6 +3112,98 @@
         "node": ">=12"
       }
     },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -1509,6 +3230,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1533,6 +3268,33 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -1569,6 +3331,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1587,6 +3359,16 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1596,6 +3378,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1607,12 +3396,86 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -1666,6 +3529,26 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1675,6 +3558,30 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1706,6 +3613,38 @@
         "rollup": "^4.34.8"
       }
     },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1719,6 +3658,198 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/heap-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
+      "integrity": "sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -1752,6 +3883,16 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.15.0.tgz",
+      "integrity": "sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/lightningcss": {
@@ -2035,6 +4176,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/livekit-server-sdk": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/livekit-server-sdk/-/livekit-server-sdk-2.17.0.tgz",
+      "integrity": "sha512-GWNEQrUD13UwZNrmosyTVFPgeBvSU2lFKGxdA4DaUI5F4sMb1cGeep/PPEE9vvRNELJYpxWS0ImS4gQmovKUDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
+        "@livekit/protocol": "^1.48.0",
+        "jose": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -2045,6 +4201,16 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2053,6 +4219,75 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mlly": {
@@ -2067,6 +4302,13 @@
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2106,6 +4348,25 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2128,6 +4389,86 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -2156,6 +4497,106 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pidusage": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-4.0.1.tgz",
+      "integrity": "sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
+      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.2",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -2251,6 +4692,41 @@
         }
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -2260,6 +4736,23 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/readdirp": {
@@ -2274,6 +4767,30 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2365,6 +4882,37 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -2372,12 +4920,85 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -2399,6 +5020,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2412,6 +5043,29 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2471,6 +5125,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/throttleit": {
@@ -2814,6 +5478,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2829,6 +5506,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/zod": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floe-guard",
-  "version": "0.11.0",
-  "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware.",
+  "version": "0.12.0",
+  "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",
   "keywords": [
@@ -26,6 +26,21 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./adapters/livekit": {
+      "types": "./dist/adapters/livekit.d.ts",
+      "import": "./dist/adapters/livekit.js",
+      "require": "./dist/adapters/livekit.cjs"
+    },
+    "./adapters/vapi": {
+      "types": "./dist/adapters/vapi.d.ts",
+      "import": "./dist/adapters/vapi.js",
+      "require": "./dist/adapters/vapi.cjs"
+    },
+    "./adapters/retell": {
+      "types": "./dist/adapters/retell.d.ts",
+      "import": "./dist/adapters/retell.js",
+      "require": "./dist/adapters/retell.cjs"
     }
   },
   "main": "./dist/index.cjs",
@@ -44,9 +59,16 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "ai": ">=4.0.0 <6.0.0"
+    "ai": ">=4.0.0 <6.0.0",
+    "@livekit/agents": ">=1.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@livekit/agents": {
+      "optional": true
+    }
   },
   "devDependencies": {
+    "@livekit/agents": "^1.6.3",
     "ai": "^4.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",

--- a/js/package.json
+++ b/js/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "ai": ">=4.0.0 <6.0.0",
-    "@livekit/agents": ">=1.5.0"
+    "@livekit/agents": ">=1.5.0 <2.0.0"
   },
   "peerDependenciesMeta": {
     "@livekit/agents": {

--- a/js/src/adapters/livekit.ts
+++ b/js/src/adapters/livekit.ts
@@ -1,0 +1,376 @@
+/**
+ * LiveKit Agents adapter (optional peer: `npm i @livekit/agents`).
+ *
+ * Like the Python `LiveKitBudgetGuard`, a LiveKit `AgentSession` (STT -> LLM ->
+ * TTS) has no single call site to wrap: turns fire for the life of a call. The
+ * two enforcement points are the agent's LLM turn hook (before the LLM call, so a
+ * turn is admitted or blocked before its TTS/audio spend piles on) and the
+ * session's usage/metrics event (real usage, after). {@link LiveKitBudgetGuard}
+ * holds the reservation state across both.
+ *
+ *     import { BudgetGuard } from "floe-guard";
+ *     import { LiveKitBudgetGuard } from "floe-guard/adapters/livekit";
+ *
+ *     const guard = new BudgetGuard(1.0, {
+ *       priceOverrides: {
+ *         "gemini-2.0-flash": { inputCostPerToken: 0.30e-6, outputCostPerToken: 2.5e-6 },
+ *       },
+ *     });
+ *     const budget = new LiveKitBudgetGuard(guard, { model: "gemini-2.0-flash" });
+ *
+ *     const session = new AgentSession({ ... });
+ *     budget.attach(session, agent);   // wire reserve / settle / release
+ *     await session.start({ agent, room });
+ *
+ * ## Why agents-js, not a blind port of the Python adapter
+ *
+ * The Node SDK (`@livekit/agents`) differs from Python and was verified against
+ * the installed types (v1.6.x):
+ *
+ * - **LLM turn hook.** Python wraps `agent.llm_node`, an async generator. The JS
+ *   analog is `Agent.llmNode(chatCtx, toolCtx, modelSettings):
+ *   Promise<ReadableStream<ChatChunk | string | FlushSentinel> | null>` — it
+ *   returns a web `ReadableStream`, not a generator. We reserve BEFORE calling the
+ *   original, then wrap the returned stream so a consumer cancel (interrupt)
+ *   releases the hold — the JS twin of Python's generator `except BaseException`.
+ *
+ * - **Settlement event.** Session-level `metrics_collected` is *deprecated in
+ *   Python* (→ `session_usage_updated` + `ChatMessage.metrics`). In **agents-js**
+ *   it is **not** deprecated: `AgentSession` (a `TypedEmitter<AgentSessionCallbacks>`)
+ *   still emits `metrics_collected` with a `MetricsCollectedEvent { metrics:
+ *   AgentMetrics }`, and `AgentMetrics` is a discriminated union keyed by `type`
+ *   (`'llm_metrics' | 'stt_metrics' | 'tts_metrics' | ...`) — not the `isinstance`
+ *   classes Python uses. We settle on that live event.
+ *
+ * LiveKit's `LLMMetrics` does not name the served model in a way we rely on, so
+ * cost is settled against the `model` passed here (as in Python). STT/TTS spend —
+ * often a voice agent's larger bill — is metered whenever you name the vendor:
+ * pass `sttModel` / `ttsModel` and the rate comes from the bundled voice cost map,
+ * or pass a per-unit override (`sttUsdPerSecond` / `ttsUsdPer1kChars`) which wins
+ * over the map. Telephony (per-minute) is metered via {@link meterTelephony},
+ * since LiveKit emits no telephony metric. A leg with neither a vendor nor an
+ * override is left un-metered (the token-only contract); a vendor the voice map
+ * cannot price fails closed ({@link UnpriceableVoiceError}).
+ *
+ * Scope is strictly **pre-turn / pre-call admission plus per-turn settlement**.
+ * There is no mid-call intervention: an admitted turn runs to completion; nothing
+ * here cuts a turn off partway.
+ */
+
+import { BudgetExceeded } from "../errors.js";
+import { preCall } from "../gates.js";
+import type { BudgetGuard, ReservationHandle } from "../guard.js";
+import { priceVoiceLeg } from "../voice-pricing.js";
+
+/**
+ * The `LLMMetrics` fields we settle against (agents-js discriminated-union member
+ * `type: 'llm_metrics'`). Typed structurally so the adapter carries no hard
+ * dependency on `@livekit/agents` — the same idiom the Vercel-AI middleware uses
+ * for `ai`. The test file pins these shapes against the real exported types.
+ */
+interface LlmMetricsLike {
+  readonly type: "llm_metrics";
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+}
+
+/** `STTMetrics` fields we meter against (`type: 'stt_metrics'`). Duration is ms. */
+interface SttMetricsLike {
+  readonly type: "stt_metrics";
+  /** Duration of the pushed audio in **milliseconds** (LiveKit's `audioDurationMs`). */
+  readonly audioDurationMs: number;
+}
+
+/** `TTSMetrics` fields we meter against (`type: 'tts_metrics'`). */
+interface TtsMetricsLike {
+  readonly type: "tts_metrics";
+  readonly charactersCount: number;
+}
+
+/** Any member of LiveKit's `AgentMetrics` union — we branch on `type`. */
+type AgentMetricsLike =
+  | LlmMetricsLike
+  | SttMetricsLike
+  | TtsMetricsLike
+  | { readonly type: string };
+
+/** The `MetricsCollectedEvent` payload (`{ metrics: AgentMetrics }`). */
+interface MetricsCollectedEventLike {
+  readonly metrics: AgentMetricsLike;
+}
+
+/**
+ * The slice of `AgentSession` we wire onto — its typed event emitter. Structural,
+ * so a stubbed session in a test (or the real `AgentSession`) both satisfy it.
+ */
+export interface LiveKitSessionLike {
+  on(event: "metrics_collected", listener: (ev: MetricsCollectedEventLike) => void): unknown;
+  on(event: "close", listener: (ev: unknown) => void): unknown;
+}
+
+/** A web `ReadableStream` (Node 18+ global), as returned by `Agent.llmNode`. */
+type LlmNodeStream = ReadableStream<unknown>;
+
+/**
+ * The slice of `Agent` we wrap — its `llmNode` turn hook. The real signature is
+ * `llmNode(chatCtx, toolCtx, modelSettings): Promise<ReadableStream<...> | null>`;
+ * we forward the arguments unchanged, so an upstream signature change can't break
+ * the wrapper.
+ */
+export interface LiveKitAgentLike {
+  llmNode: (...args: unknown[]) => Promise<LlmNodeStream | null>;
+}
+
+/** Callback invoked when a turn is blocked, so the bot can speak a wrap-up line. */
+export type OnBudgetExceeded = (error: BudgetExceeded) => Promise<void> | void;
+
+export interface LiveKitBudgetGuardOptions {
+  /**
+   * Model id to settle LLM cost against (LiveKit's `LLMMetrics` carries no model
+   * name we rely on). Must be priceable via the bundled cost map or the guard's
+   * `priceOverrides`.
+   */
+  model: string;
+  /**
+   * Invoked with the {@link BudgetExceeded} when a turn is blocked, so a bot can
+   * speak a graceful "wrapping up" line before the turn ends silently (the LLM
+   * hook returns no stream). If omitted, the {@link BudgetExceeded} propagates out
+   * of `llmNode`.
+   */
+  onBudgetExceeded?: OnBudgetExceeded;
+  /** Voice-map vendor key for the STT leg (e.g. `"deepgram-nova-3"`). */
+  sttModel?: string;
+  /** Voice-map vendor key for the TTS leg (e.g. `"elevenlabs-flash-v2.5"`). */
+  ttsModel?: string;
+  /** Voice-map vendor key for the telephony leg (e.g. `"twilio-us-inbound-local"`). */
+  telephony?: string;
+  /** Per-second STT override — wins over `sttModel`. Omit both to leave STT un-metered. */
+  sttUsdPerSecond?: number;
+  /** Per-1k-chars TTS override — wins over `ttsModel`. Omit both to leave TTS un-metered. */
+  ttsUsdPer1kChars?: number;
+  /** Per-minute telephony override — wins over `telephony`. */
+  telephonyUsdPerMinute?: number;
+}
+
+/**
+ * One `llmNode` invocation awaiting (or already past) its `LLMMetrics` event.
+ *
+ * `open` means the USD amount is still held on the {@link BudgetGuard}. Early
+ * release (next turn, interrupt, close) clears the guard hold but leaves the slot
+ * in the FIFO queue so a delayed metrics event settles against this turn's slot
+ * (with `amount` 0) instead of stealing a later turn's hold.
+ */
+interface TurnSlot {
+  amount: ReservationHandle;
+  open: boolean;
+}
+
+/**
+ * Enforce a {@link BudgetGuard} ceiling on a LiveKit `AgentSession`, one turn at
+ * a time: reserve before the LLM turn, settle on real usage, release on interrupt.
+ */
+export class LiveKitBudgetGuard {
+  private readonly guard: BudgetGuard;
+  private readonly model: string;
+  private readonly onBudgetExceeded?: OnBudgetExceeded;
+  private readonly sttModel?: string;
+  private readonly ttsModel?: string;
+  private readonly telephony?: string;
+  private readonly sttUsdPerSecond?: number;
+  private readonly ttsUsdPer1kChars?: number;
+  private readonly telephonyUsdPerMinute?: number;
+
+  private pending = false;
+  private active: TurnSlot | null = null;
+  /** FIFO of turns that may still emit `LLMMetrics` (including early-released). */
+  private readonly slots: TurnSlot[] = [];
+
+  constructor(guard: BudgetGuard, options: LiveKitBudgetGuardOptions) {
+    this.guard = guard;
+    this.model = options.model;
+    this.onBudgetExceeded = options.onBudgetExceeded;
+    this.sttModel = options.sttModel;
+    this.ttsModel = options.ttsModel;
+    this.telephony = options.telephony;
+    this.sttUsdPerSecond = options.sttUsdPerSecond;
+    this.ttsUsdPer1kChars = options.ttsUsdPer1kChars;
+    this.telephonyUsdPerMinute = options.telephonyUsdPerMinute;
+    // Bound once so the emitter calls them with the right `this`.
+    this.onMetrics = this.onMetrics.bind(this);
+    this.onClose = this.onClose.bind(this);
+  }
+
+  /**
+   * Wire reserve (`agent.llmNode`), settle/meter (`metrics_collected`) and release
+   * (`close`) onto a session + agent pair. Reserving before the LLM turn is what
+   * blocks a turn before its TTS/audio spend piles on.
+   */
+  attach(session: LiveKitSessionLike, agent: LiveKitAgentLike): void {
+    // Bind so the original keeps its `this` when we call it from the wrapper.
+    const origLlmNode = agent.llmNode.bind(agent);
+
+    const guardedLlmNode = async (...args: unknown[]): Promise<LlmNodeStream | null> => {
+      // A previous turn that never settled still holds its reservation — release
+      // the guard hold before opening this one, but keep a queue slot so delayed
+      // metrics cannot steal this turn's hold.
+      if (this.pending) this.earlyReleaseActive();
+
+      let handle: ReservationHandle;
+      try {
+        handle = this.guard.reserve(); // throws BudgetExceeded before the turn runs
+      } catch (err) {
+        this.clearActive();
+        if (err instanceof BudgetExceeded && this.onBudgetExceeded !== undefined) {
+          // Let the bot speak a wrap-up line; the turn ends with no stream.
+          await this.onBudgetExceeded(err);
+          return null;
+        }
+        throw err;
+      }
+
+      const slot: TurnSlot = { amount: handle, open: true };
+      this.slots.push(slot);
+      this.active = slot;
+      this.pending = true;
+
+      let stream: LlmNodeStream | null;
+      try {
+        stream = await origLlmNode(...args);
+      } catch (err) {
+        // Release only if this invocation still owns the open hold — a later turn
+        // may already have early-released ours and reserved its own.
+        if (this.active === slot) this.earlyReleaseActive();
+        throw err;
+      }
+
+      // No stream to wrap (realtime / text-only turn): leave the slot open for the
+      // metrics event to settle against.
+      if (stream === null) return null;
+      return this.guardStream(stream, slot);
+    };
+
+    agent.llmNode = guardedLlmNode;
+    session.on("metrics_collected", this.onMetrics);
+    session.on("close", this.onClose);
+  }
+
+  /**
+   * Pre-call admission decision (`true` = admit, `false` = reject), delegating to
+   * {@link preCall} on the wrapped guard's remaining budget. A coarse,
+   * non-binding preflight — the binding hard-stop is the per-turn reserve wired by
+   * {@link attach}. Pass `estimatedCallUsd` (e.g. `$/min × expected minutes`) to
+   * reject earlier, when the remaining budget can't cover the call.
+   */
+  admitCall(options: { estimatedCallUsd?: number } = {}): boolean {
+    return preCall(this.guard, options);
+  }
+
+  /**
+   * Accrue telephony spend for `minutes` of call time (per-minute).
+   *
+   * LiveKit emits no telephony metric, so the transport/caller drives this — call
+   * it as the call accrues minutes, or once with the final duration. This is
+   * per-minute accrual, not live line-cutting: the guard meters the leg, it does
+   * not cut the phone line mid-call. Priced from the voice map when `telephony` is
+   * set, or the `telephonyUsdPerMinute` override; returns `null` (no-op) when the
+   * leg is unconfigured, and fails closed on a vendor the voice map cannot price.
+   * Returns the USD accrued, if any.
+   */
+  meterTelephony(minutes: number): number | null {
+    const cost = priceVoiceLeg("telephony", minutes, {
+      model: this.telephony,
+      override: this.telephonyUsdPerMinute,
+    });
+    if (cost !== null) this.guard.recordTool("livekit-telephony", cost);
+    return cost;
+  }
+
+  /**
+   * Wrap the `llmNode` stream so a consumer cancel (interrupt) releases this turn's
+   * hold — the JS twin of Python's generator `except BaseException`. Chunks pass
+   * through untouched; a clean end leaves the hold for the metrics event to settle.
+   */
+  private guardStream(stream: LlmNodeStream, slot: TurnSlot): LlmNodeStream {
+    const release = (): void => {
+      // Release only if this turn still owns the open hold — a metrics event may
+      // already have settled it, or a later turn early-released it.
+      if (this.active === slot) this.earlyReleaseActive();
+    };
+    return stream.pipeThrough(
+      new TransformStream<unknown, unknown>({
+        transform(chunk, controller) {
+          controller.enqueue(chunk); // passthrough; we only need the lifecycle hooks
+        },
+        // Clean completion: do NOT release — leave the hold for the metrics event
+        // to settle against (mirrors Python's generator finishing normally).
+        flush() {},
+        // Interrupt / downstream cancel: free the held budget. `cancel` is valid
+        // per the Streams spec and supported in Node 18+, but TS's Transformer lib
+        // type lags and omits it — cast to keep the type check (as the middleware does).
+        cancel() {
+          release();
+        },
+      } as Transformer<unknown, unknown>),
+    );
+  }
+
+  private onMetrics(ev: MetricsCollectedEventLike): void {
+    const m = ev.metrics;
+    if (m.type === "llm_metrics") {
+      const metrics = m as LlmMetricsLike;
+      // Pop the oldest turn slot. Early-released turns contribute 0 so a delayed
+      // metrics event meters usage without consuming a later hold. An empty queue
+      // (reserve hook bypassed) settles as a plain record().
+      let reserved: ReservationHandle = 0;
+      const slot = this.slots.shift();
+      if (slot !== undefined) {
+        if (slot.open) {
+          reserved = slot.amount;
+          slot.open = false;
+        }
+        if (this.active === slot) this.clearActive();
+      }
+      this.guard.settle(this.model, metrics.promptTokens, metrics.completionTokens, { reserved });
+    } else if (m.type === "stt_metrics") {
+      // audioDurationMs is milliseconds; the STT leg is priced per second.
+      const seconds = (m as SttMetricsLike).audioDurationMs / 1000;
+      const cost = priceVoiceLeg("stt", seconds, {
+        model: this.sttModel,
+        override: this.sttUsdPerSecond,
+      });
+      if (cost !== null) this.guard.recordTool("livekit-stt", cost);
+    } else if (m.type === "tts_metrics") {
+      const cost = priceVoiceLeg("tts", (m as TtsMetricsLike).charactersCount, {
+        model: this.ttsModel,
+        override: this.ttsUsdPer1kChars,
+      });
+      if (cost !== null) this.guard.recordTool("livekit-tts", cost);
+    }
+    // Other metric kinds (VAD, EOU, realtime, ...) carry no billable leg here.
+  }
+
+  private onClose(): void {
+    // Session torn down with a turn still reserved — release it. Drop any leftover
+    // slots so a post-close metrics event cannot touch a stale hold.
+    if (this.pending) this.earlyReleaseActive();
+    this.slots.length = 0;
+  }
+
+  private clearActive(): void {
+    this.active = null;
+    this.pending = false;
+  }
+
+  /** Drop the open guard hold; leave a zeroed queue slot for delayed metrics. */
+  private earlyReleaseActive(): void {
+    const slot = this.active;
+    if (slot === null || !slot.open) {
+      this.clearActive();
+      return;
+    }
+    this.guard.release(slot.amount);
+    slot.open = false;
+    slot.amount = 0;
+    this.clearActive();
+  }
+}

--- a/js/src/adapters/livekit.ts
+++ b/js/src/adapters/livekit.ts
@@ -181,9 +181,18 @@ export class LiveKitBudgetGuard {
   private readonly telephonyUsdPerMinute?: number;
 
   private pending = false;
+  private attached = false;
   private active: TurnSlot | null = null;
   /** FIFO of turns that may still emit `LLMMetrics` (including early-released). */
   private readonly slots: TurnSlot[] = [];
+  /**
+   * Cap on the FIFO. A realtime / text-only turn returns no stream and emits
+   * `realtime_metrics` (not `llm_metrics`), so its slot never settles and would
+   * linger; on a long call the queue would grow without bound. Past this many
+   * slots we drop the oldest (releasing an open hold), bounding memory and the
+   * settlement drift a stale slot introduces.
+   */
+  private static readonly MAX_SLOTS = 64;
 
   constructor(guard: BudgetGuard, options: LiveKitBudgetGuardOptions) {
     this.guard = guard;
@@ -198,6 +207,12 @@ export class LiveKitBudgetGuard {
     // Bound once so the emitter calls them with the right `this`.
     this.onMetrics = this.onMetrics.bind(this);
     this.onClose = this.onClose.bind(this);
+    // Fail fast: a misconfigured voice vendor throws UnpriceableVoiceError at
+    // construction, not mid-call. quantity 0 resolves the rate (priced at $0)
+    // without metering; an unconfigured leg is a no-op (null).
+    priceVoiceLeg("stt", 0, { model: this.sttModel, override: this.sttUsdPerSecond });
+    priceVoiceLeg("tts", 0, { model: this.ttsModel, override: this.ttsUsdPer1kChars });
+    priceVoiceLeg("telephony", 0, { model: this.telephony, override: this.telephonyUsdPerMinute });
   }
 
   /**
@@ -206,6 +221,17 @@ export class LiveKitBudgetGuard {
    * blocks a turn before its TTS/audio spend piles on.
    */
   attach(session: LiveKitSessionLike, agent: LiveKitAgentLike): void {
+    // One guard binds one session/agent pair. A second attach() would wrap the
+    // wrapper and register duplicate listeners — each turn would then reserve and
+    // settle twice, double-counting spend. Reject the repeat (a reconnect / retried
+    // setup should create a fresh LiveKitBudgetGuard).
+    if (this.attached) {
+      throw new Error(
+        "LiveKitBudgetGuard.attach() called twice — a guard instance binds one " +
+          "session/agent pair. Create a new LiveKitBudgetGuard to re-attach.",
+      );
+    }
+    this.attached = true;
     // Bind so the original keeps its `this` when we call it from the wrapper.
     const origLlmNode = agent.llmNode.bind(agent);
 
@@ -232,6 +258,7 @@ export class LiveKitBudgetGuard {
       this.slots.push(slot);
       this.active = slot;
       this.pending = true;
+      this.trimSlots(slot);
 
       let stream: LlmNodeStream | null;
       try {
@@ -304,9 +331,11 @@ export class LiveKitBudgetGuard {
         // Clean completion: do NOT release — leave the hold for the metrics event
         // to settle against (mirrors Python's generator finishing normally).
         flush() {},
-        // Interrupt / downstream cancel: free the held budget. `cancel` is valid
-        // per the Streams spec and supported in Node 18+, but TS's Transformer lib
-        // type lags and omits it — cast to keep the type check (as the middleware does).
+        // Interrupt / downstream cancel: free the held budget. `Transformer.cancel`
+        // is honored on Node >=20.14; Node 18 does NOT invoke it — there the hold is
+        // released at the next turn's early-release or on session close instead
+        // (delayed, never leaked). TS's Transformer lib type lags and omits cancel —
+        // cast to keep the type check (as the Vercel-AI middleware does).
         cancel() {
           release();
         },
@@ -372,5 +401,17 @@ export class LiveKitBudgetGuard {
     slot.open = false;
     slot.amount = 0;
     this.clearActive();
+  }
+
+  /**
+   * Bound the FIFO: drop oldest slots past {@link MAX_SLOTS}, releasing an open
+   * hold as it goes. Never drops the just-reserved active slot. Prevents a long
+   * call from accumulating slots for turns that never emit `llm_metrics`.
+   */
+  private trimSlots(active: TurnSlot): void {
+    while (this.slots.length > LiveKitBudgetGuard.MAX_SLOTS && this.slots[0] !== active) {
+      const stale = this.slots.shift();
+      if (stale !== undefined && stale.open) this.guard.release(stale.amount);
+    }
   }
 }

--- a/js/src/adapters/retell.ts
+++ b/js/src/adapters/retell.ts
@@ -1,0 +1,354 @@
+/**
+ * Retell custom-LLM WebSocket adapter (optional peer: the `ws` server your custom
+ * LLM already runs — this adapter never opens or hard-depends on it).
+ *
+ * Retell's custom LLM runs over a WebSocket (docs.retellai.com/api-references/
+ * llm-websocket). Retell sends interaction events to your server; the billable one
+ * is **`response_required`** (an auto-incrementing `response_id` plus the running
+ * `transcript`), and its twin **`reminder_required`**. Your server streams back
+ * **`response`** events — many partials per turn — ending with `content_complete:
+ * true`. A NEW `response_required` with a higher `response_id` means the caller
+ * barged in: it **interrupts** the turn in flight, which never reaches
+ * `content_complete`.
+ *
+ * Like the LiveKit adapter, a Retell call has no single call site to wrap: turns
+ * fire for the life of the socket. The two enforcement points are the arrival of a
+ * `response_required` (before the LLM call, so a turn is admitted or blocked before
+ * its TTS/telephony spend piles on) and the turn's real token usage (after
+ * `content_complete`). {@link RetellBudgetGuard} holds the reservation across both,
+ * keyed by `response_id`, and releases it when a newer turn interrupts.
+ *
+ *     import { BudgetGuard } from "floe-guard";
+ *     import { RetellBudgetGuard } from "floe-guard/adapters/retell";
+ *
+ *     const guard = new BudgetGuard(1.0, {
+ *       priceOverrides: {
+ *         "gpt-4o-mini": { inputCostPerToken: 0.15e-6, outputCostPerToken: 0.6e-6 },
+ *       },
+ *     });
+ *     const budget = new RetellBudgetGuard(guard, {
+ *       model: "gpt-4o-mini",
+ *       sttModel: "deepgram-nova-3",
+ *       ttsModel: "elevenlabs-flash-v2.5",
+ *       telephony: "twilio-us-inbound-local",
+ *     });
+ *
+ *     // In your custom-LLM WS message handler:
+ *     ws.on("message", async (raw) => {
+ *       const event = JSON.parse(raw);
+ *       if (event.interaction_type === "response_required" ||
+ *           event.interaction_type === "reminder_required") {
+ *         const turn = budget.beginTurn(event);        // reserve before the LLM call
+ *         if (!turn.admitted) {                         // budget exhausted
+ *           ws.send(JSON.stringify(
+ *             budget.response(event.response_id, "I'm out of budget — wrapping up.",
+ *                             { complete: true, endCall: true })));
+ *           return;
+ *         }
+ *         const { text, usage } = await callYourLlm(event.transcript); // your LLM
+ *         ws.send(JSON.stringify(budget.response(event.response_id, text, { complete: true })));
+ *         budget.settleTurn(event.response_id, usage);  // settle real token usage
+ *       }
+ *     });
+ *
+ * ## Why a WebSocket adapter, not a request wrapper
+ *
+ * The custom LLM sees only the **LLM leg** (the tokens behind each `response`). STT,
+ * TTS and telephony are billed by Retell/the carrier and never cross this socket, so
+ * they are metered **explicitly** — call {@link RetellBudgetGuard.meterStt} /
+ * {@link RetellBudgetGuard.meterTts} / {@link RetellBudgetGuard.meterTelephony} from
+ * wherever those durations are known (webhook, call-ended event). Each is priced
+ * from the bundled voice cost map when you name the vendor, or a per-unit override
+ * which wins over the map; a leg with neither is left un-metered (the token-only
+ * contract), and a named vendor the map cannot price fails closed
+ * ({@link UnpriceableVoiceError}).
+ *
+ * Scope is strictly **pre-turn / pre-call admission plus per-turn settlement**.
+ * There is no mid-call intervention: an admitted turn runs to `content_complete`;
+ * nothing here cuts a turn off partway. The only release is the interrupt Retell
+ * itself signals (a newer `response_id`) or an explicit {@link RetellBudgetGuard.close}
+ * on call teardown.
+ */
+
+import { BudgetExceeded } from "../errors.js";
+import * as gates from "../gates.js";
+import type { BudgetGuard, ReservationHandle } from "../guard.js";
+import { priceVoiceLeg } from "../voice-pricing.js";
+
+/** One entry of a Retell `transcript` (loosely typed — we never read into it). */
+export interface RetellUtterance {
+  readonly role: "agent" | "user";
+  readonly content: string;
+}
+
+/**
+ * The Retell interaction events that require a turn. `response_required` is a real
+ * user utterance; `reminder_required` fires after silence — both carry an
+ * auto-incrementing `response_id` and expect a `response` stream in reply. Typed
+ * structurally so a parsed WS message satisfies it with no Retell SDK dependency.
+ */
+export interface RetellResponseRequiredEvent {
+  readonly interaction_type: "response_required" | "reminder_required";
+  /** Auto-incrementing turn id; a higher value than the open turn means an interrupt. */
+  readonly response_id: number;
+  readonly transcript?: readonly RetellUtterance[];
+}
+
+/**
+ * A `response` event to stream back to Retell. Emit several partials per turn
+ * (`content_complete: false`), then a final one with `content_complete: true`.
+ * Build them with {@link RetellBudgetGuard.response}.
+ */
+export interface RetellResponseEvent {
+  readonly response_type: "response";
+  readonly response_id: number;
+  readonly content: string;
+  readonly content_complete: boolean;
+  readonly end_call?: boolean;
+}
+
+/** Real token usage for a settled turn — the LLM leg the socket sees. */
+export interface RetellTokenUsage {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+}
+
+/**
+ * The decision {@link RetellBudgetGuard.beginTurn} returns. `admitted: true` means
+ * the turn's reservation is held — run the LLM and settle it. `admitted: false`
+ * means the budget is spent: send a wrap-up `response` (with `content_complete`) and
+ * do not call the LLM; `error` carries the {@link BudgetExceeded} for logging.
+ */
+export type RetellTurnDecision =
+  | { readonly admitted: true; readonly responseId: number }
+  | { readonly admitted: false; readonly responseId: number; readonly error: BudgetExceeded };
+
+export interface RetellBudgetGuardOptions {
+  /**
+   * Model id to settle LLM cost against (Retell's usage payload names no model we
+   * rely on). Must be priceable via the bundled cost map or the guard's
+   * `priceOverrides`.
+   */
+  model: string;
+  /** Voice-map vendor key for the STT leg (e.g. `"deepgram-nova-3"`). */
+  sttModel?: string;
+  /** Voice-map vendor key for the TTS leg (e.g. `"elevenlabs-flash-v2.5"`). */
+  ttsModel?: string;
+  /** Voice-map vendor key for the telephony leg (e.g. `"twilio-us-inbound-local"`). */
+  telephony?: string;
+  /** Per-second STT override — wins over `sttModel`. Omit both to leave STT un-metered. */
+  sttUsdPerSecond?: number;
+  /** Per-1k-chars TTS override — wins over `ttsModel`. Omit both to leave TTS un-metered. */
+  ttsUsdPer1kChars?: number;
+  /** Per-minute telephony override — wins over `telephony`. */
+  telephonyUsdPerMinute?: number;
+}
+
+/**
+ * One turn's reservation, keyed by `response_id`. `open` means the USD amount is
+ * still held on the {@link BudgetGuard}. A settle or an interrupt closes it.
+ */
+interface TurnSlot {
+  readonly responseId: number;
+  amount: ReservationHandle;
+  open: boolean;
+}
+
+/**
+ * Enforce a {@link BudgetGuard} ceiling on a Retell custom-LLM socket, one turn at
+ * a time: reserve when a `response_required` arrives, settle on real token usage
+ * after `content_complete`, release when a newer `response_id` interrupts.
+ */
+export class RetellBudgetGuard {
+  private readonly guard: BudgetGuard;
+  private readonly model: string;
+  private readonly sttModel?: string;
+  private readonly ttsModel?: string;
+  private readonly telephony?: string;
+  private readonly sttUsdPerSecond?: number;
+  private readonly ttsUsdPer1kChars?: number;
+  private readonly telephonyUsdPerMinute?: number;
+
+  /** Open (and just-settled) turns keyed by `response_id`. */
+  private readonly slots = new Map<number, TurnSlot>();
+  /** The most recently begun turn — the one a newer `response_required` interrupts. */
+  private activeResponseId: number | null = null;
+
+  constructor(guard: BudgetGuard, options: RetellBudgetGuardOptions) {
+    this.guard = guard;
+    this.model = options.model;
+    this.sttModel = options.sttModel;
+    this.ttsModel = options.ttsModel;
+    this.telephony = options.telephony;
+    this.sttUsdPerSecond = options.sttUsdPerSecond;
+    this.ttsUsdPer1kChars = options.ttsUsdPer1kChars;
+    this.telephonyUsdPerMinute = options.telephonyUsdPerMinute;
+  }
+
+  /**
+   * Reserve budget for a `response_required` / `reminder_required` turn before its
+   * LLM call runs. Returns an admit/block {@link RetellTurnDecision}.
+   *
+   * A newer `response_id` arriving while a prior turn is still open is Retell's
+   * interrupt signal — this releases that prior turn's hold before reserving the new
+   * one (its `content_complete` will never arrive). Reserving here is what blocks a
+   * turn before its downstream TTS/telephony spend piles on. Calling twice with the
+   * same still-open `response_id` is idempotent (no double hold).
+   */
+  beginTurn(event: RetellResponseRequiredEvent): RetellTurnDecision {
+    const responseId = event.response_id;
+
+    // Idempotent: this turn already holds a reservation.
+    const existing = this.slots.get(responseId);
+    if (existing !== undefined && existing.open) {
+      return { admitted: true, responseId };
+    }
+
+    // A newer turn interrupts the prior open turn — free its hold before opening this
+    // one. Its usage never settles (no content_complete); a stray late settle for it
+    // finds no open slot and records actual usage against a zero reservation.
+    this.releaseActive(responseId);
+
+    let handle: ReservationHandle;
+    try {
+      handle = this.guard.reserve(); // throws BudgetExceeded before the turn runs
+    } catch (err) {
+      if (err instanceof BudgetExceeded) {
+        return { admitted: false, responseId, error: err };
+      }
+      throw err;
+    }
+
+    this.slots.set(responseId, { responseId, amount: handle, open: true });
+    this.activeResponseId = responseId;
+    return { admitted: true, responseId };
+  }
+
+  /**
+   * Settle a turn's real token usage after its `content_complete`. Consumes the
+   * reservation opened by {@link beginTurn} for this `response_id`; a turn with no
+   * open slot (already interrupted, or a settle for an id never begun) records the
+   * usage against a zero reservation instead of stealing another turn's hold.
+   */
+  settleTurn(responseId: number, usage: RetellTokenUsage): void {
+    let reserved: ReservationHandle = 0;
+    const slot = this.slots.get(responseId);
+    if (slot !== undefined) {
+      if (slot.open) {
+        reserved = slot.amount;
+        slot.open = false;
+      }
+      this.slots.delete(responseId);
+    }
+    if (this.activeResponseId === responseId) this.activeResponseId = null;
+    this.guard.settle(this.model, usage.promptTokens, usage.completionTokens, { reserved });
+  }
+
+  /**
+   * Pre-call admission for Retell's inbound-call webhook, wrapping {@link gates.retell}.
+   * On budget exhaustion returns `{ call_inbound: { reject: true } }`; otherwise
+   * `{ call_inbound: {...} }` carrying any `admit` overrides (`dynamic_variables`,
+   * `metadata`, `override_agent_id`, …).
+   *
+   * A coarse, non-binding preflight — the binding hard-stop is the per-turn reserve
+   * in {@link beginTurn}. Pass `estimatedCallUsd` (e.g. `$/min × expected minutes`)
+   * to reject earlier, when the remaining budget can't cover the call.
+   */
+  admitCall(
+    options: { estimatedCallUsd?: number; admit?: Record<string, unknown> } = {},
+  ): { call_inbound: Record<string, unknown> } {
+    return gates.retell(this.guard, options);
+  }
+
+  /**
+   * Build a `response` event to stream back to Retell. Send partials with
+   * `complete: false`, then a final one with `complete: true`; settle the turn's
+   * token usage after that final one. Pass `endCall: true` to hang up (e.g. on a
+   * budget wrap-up line). A thin convenience — you may build the shape yourself.
+   */
+  response(
+    responseId: number,
+    content: string,
+    options: { complete?: boolean; endCall?: boolean } = {},
+  ): RetellResponseEvent {
+    return {
+      response_type: "response",
+      response_id: responseId,
+      content,
+      content_complete: options.complete ?? false,
+      ...(options.endCall ? { end_call: true } : {}),
+    };
+  }
+
+  /**
+   * Accrue STT spend for `seconds` of transcribed audio (per-second). The socket
+   * never sees the STT leg, so drive this from wherever the duration is known.
+   * Priced from the voice map when `sttModel` is set, or the `sttUsdPerSecond`
+   * override; returns `null` (no-op) when the leg is unconfigured, and fails closed
+   * on a vendor the map cannot price. Returns the USD accrued, if any.
+   */
+  meterStt(seconds: number): number | null {
+    const cost = priceVoiceLeg("stt", seconds, {
+      model: this.sttModel,
+      override: this.sttUsdPerSecond,
+    });
+    if (cost !== null) this.guard.recordTool("retell-stt", cost);
+    return cost;
+  }
+
+  /**
+   * Accrue TTS spend for `characters` of synthesized speech (per-1k-chars). Priced
+   * from the voice map when `ttsModel` is set, or the `ttsUsdPer1kChars` override;
+   * returns `null` when unconfigured, and fails closed on an unpriceable vendor.
+   */
+  meterTts(characters: number): number | null {
+    const cost = priceVoiceLeg("tts", characters, {
+      model: this.ttsModel,
+      override: this.ttsUsdPer1kChars,
+    });
+    if (cost !== null) this.guard.recordTool("retell-tts", cost);
+    return cost;
+  }
+
+  /**
+   * Accrue telephony spend for `minutes` of call time (per-minute). Per-minute
+   * accrual, not live line-cutting: the guard meters the leg, it does not cut the
+   * phone line mid-call. Priced from the voice map when `telephony` is set, or the
+   * `telephonyUsdPerMinute` override; returns `null` when unconfigured, and fails
+   * closed on an unpriceable vendor. Returns the USD accrued, if any.
+   */
+  meterTelephony(minutes: number): number | null {
+    const cost = priceVoiceLeg("telephony", minutes, {
+      model: this.telephony,
+      override: this.telephonyUsdPerMinute,
+    });
+    if (cost !== null) this.guard.recordTool("retell-telephony", cost);
+    return cost;
+  }
+
+  /**
+   * Release any still-open turn's reservation on call teardown (socket close, call
+   * ended). A turn that never reached `content_complete` would otherwise leak its
+   * hold and shrink `remainingUsd` permanently.
+   */
+  close(): void {
+    for (const slot of this.slots.values()) {
+      if (slot.open) this.guard.release(slot.amount);
+    }
+    this.slots.clear();
+    this.activeResponseId = null;
+  }
+
+  /** Release the active open turn's hold unless it is `exceptId` (the incoming turn). */
+  private releaseActive(exceptId: number): void {
+    const id = this.activeResponseId;
+    if (id === null || id === exceptId) return;
+    const slot = this.slots.get(id);
+    if (slot !== undefined && slot.open) {
+      this.guard.release(slot.amount);
+      slot.open = false;
+      this.slots.delete(id);
+    }
+    this.activeResponseId = null;
+  }
+}

--- a/js/src/adapters/vapi.ts
+++ b/js/src/adapters/vapi.ts
@@ -1,0 +1,378 @@
+/**
+ * Vapi custom-LLM adapter (no SDK dependency — typed structurally).
+ *
+ * Vapi's **custom-LLM** feature points Vapi's model leg at YOUR OpenAI-compatible
+ * `POST /chat/completions` endpoint (docs.vapi.ai/customization/custom-llm/using-your-server).
+ * Vapi sends an OpenAI-format request (`{ model, messages, temperature, tools?,
+ * stream }`); your endpoint proxies it to an upstream LLM and returns an
+ * OpenAI-compatible completion — a single JSON object, or an SSE stream of chunks.
+ *
+ * Like the LiveKit adapter, a Vapi call has no single wrap point that sees every
+ * cost: the custom-LLM proxy only sees the **model leg**. So this adapter has three
+ * jobs, and only the first is automatic:
+ *
+ *   1. **Guard the model turn** — {@link VapiBudgetGuard.guardCompletion} (JSON)
+ *      and {@link VapiBudgetGuard.guardStream} (SSE) reserve the estimated cost
+ *      BEFORE the upstream call, meter the **real** `usage` after, and release the
+ *      hold on error/abort. Reserving first is what refuses a turn before its spend
+ *      lands: an over-budget turn throws {@link BudgetExceeded} instead of proxying.
+ *   2. **Admit the call** — {@link VapiBudgetGuard.assistantRequest} answers Vapi's
+ *      `assistant-request` webhook from the remaining budget (exhausted → a spoken
+ *      error; else hand back `assistant`/`assistantId`), delegating to {@link gates.vapi}.
+ *   3. **Meter the other legs** — the proxy never sees STT/TTS/telephony, so
+ *      {@link VapiBudgetGuard.meterStt} / {@link VapiBudgetGuard.meterTts} /
+ *      {@link VapiBudgetGuard.meterTelephony} accrue them explicitly (the Vapi twin
+ *      of LiveKit's `.meterTelephony`), priced from the bundled voice cost map or a
+ *      per-unit override.
+ *
+ *     import { BudgetGuard } from "floe-guard";
+ *     import { VapiBudgetGuard } from "floe-guard/adapters/vapi";
+ *
+ *     const guard = new BudgetGuard(1.0);
+ *     const budget = new VapiBudgetGuard(guard, {
+ *       sttModel: "deepgram-nova-3",
+ *       ttsModel: "elevenlabs-flash-v2.5",
+ *       telephony: "twilio-us-inbound-local",
+ *     });
+ *
+ *     // POST /chat/completions — the custom-LLM endpoint Vapi calls each turn.
+ *     app.post("/chat/completions", async (req, reply) => {
+ *       const { model, messages, tools, stream } = req.body;
+ *       try {
+ *         if (stream) {
+ *           // Upstream MUST set stream_options:{ include_usage: true } — see below.
+ *           const sse = budget.guardStream(
+ *             () => openai.chat.completions.create({ model, messages, tools, stream: true,
+ *               stream_options: { include_usage: true } }),
+ *             { model },
+ *           );
+ *           return reply.sse(sse); // pipe chunks straight through
+ *         }
+ *         const completion = await budget.guardCompletion(
+ *           () => openai.chat.completions.create({ model, messages, tools }),
+ *           { model },
+ *         );
+ *         return reply.send(completion);
+ *       } catch (err) {
+ *         if (err instanceof BudgetExceeded) return reply.code(402).send({ error: String(err) });
+ *         throw err;
+ *       }
+ *     });
+ *
+ * ## The streaming usage requirement (read this)
+ *
+ * OpenAI-style SSE omits `usage` from every chunk **unless** the caller sets
+ * `stream_options: { include_usage: true }` on the upstream request — with it, a
+ * final chunk (empty `choices`) carries the token `usage`. This adapter meters the
+ * model turn from that real `usage`; if a stream ends with no usage anywhere,
+ * {@link VapiBudgetGuard.guardStream} **fails loudly** ({@link VapiUsageMissingError})
+ * and releases the hold rather than silently metering the turn at $0. Set
+ * `include_usage: true` on your upstream streaming call.
+ *
+ * Scope is strictly **pre-call admission plus per-turn settlement**. There is no
+ * mid-call intervention: an admitted turn runs to completion; nothing here cuts a
+ * turn — or a stream — off partway.
+ */
+
+import { BudgetExceeded, FloeGuardError } from "../errors.js";
+import { vapi as vapiGate } from "../gates.js";
+import type { BudgetGuard, ReservationHandle } from "../guard.js";
+import { priceVoiceLeg } from "../voice-pricing.js";
+
+/**
+ * The OpenAI `usage` block we settle against. Vapi speaks the OpenAI wire format,
+ * so the fields are snake_case (`prompt_tokens` / `completion_tokens`). Typed
+ * structurally — the adapter carries no dependency on `openai` or any Vapi SDK.
+ */
+export interface OpenAiUsageLike {
+  readonly prompt_tokens: number;
+  readonly completion_tokens: number;
+}
+
+/** A non-streaming OpenAI `ChatCompletion` — we read its `usage`. */
+export interface ChatCompletionLike {
+  readonly usage?: OpenAiUsageLike | null;
+}
+
+/**
+ * One OpenAI `ChatCompletionChunk` from an SSE stream. Only the final chunk carries
+ * `usage`, and only when the upstream request set
+ * `stream_options: { include_usage: true }` — see the module docstring.
+ */
+export interface ChatCompletionChunkLike {
+  readonly usage?: OpenAiUsageLike | null;
+}
+
+/**
+ * Thrown when a guarded stream ends with no token `usage` to settle against.
+ *
+ * Almost always the fix is `stream_options: { include_usage: true }` on the
+ * upstream streaming request (OpenAI omits `usage` from SSE without it). We refuse
+ * rather than meter the turn at $0 — "we cannot cap what we cannot measure". Extends
+ * {@link FloeGuardError} so it is caught by the same family as the priced errors;
+ * it is adapter-local (not part of the shared `errors.ts` cross-language family).
+ */
+export class VapiUsageMissingError extends FloeGuardError {
+  readonly model: string;
+
+  constructor(model: string) {
+    super(
+      `Vapi custom-LLM stream for model '${model}' ended with no token usage to ` +
+        `settle against. OpenAI-style SSE only includes usage when the upstream ` +
+        `request sets stream_options:{ include_usage: true } — set it, or the guard ` +
+        `cannot meter the turn (it refuses rather than accrue a silent $0).`,
+    );
+    this.name = "VapiUsageMissingError";
+    this.model = model;
+  }
+}
+
+export interface VapiBudgetGuardOptions {
+  /**
+   * Default model id to settle LLM cost against when a per-call `model` is not
+   * passed to {@link VapiBudgetGuard.guardCompletion} / `guardStream`. Vapi's
+   * request carries the model, so passing it per-call is usual; this is the
+   * fallback. Must be priceable via the bundled cost map or the guard's
+   * `priceOverrides`.
+   */
+  model?: string;
+  /** Voice-map vendor key for the STT leg (e.g. `"deepgram-nova-3"`). */
+  sttModel?: string;
+  /** Voice-map vendor key for the TTS leg (e.g. `"elevenlabs-flash-v2.5"`). */
+  ttsModel?: string;
+  /** Voice-map vendor key for the telephony leg (e.g. `"twilio-us-inbound-local"`). */
+  telephony?: string;
+  /** Per-second STT override — wins over `sttModel`. Omit both to leave STT un-metered. */
+  sttUsdPerSecond?: number;
+  /** Per-1k-chars TTS override — wins over `ttsModel`. Omit both to leave TTS un-metered. */
+  ttsUsdPer1kChars?: number;
+  /** Per-minute telephony override — wins over `telephony`. */
+  telephonyUsdPerMinute?: number;
+}
+
+/** A source of an OpenAI completion — a thunk, so we reserve BEFORE the call runs. */
+type CompletionSource<T> = () => Promise<T> | T;
+
+/** A source of an SSE chunk stream — a thunk, for the same reserve-first reason. */
+type StreamSource<C> = () => AsyncIterable<C> | Promise<AsyncIterable<C>>;
+
+/**
+ * Enforce a {@link BudgetGuard} ceiling on a Vapi custom-LLM endpoint: reserve
+ * before the model turn, settle on the real OpenAI `usage`, release on error/abort,
+ * and meter the STT/TTS/telephony legs the proxy never sees.
+ */
+export class VapiBudgetGuard {
+  private readonly guard: BudgetGuard;
+  private readonly model?: string;
+  private readonly sttModel?: string;
+  private readonly ttsModel?: string;
+  private readonly telephony?: string;
+  private readonly sttUsdPerSecond?: number;
+  private readonly ttsUsdPer1kChars?: number;
+  private readonly telephonyUsdPerMinute?: number;
+
+  constructor(guard: BudgetGuard, options: VapiBudgetGuardOptions = {}) {
+    this.guard = guard;
+    this.model = options.model;
+    this.sttModel = options.sttModel;
+    this.ttsModel = options.ttsModel;
+    this.telephony = options.telephony;
+    this.sttUsdPerSecond = options.sttUsdPerSecond;
+    this.ttsUsdPer1kChars = options.ttsUsdPer1kChars;
+    this.telephonyUsdPerMinute = options.telephonyUsdPerMinute;
+  }
+
+  /**
+   * Answer Vapi's `assistant-request` webhook from the remaining budget.
+   *
+   * Budget exhausted → `{ error }` (Vapi speaks it, then ends the call); otherwise
+   * admits with `{ assistantId }` (precedence) or `{ assistant }`. A thin wrapper
+   * over {@link gates.vapi} — the same webhook contract the hosted gateway serves,
+   * so the paid upgrade is a URL swap, not a rewrite. Respond within ~7.5 s.
+   *
+   * This is coarse, non-binding pre-call admission (a budget read, no reservation);
+   * the binding hard-stop is the per-turn reserve in {@link guardCompletion} /
+   * {@link guardStream}. Pass `estimatedCallUsd` (e.g. `$/min × expected minutes`)
+   * to reject earlier, when the remaining budget can't cover the call.
+   *
+   * @throws RangeError when admitted but neither `assistant` nor `assistantId` was
+   *   given — there'd be nothing to hand Vapi (surfaced by {@link gates.vapi}).
+   */
+  assistantRequest(
+    options: {
+      assistant?: Record<string, unknown>;
+      assistantId?: string;
+      errorMessage?: string;
+      estimatedCallUsd?: number;
+    } = {},
+  ): Record<string, unknown> {
+    return vapiGate(this.guard, options);
+  }
+
+  /**
+   * Guard a **non-streaming** model turn: reserve, run the upstream completion,
+   * settle on its real `usage`, release the hold on error.
+   *
+   * Reserving first throws {@link BudgetExceeded} BEFORE `run` is called when the
+   * turn would cross the ceiling, so an over-budget turn never reaches the upstream
+   * LLM. The completion is returned untouched for the handler to forward to Vapi. A
+   * completion with no `usage` fails loudly ({@link VapiUsageMissingError}) and
+   * releases the hold rather than metering $0.
+   */
+  async guardCompletion<T extends ChatCompletionLike>(
+    run: CompletionSource<T>,
+    options: { model?: string; estimatedCost?: number } = {},
+  ): Promise<T> {
+    const model = this.resolveModel(options.model);
+    // Synchronous at the top of the async body: a block rejects the returned
+    // promise with BudgetExceeded before `run` is ever called.
+    const reserved = this.guard.reserve(options.estimatedCost);
+
+    let completion: T;
+    try {
+      completion = await run();
+    } catch (err) {
+      this.guard.release(reserved);
+      throw err;
+    }
+
+    const usage = readUsage(completion.usage);
+    if (usage === null) {
+      this.guard.release(reserved);
+      throw new VapiUsageMissingError(model);
+    }
+    this.guard.settle(model, usage.prompt, usage.completion, { reserved });
+    return completion;
+  }
+
+  /**
+   * Guard a **streaming** model turn: reserve, then wrap the SSE chunk stream so it
+   * settles on the final chunk's `usage`, releasing the hold on error or early abort.
+   *
+   * Reserving first throws {@link BudgetExceeded} BEFORE the stream is opened when
+   * the turn would cross the ceiling (this method throws synchronously — the handler
+   * learns immediately, before piping anything to Vapi). Chunks pass through
+   * untouched; the returned async iterable is what you forward to the SSE response.
+   *
+   * **Usage requirement:** OpenAI SSE only carries `usage` when the upstream request
+   * set `stream_options: { include_usage: true }`. A stream that ends with no usage
+   * anywhere fails loudly ({@link VapiUsageMissingError}) and releases the hold — it
+   * is not metered at $0. Breaking out of the consuming loop early (abort/interrupt)
+   * also releases the hold; nothing is metered for an aborted turn.
+   *
+   * The returned iterable holds the reservation until it is consumed to completion,
+   * or returned/aborted — pipe it straight to the response so the hold cannot leak.
+   */
+  guardStream<C extends ChatCompletionChunkLike>(
+    run: StreamSource<C>,
+    options: { model?: string; estimatedCost?: number } = {},
+  ): AsyncIterableIterator<C> {
+    const model = this.resolveModel(options.model);
+    // Eager reserve (outside the generator) so a block throws synchronously here,
+    // not lazily on first pull — the handler refuses the turn before streaming.
+    const reserved = this.guard.reserve(options.estimatedCost);
+    return this.iterateStream(run, model, reserved);
+  }
+
+  private async *iterateStream<C extends ChatCompletionChunkLike>(
+    run: StreamSource<C>,
+    model: string,
+    reserved: ReservationHandle,
+  ): AsyncIterableIterator<C> {
+    let usage: { prompt: number; completion: number } | null = null;
+    let settled = false;
+    try {
+      const stream = await run();
+      for await (const chunk of stream) {
+        // Last non-null usage wins — the final (empty-choices) chunk carries it.
+        usage = readUsage(chunk.usage) ?? usage;
+        yield chunk;
+      }
+      // Clean end: settle on real usage, or fail loudly if none was ever seen.
+      if (usage === null) throw new VapiUsageMissingError(model);
+      this.guard.settle(model, usage.prompt, usage.completion, { reserved });
+      settled = true;
+    } finally {
+      // Any exit without a settle — error mid-stream, missing usage, or an early
+      // consumer abort (for-await break -> generator.return()) — frees the hold.
+      if (!settled) this.guard.release(reserved);
+    }
+  }
+
+  /** Accrue STT spend for `seconds` of transcribed audio (per second). See {@link meterTelephony}. */
+  meterStt(seconds: number): number | null {
+    const cost = priceVoiceLeg("stt", seconds, {
+      model: this.sttModel,
+      override: this.sttUsdPerSecond,
+    });
+    if (cost !== null) this.guard.recordTool("vapi-stt", cost);
+    return cost;
+  }
+
+  /** Accrue TTS spend for `characters` of synthesized speech (per 1k chars). See {@link meterTelephony}. */
+  meterTts(characters: number): number | null {
+    const cost = priceVoiceLeg("tts", characters, {
+      model: this.ttsModel,
+      override: this.ttsUsdPer1kChars,
+    });
+    if (cost !== null) this.guard.recordTool("vapi-tts", cost);
+    return cost;
+  }
+
+  /**
+   * Accrue telephony spend for `minutes` of call time (per minute).
+   *
+   * The custom-LLM proxy sees only the model leg, so the caller drives this (and
+   * `meterStt` / `meterTts`) explicitly — from Vapi's `end-of-call-report` webhook,
+   * or as the call accrues. This is per-unit accrual, not live line-cutting: the
+   * guard meters the leg, it does not cut the call mid-turn. Priced from the voice
+   * map when the vendor is set, or the per-unit override; returns `null` (no-op)
+   * when the leg is unconfigured, and fails closed ({@link UnpriceableVoiceError})
+   * on a vendor the voice map cannot price. Returns the USD accrued, if any.
+   */
+  meterTelephony(minutes: number): number | null {
+    const cost = priceVoiceLeg("telephony", minutes, {
+      model: this.telephony,
+      override: this.telephonyUsdPerMinute,
+    });
+    if (cost !== null) this.guard.recordTool("vapi-telephony", cost);
+    return cost;
+  }
+
+  /**
+   * The model to settle against: the per-call override (Vapi's request model) or
+   * the constructor default. Fails loudly if neither is set — the guard cannot
+   * price a turn it cannot name.
+   */
+  private resolveModel(override?: string): string {
+    const model = override ?? this.model;
+    if (model === undefined || model === null || model === "") {
+      throw new RangeError(
+        "no model to settle the Vapi turn against: pass { model } to " +
+          "guardCompletion/guardStream (Vapi's request model), or set `model` on the " +
+          "VapiBudgetGuard constructor.",
+      );
+    }
+    return model;
+  }
+}
+
+// Re-export so a handler can `catch (e) { if (e instanceof BudgetExceeded) ... }`
+// without a second import path.
+export { BudgetExceeded };
+
+/**
+ * Read an OpenAI `usage` block into settled prompt/completion counts, or `null`
+ * when absent/malformed. Both fields must be finite numbers — a partial or
+ * non-numeric usage is treated as no usage (fail-closed), never coerced to 0.
+ */
+function readUsage(
+  usage: OpenAiUsageLike | null | undefined,
+): { prompt: number; completion: number } | null {
+  if (usage === null || usage === undefined) return null;
+  const prompt = usage.prompt_tokens;
+  const completion = usage.completion_tokens;
+  if (typeof prompt !== "number" || !Number.isFinite(prompt)) return null;
+  if (typeof completion !== "number" || !Number.isFinite(completion)) return null;
+  return { prompt, completion };
+}

--- a/js/src/adapters/vapi.ts
+++ b/js/src/adapters/vapi.ts
@@ -290,10 +290,15 @@ export class VapiBudgetGuard {
       }
       // Clean end: settle on real usage, or fail loudly if none was ever seen.
       if (usage === null) throw new VapiUsageMissingError(model);
-      this.guard.settle(model, usage.prompt, usage.completion, { reserved });
+      // Mark settled BEFORE the call: guard.settle owns the reservation on every
+      // exit — it releases the hold on its own failure paths (unpriceable model,
+      // priceTokens error) before throwing — so the finally must not release it a
+      // second time (a double release drives `reserved` negative and weakens the
+      // ceiling for other in-flight turns).
       settled = true;
+      this.guard.settle(model, usage.prompt, usage.completion, { reserved });
     } finally {
-      // Any exit without a settle — error mid-stream, missing usage, or an early
+      // Any exit before settle — error mid-stream, missing usage, or an early
       // consumer abort (for-await break -> generator.return()) — frees the hold.
       if (!settled) this.guard.release(reserved);
     }

--- a/js/test/livekit-adapter.test.ts
+++ b/js/test/livekit-adapter.test.ts
@@ -1,0 +1,276 @@
+/**
+ * LiveKitBudgetGuard — reserve before the LLM turn, settle on real usage, release
+ * on interrupt, and price STT/TTS/telephony legs via the voice cost map.
+ *
+ * Stubbed session/agent objects drive the adapter — no @livekit/agents runtime, no
+ * network, no keys. The adapter is typed structurally; the `types` block at the
+ * bottom pins those structural shapes against the REAL exported @livekit/agents
+ * types, so this test also fails if the SDK's surface drifts from what we wrapped.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { BudgetExceeded, BudgetGuard, UnpriceableVoiceError, priceVoiceLeg } from "../src/index.js";
+import {
+  LiveKitBudgetGuard,
+  type LiveKitAgentLike,
+  type LiveKitSessionLike,
+} from "../src/adapters/livekit.js";
+
+const PRICE = { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 };
+
+/** Minimal typed-emitter stand-in for `AgentSession` — record listeners, emit to them. */
+class FakeSession implements LiveKitSessionLike {
+  private readonly listeners: Record<string, ((ev: unknown) => void)[]> = {};
+  on(event: string, listener: (ev: never) => void): this {
+    (this.listeners[event] ??= []).push(listener as (ev: unknown) => void);
+    return this;
+  }
+  emit(event: string, ev: unknown): void {
+    for (const listener of this.listeners[event] ?? []) listener(ev);
+  }
+}
+
+/** A web ReadableStream of the given chunks (as `Agent.llmNode` returns). */
+function streamOf(chunks: unknown[]): ReadableStream<unknown> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function drain(stream: ReadableStream<unknown>): Promise<void> {
+  const reader = stream.getReader();
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+/** An agent whose `llmNode` yields a fresh two-chunk stream on each turn. */
+function fakeAgent(): LiveKitAgentLike & { calls: number } {
+  return {
+    calls: 0,
+    async llmNode(this: { calls: number }) {
+      this.calls += 1;
+      return streamOf(["hello", "world"]);
+    },
+  };
+}
+
+function llmMetrics(promptTokens: number, completionTokens: number) {
+  return { metrics: { type: "llm_metrics", promptTokens, completionTokens } };
+}
+
+describe("LiveKitBudgetGuard — reserve before the LLM turn", () => {
+  it("blocks an over-budget turn before the LLM runs (no stream, no llmNode call)", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 1.0); // spend the ceiling
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(new FakeSession(), agent);
+
+    await expect(agent.llmNode()).rejects.toBeInstanceOf(BudgetExceeded);
+    expect(agent.calls).toBe(0); // the original llmNode was never reached
+  });
+
+  it("invokes onBudgetExceeded and ends the turn with no stream instead of throwing", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 1.0);
+    const spoken = vi.fn(async (_e: BudgetExceeded) => {});
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m", onBudgetExceeded: spoken }).attach(
+      new FakeSession(),
+      agent,
+    );
+
+    const stream = await agent.llmNode();
+    expect(stream).toBeNull();
+    expect(spoken).toHaveBeenCalledOnce();
+    expect(spoken.mock.calls[0]![0]).toBeInstanceOf(BudgetExceeded);
+    expect(agent.calls).toBe(0);
+  });
+
+  it("admits an under-budget turn and returns a (wrapped) stream", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(new FakeSession(), agent);
+
+    const stream = await agent.llmNode();
+    expect(stream).not.toBeNull();
+    await drain(stream!);
+    expect(agent.calls).toBe(1);
+  });
+});
+
+describe("LiveKitBudgetGuard — settle on real usage", () => {
+  it("accrues the priced LLM cost from a metrics_collected event and frees the hold", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(session, agent);
+
+    await drain((await agent.llmNode())!); // clean end leaves the hold for the metrics event
+    session.emit("metrics_collected", llmMetrics(1000, 500));
+
+    // 1000 * 1e-6 + 500 * 2e-6 = 0.002
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12);
+    // Reservation consumed (not leaked): remaining == limit - spent, no held slice.
+    expect(guard.remainingUsd).toBeCloseTo(1.0 - 0.002, 12);
+    expect(guard.spendLog).toHaveLength(1);
+    expect(guard.spendLog[0]!.modelOrTool).toBe("m");
+  });
+
+  it("settles a delayed metrics event (empty-queue path) as a plain record", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(session, fakeAgent());
+
+    // No turn opened — a stray metrics event still meters usage.
+    session.emit("metrics_collected", llmMetrics(1000, 0));
+    expect(guard.spentUsd).toBeCloseTo(0.001, 12);
+  });
+});
+
+describe("LiveKitBudgetGuard — release on interrupt", () => {
+  it("cancelling the turn stream frees the held reservation", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(session, agent);
+
+    // Turn 1: settle so the guard's next-call estimate becomes non-zero (0.002),
+    // making the following turn's reservation observable in remainingUsd.
+    await drain((await agent.llmNode())!);
+    session.emit("metrics_collected", llmMetrics(1000, 500));
+    const afterTurn1 = guard.remainingUsd; // 1.0 - 0.002
+
+    // Turn 2: opening it reserves the 0.002 estimate — remaining drops.
+    const stream2 = await agent.llmNode();
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1 - 0.002, 12);
+
+    // Interrupt: cancel the stream instead of draining it. The hold is released.
+    await stream2!.cancel();
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12);
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12); // no new spend accrued by the interrupt
+  });
+
+  it("close releases a still-open turn's reservation", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    const agent = fakeAgent();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(session, agent);
+
+    await drain((await agent.llmNode())!);
+    session.emit("metrics_collected", llmMetrics(1000, 500));
+    const afterTurn1 = guard.remainingUsd;
+
+    await agent.llmNode(); // turn 2 holds 0.002, never settles
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1 - 0.002, 12);
+
+    session.emit("close", { type: "close" });
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12);
+  });
+});
+
+describe("LiveKitBudgetGuard — voice legs price via the cost map", () => {
+  it("meters STT (per second) and TTS (per 1k chars) from named vendors", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    new LiveKitBudgetGuard(guard, {
+      model: "m",
+      sttModel: "deepgram-nova-3",
+      ttsModel: "elevenlabs-flash-v2.5",
+    }).attach(session, fakeAgent());
+
+    // 30_000 ms of audio -> 30 s; 1_200 synthesized characters.
+    session.emit("metrics_collected", {
+      metrics: { type: "stt_metrics", audioDurationMs: 30_000 },
+    });
+    session.emit("metrics_collected", {
+      metrics: { type: "tts_metrics", charactersCount: 1_200 },
+    });
+
+    const expectedStt = priceVoiceLeg("stt", 30, { model: "deepgram-nova-3" });
+    const expectedTts = priceVoiceLeg("tts", 1_200, { model: "elevenlabs-flash-v2.5" });
+    expect(guard.toolCosts["livekit-stt"]).toBeCloseTo(expectedStt!, 12);
+    expect(guard.toolCosts["livekit-tts"]).toBeCloseTo(expectedTts!, 12);
+  });
+
+  it("meters telephony per minute via meterTelephony", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const budget = new LiveKitBudgetGuard(guard, {
+      model: "m",
+      telephony: "twilio-us-inbound-local",
+    });
+
+    const accrued = budget.meterTelephony(2.5);
+    expect(accrued).toBeCloseTo(priceVoiceLeg("telephony", 2.5, { model: "twilio-us-inbound-local" })!, 12);
+    expect(guard.toolCosts["livekit-telephony"]).toBeCloseTo(accrued!, 12);
+  });
+
+  it("leaves an unconfigured leg un-metered (token-only contract)", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(session, fakeAgent());
+
+    session.emit("metrics_collected", {
+      metrics: { type: "stt_metrics", audioDurationMs: 30_000 },
+    });
+    expect(guard.toolCosts["livekit-stt"]).toBeUndefined();
+    expect(guard.spentUsd).toBe(0);
+  });
+
+  it("fails closed on a vendor the voice map cannot price", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const session = new FakeSession();
+    new LiveKitBudgetGuard(guard, { model: "m", sttModel: "no-such-vendor" }).attach(
+      session,
+      fakeAgent(),
+    );
+
+    expect(() =>
+      session.emit("metrics_collected", {
+        metrics: { type: "stt_metrics", audioDurationMs: 1_000 },
+      }),
+    ).toThrow(UnpriceableVoiceError);
+  });
+});
+
+describe("LiveKitBudgetGuard — pre-call admission", () => {
+  it("admitCall delegates to the budget gate", () => {
+    const guard = new BudgetGuard(1.0);
+    const budget = new LiveKitBudgetGuard(guard, { model: "m" });
+    expect(budget.admitCall()).toBe(true);
+    guard.recordTool("prior", 1.0);
+    expect(budget.admitCall()).toBe(false);
+  });
+});
+
+// --- Type pins: the adapter is structurally typed; assert those shapes accept the
+// --- REAL @livekit/agents exports so this test breaks if the SDK surface drifts.
+// --- Type-only — never executed.
+import type { Agent, AgentSession, LLMMetrics, MetricsCollectedEvent } from "@livekit/agents";
+
+function __typePins(
+  realSession: AgentSession,
+  realEvent: MetricsCollectedEvent,
+  realLlm: LLMMetrics,
+): void {
+  // The real Agent.llmNode takes exactly 3 args (chatCtx, toolCtx, modelSettings)
+  // — the arity we forward unchanged. Breaks here if the SDK changes it.
+  const arity: 3 = null as unknown as Parameters<Agent["llmNode"]>["length"];
+  // The real MetricsCollectedEvent carries a `.metrics` union with a `type`
+  // discriminator (what onMetrics branches on), and LLMMetrics reports
+  // promptTokens/completionTokens (what we settle against).
+  const kind: string = realEvent.metrics.type;
+  const tokens: number = realLlm.promptTokens + realLlm.completionTokens;
+  // The real AgentSession is a typed emitter we can attach onto.
+  const sessionLike: LiveKitSessionLike = realSession as unknown as LiveKitSessionLike;
+  void arity;
+  void kind;
+  void tokens;
+  void sessionLike;
+}
+void __typePins;

--- a/js/test/livekit-adapter.test.ts
+++ b/js/test/livekit-adapter.test.ts
@@ -222,19 +222,36 @@ describe("LiveKitBudgetGuard — voice legs price via the cost map", () => {
     expect(guard.spentUsd).toBe(0);
   });
 
-  it("fails closed on a vendor the voice map cannot price", () => {
+  it("fails closed at construction on a vendor the voice map cannot price", () => {
     const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
-    const session = new FakeSession();
-    new LiveKitBudgetGuard(guard, { model: "m", sttModel: "no-such-vendor" }).attach(
-      session,
-      fakeAgent(),
-    );
-
-    expect(() =>
-      session.emit("metrics_collected", {
-        metrics: { type: "stt_metrics", audioDurationMs: 1_000 },
-      }),
+    // Validated in the constructor — a typo'd vendor throws before any turn runs,
+    // not deep in a metrics callback mid-call.
+    expect(
+      () => new LiveKitBudgetGuard(guard, { model: "m", sttModel: "no-such-vendor" }),
     ).toThrow(UnpriceableVoiceError);
+  });
+
+  it("releases the hold when the wrapped llmNode throws", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 0.1); // set a non-zero next-call estimate to reserve
+    const before = guard.remainingUsd; // 0.90
+    const agent: LiveKitAgentLike & { calls: number } = {
+      calls: 0,
+      async llmNode() {
+        this.calls += 1;
+        throw new Error("upstream boom");
+      },
+    };
+    new LiveKitBudgetGuard(guard, { model: "m" }).attach(new FakeSession(), agent);
+    await expect(agent.llmNode()).rejects.toThrow("upstream boom");
+    expect(guard.remainingUsd).toBe(before); // hold released — a failed turn never leaks
+  });
+
+  it("attach is single-use — a second attach throws", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new LiveKitBudgetGuard(guard, { model: "m" });
+    budget.attach(new FakeSession(), fakeAgent());
+    expect(() => budget.attach(new FakeSession(), fakeAgent())).toThrow(/twice/);
   });
 });
 
@@ -243,6 +260,9 @@ describe("LiveKitBudgetGuard — pre-call admission", () => {
     const guard = new BudgetGuard(1.0);
     const budget = new LiveKitBudgetGuard(guard, { model: "m" });
     expect(budget.admitCall()).toBe(true);
+    // estimatedCallUsd rejects before the remaining budget can cover the call.
+    expect(budget.admitCall({ estimatedCallUsd: 1.5 })).toBe(false);
+    expect(budget.admitCall({ estimatedCallUsd: 0.5 })).toBe(true);
     guard.recordTool("prior", 1.0);
     expect(budget.admitCall()).toBe(false);
   });
@@ -251,12 +271,21 @@ describe("LiveKitBudgetGuard — pre-call admission", () => {
 // --- Type pins: the adapter is structurally typed; assert those shapes accept the
 // --- REAL @livekit/agents exports so this test breaks if the SDK surface drifts.
 // --- Type-only — never executed.
-import type { Agent, AgentSession, LLMMetrics, MetricsCollectedEvent } from "@livekit/agents";
+import type {
+  Agent,
+  AgentSession,
+  LLMMetrics,
+  MetricsCollectedEvent,
+  STTMetrics,
+  TTSMetrics,
+} from "@livekit/agents";
 
 function __typePins(
   realSession: AgentSession,
   realEvent: MetricsCollectedEvent,
   realLlm: LLMMetrics,
+  realStt: STTMetrics,
+  realTts: TTSMetrics,
 ): void {
   // The real Agent.llmNode takes exactly 3 args (chatCtx, toolCtx, modelSettings)
   // — the arity we forward unchanged. Breaks here if the SDK changes it.
@@ -266,11 +295,19 @@ function __typePins(
   // promptTokens/completionTokens (what we settle against).
   const kind: string = realEvent.metrics.type;
   const tokens: number = realLlm.promptTokens + realLlm.completionTokens;
-  // The real AgentSession is a typed emitter we can attach onto.
-  const sessionLike: LiveKitSessionLike = realSession as unknown as LiveKitSessionLike;
+  // The STT/TTS metric fields we meter against: STT audio duration in ms (we
+  // divide by 1000), TTS character count. Breaks here if either field is renamed.
+  const sttMs: number = realStt.audioDurationMs;
+  const ttsChars: number = realTts.charactersCount;
+  // The real AgentSession is a typed emitter we can attach onto — a DIRECT
+  // assignment (no cast) so the compiler actually checks AgentSession satisfies
+  // LiveKitSessionLike; breaks here if the SDK's `on(...)` surface drifts.
+  const sessionLike: LiveKitSessionLike = realSession;
   void arity;
   void kind;
   void tokens;
+  void sttMs;
+  void ttsChars;
   void sessionLike;
 }
 void __typePins;

--- a/js/test/retell-adapter.test.ts
+++ b/js/test/retell-adapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * RetellBudgetGuard — reserve when a `response_required` arrives, settle on real
+ * token usage after `content_complete`, release when a newer `response_id`
+ * interrupts, and price STT/TTS/telephony legs via the voice cost map.
+ *
+ * Fake Retell interaction events drive the adapter — no `ws` server, no Retell SDK,
+ * no network, no keys. Everything is a plain parsed-message shape.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BudgetGuard, UnpriceableVoiceError, gates, priceVoiceLeg } from "../src/index.js";
+import {
+  RetellBudgetGuard,
+  type RetellResponseRequiredEvent,
+} from "../src/adapters/retell.js";
+
+const PRICE = { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 };
+
+/** A `response_required` interaction event, as Retell delivers it over the WS. */
+function responseRequired(responseId: number): RetellResponseRequiredEvent {
+  return {
+    interaction_type: "response_required",
+    response_id: responseId,
+    transcript: [{ role: "user", content: "hi" }],
+  };
+}
+
+describe("RetellBudgetGuard — reserve before the LLM turn", () => {
+  it("blocks an over-budget turn (admitted: false, carries the BudgetExceeded)", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 1.0); // spend the ceiling
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    const decision = budget.beginTurn(responseRequired(1));
+    expect(decision.admitted).toBe(false);
+    if (!decision.admitted) {
+      expect(decision.error.name).toBe("BudgetExceeded");
+      expect(decision.responseId).toBe(1);
+    }
+  });
+
+  it("admits an under-budget turn", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    const decision = budget.beginTurn(responseRequired(1));
+    expect(decision.admitted).toBe(true);
+    expect(decision.responseId).toBe(1);
+  });
+});
+
+describe("RetellBudgetGuard — settle on real usage", () => {
+  it("accrues the priced LLM cost after content_complete and frees the hold", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    budget.beginTurn(responseRequired(1));
+    budget.settleTurn(1, { promptTokens: 1000, completionTokens: 500 });
+
+    // 1000 * 1e-6 + 500 * 2e-6 = 0.002
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12);
+    // Reservation consumed (not leaked): remaining == limit - spent, no held slice.
+    expect(guard.remainingUsd).toBeCloseTo(1.0 - 0.002, 12);
+    expect(guard.spendLog).toHaveLength(1);
+    expect(guard.spendLog[0]!.modelOrTool).toBe("m");
+  });
+
+  it("settles a turn that was never begun (no open slot) as a plain record", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    budget.settleTurn(99, { promptTokens: 1000, completionTokens: 0 });
+    expect(guard.spentUsd).toBeCloseTo(0.001, 12);
+  });
+});
+
+describe("RetellBudgetGuard — release on interrupt", () => {
+  it("a newer response_id releases the prior open turn's reservation", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    // Turn 1: settle so the guard's next-call estimate becomes non-zero (0.002),
+    // making the following turn's reservation observable in remainingUsd.
+    budget.beginTurn(responseRequired(1));
+    budget.settleTurn(1, { promptTokens: 1000, completionTokens: 500 });
+    const afterTurn1 = guard.remainingUsd; // 1.0 - 0.002
+
+    // Turn 2: reserves the 0.002 estimate — remaining drops.
+    budget.beginTurn(responseRequired(2));
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1 - 0.002, 12);
+
+    // Turn 3 (higher response_id) arrives before turn 2 settles — turn 2 is
+    // interrupted and its hold released. Turn 3 then holds its own 0.002.
+    budget.beginTurn(responseRequired(3));
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1 - 0.002, 12); // only turn 3 held
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12); // interrupt accrued no new spend
+  });
+
+  it("close releases a still-open turn's reservation", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    budget.beginTurn(responseRequired(1));
+    budget.settleTurn(1, { promptTokens: 1000, completionTokens: 500 });
+    const afterTurn1 = guard.remainingUsd;
+
+    budget.beginTurn(responseRequired(2)); // holds 0.002, never settles
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1 - 0.002, 12);
+
+    budget.close();
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12);
+  });
+});
+
+describe("RetellBudgetGuard — pre-call admission via gates.retell", () => {
+  it("admits with available budget and rejects when exhausted", () => {
+    const guard = new BudgetGuard(1.0);
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    const admit = budget.admitCall({ admit: { metadata: { plan: "free" } } });
+    expect(admit).toEqual(gates.retell(guard, { admit: { metadata: { plan: "free" } } }));
+    expect(admit.call_inbound.reject).toBeUndefined();
+
+    guard.recordTool("prior", 1.0); // spend the ceiling
+    expect(budget.admitCall()).toEqual({ call_inbound: { reject: true } });
+  });
+});
+
+describe("RetellBudgetGuard — voice legs price via the cost map", () => {
+  it("meters STT (per second), TTS (per 1k chars) and telephony (per minute)", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, {
+      model: "m",
+      sttModel: "deepgram-nova-3",
+      ttsModel: "elevenlabs-flash-v2.5",
+      telephony: "twilio-us-inbound-local",
+    });
+
+    const stt = budget.meterStt(30);
+    const tts = budget.meterTts(1_200);
+    const tel = budget.meterTelephony(2.5);
+
+    expect(stt).toBeCloseTo(priceVoiceLeg("stt", 30, { model: "deepgram-nova-3" })!, 12);
+    expect(tts).toBeCloseTo(priceVoiceLeg("tts", 1_200, { model: "elevenlabs-flash-v2.5" })!, 12);
+    expect(tel).toBeCloseTo(
+      priceVoiceLeg("telephony", 2.5, { model: "twilio-us-inbound-local" })!,
+      12,
+    );
+    expect(guard.toolCosts["retell-stt"]).toBeCloseTo(stt!, 12);
+    expect(guard.toolCosts["retell-tts"]).toBeCloseTo(tts!, 12);
+    expect(guard.toolCosts["retell-telephony"]).toBeCloseTo(tel!, 12);
+  });
+
+  it("leaves an unconfigured leg un-metered (token-only contract)", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m" });
+
+    expect(budget.meterStt(30)).toBeNull();
+    expect(guard.toolCosts["retell-stt"]).toBeUndefined();
+    expect(guard.spentUsd).toBe(0);
+  });
+
+  it("fails closed on a vendor the voice map cannot price", () => {
+    const guard = new BudgetGuard(10.0, { priceOverrides: { m: PRICE } });
+    const budget = new RetellBudgetGuard(guard, { model: "m", sttModel: "no-such-vendor" });
+
+    expect(() => budget.meterStt(1)).toThrow(UnpriceableVoiceError);
+  });
+});

--- a/js/test/vapi-adapter.test.ts
+++ b/js/test/vapi-adapter.test.ts
@@ -1,0 +1,239 @@
+/**
+ * VapiBudgetGuard — reserve before the model turn, settle on the real OpenAI usage,
+ * release on error/abort, admit the call via the assistant-request gate, and price
+ * the STT/TTS/telephony legs the custom-LLM proxy never sees.
+ *
+ * Fabricated OpenAI-shaped completions / SSE chunk streams drive the adapter — no
+ * Vapi SDK, no `openai` runtime, no network, no keys. The adapter is typed
+ * structurally against the OpenAI wire format Vapi speaks.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BudgetExceeded, BudgetGuard, UnpriceableVoiceError, priceVoiceLeg } from "../src/index.js";
+import {
+  VapiBudgetGuard,
+  VapiUsageMissingError,
+  type ChatCompletionChunkLike,
+  type ChatCompletionLike,
+} from "../src/adapters/vapi.js";
+
+const PRICE = { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 };
+
+/** An OpenAI-format non-streaming completion carrying a usage block. */
+function completion(promptTokens: number, completionTokens: number) {
+  return {
+    id: "chatcmpl-x",
+    choices: [{ message: { role: "assistant", content: "hi" } }],
+    usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens },
+  };
+}
+
+/**
+ * A fake OpenAI SSE stream: content chunks (no usage), then — if `usage` is given —
+ * a final empty-choices chunk carrying it, exactly as `stream_options:{include_usage:true}`
+ * produces. Omit `usage` to model a stream WITHOUT include_usage.
+ */
+async function* sseStream(
+  contentChunks: number,
+  usage?: { prompt_tokens: number; completion_tokens: number },
+): AsyncGenerator<ChatCompletionChunkLike> {
+  for (let i = 0; i < contentChunks; i++) {
+    yield { choices: [{ delta: { content: "tok" } }] } as ChatCompletionChunkLike;
+  }
+  if (usage !== undefined) {
+    yield { choices: [], usage } as ChatCompletionChunkLike;
+  }
+}
+
+async function drainStream(stream: AsyncIterable<unknown>): Promise<number> {
+  let n = 0;
+  for await (const _ of stream) n += 1;
+  return n;
+}
+
+describe("VapiBudgetGuard — reserve before the model turn", () => {
+  it("blocks an over-budget non-streaming turn before the upstream call runs", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 1.0); // spend the ceiling
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    let ran = false;
+    await expect(
+      budget.guardCompletion(() => {
+        ran = true;
+        return completion(1000, 500);
+      }),
+    ).rejects.toBeInstanceOf(BudgetExceeded);
+    expect(ran).toBe(false); // upstream never reached
+  });
+
+  it("blocks an over-budget streaming turn synchronously, before the stream opens", () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    guard.recordTool("prior", 1.0);
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    let opened = false;
+    // guardStream reserves eagerly, so the block throws right here — not lazily on
+    // first pull. The handler learns before piping anything to Vapi.
+    expect(() =>
+      budget.guardStream(() => {
+        opened = true;
+        return sseStream(3, { prompt_tokens: 10, completion_tokens: 5 });
+      }),
+    ).toThrow(BudgetExceeded);
+    expect(opened).toBe(false);
+  });
+});
+
+describe("VapiBudgetGuard — settle on real usage", () => {
+  it("accrues the priced LLM cost from a non-streaming completion and frees the hold", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    const out = await budget.guardCompletion(() => completion(1000, 500));
+    expect(out.usage?.completion_tokens).toBe(500); // returned untouched
+
+    // 1000 * 1e-6 + 500 * 2e-6 = 0.002
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12);
+    expect(guard.remainingUsd).toBeCloseTo(1.0 - 0.002, 12); // reservation consumed, not leaked
+    expect(guard.spendLog).toHaveLength(1);
+    expect(guard.spendLog[0]!.modelOrTool).toBe("m");
+  });
+
+  it("settles a streaming turn on the final chunk's usage and passes chunks through", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    const stream = budget.guardStream(() =>
+      sseStream(4, { prompt_tokens: 1000, completion_tokens: 500 }),
+    );
+    const yielded = await drainStream(stream);
+
+    expect(yielded).toBe(5); // 4 content chunks + 1 usage chunk, all forwarded
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12);
+    expect(guard.remainingUsd).toBeCloseTo(1.0 - 0.002, 12);
+  });
+
+  it("uses the per-call model (Vapi's request model) over the constructor default", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { "req-model": PRICE } });
+    const budget = new VapiBudgetGuard(guard); // no default model
+
+    await budget.guardCompletion(() => completion(1000, 0), { model: "req-model" });
+    expect(guard.spendLog[0]!.modelOrTool).toBe("req-model");
+  });
+});
+
+describe("VapiBudgetGuard — release on error / abort", () => {
+  it("releases the hold when the upstream completion call throws", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    // Prime a non-zero next-call estimate so the reservation is observable.
+    await budget.guardCompletion(() => completion(1000, 500));
+    const afterTurn1 = guard.remainingUsd; // 1.0 - 0.002
+
+    await expect(
+      budget.guardCompletion(() => Promise.reject(new Error("upstream 500"))),
+    ).rejects.toThrow("upstream 500");
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12); // hold released
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12); // no new spend
+  });
+
+  it("releases the hold when the caller aborts the stream early (break)", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    await budget.guardCompletion(() => completion(1000, 500)); // prime estimate 0.002
+    const afterTurn1 = guard.remainingUsd;
+
+    const stream = budget.guardStream(() =>
+      sseStream(10, { prompt_tokens: 1000, completion_tokens: 500 }),
+    );
+    // Break after one chunk — for-await calls stream.return(), unwinding to the
+    // generator's finally, which releases the still-open hold.
+    for await (const _ of stream) break;
+
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12);
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12); // aborted turn metered nothing
+  });
+});
+
+describe("VapiBudgetGuard — missing usage fails loudly", () => {
+  it("throws VapiUsageMissingError and releases the hold for a non-streaming completion with no usage", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+    await budget.guardCompletion(() => completion(1000, 500)); // prime estimate
+    const afterTurn1 = guard.remainingUsd;
+
+    const noUsage: ChatCompletionLike = { usage: null }; // completion with no usable usage
+    await expect(budget.guardCompletion(() => noUsage)).rejects.toBeInstanceOf(
+      VapiUsageMissingError,
+    );
+    expect(guard.remainingUsd).toBeCloseTo(afterTurn1, 12); // released, not metered at $0
+    expect(guard.spentUsd).toBeCloseTo(0.002, 12);
+  });
+
+  it("throws VapiUsageMissingError for a stream with no include_usage chunk", async () => {
+    const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
+    const budget = new VapiBudgetGuard(guard, { model: "m" });
+
+    const stream = budget.guardStream(() => sseStream(3)); // no usage chunk emitted
+    await expect(drainStream(stream)).rejects.toBeInstanceOf(VapiUsageMissingError);
+    expect(guard.spentUsd).toBe(0); // nothing metered
+  });
+});
+
+describe("VapiBudgetGuard — assistant-request admission via gates.vapi", () => {
+  it("admits an under-budget call with the assistant/assistantId shape", () => {
+    const guard = new BudgetGuard(1.0);
+    const budget = new VapiBudgetGuard(guard);
+    expect(budget.assistantRequest({ assistantId: "asst_123" })).toEqual({
+      assistantId: "asst_123",
+    });
+  });
+
+  it("rejects an exhausted call with a spoken error", () => {
+    const guard = new BudgetGuard(1.0);
+    guard.recordTool("prior", 1.0);
+    const budget = new VapiBudgetGuard(guard);
+    expect(
+      budget.assistantRequest({ assistantId: "asst_123", errorMessage: "Out of budget." }),
+    ).toEqual({ error: "Out of budget." });
+  });
+});
+
+describe("VapiBudgetGuard — voice legs price via the cost map", () => {
+  it("meters STT, TTS, and telephony from named vendors", () => {
+    const guard = new BudgetGuard(10.0);
+    const budget = new VapiBudgetGuard(guard, {
+      sttModel: "deepgram-nova-3",
+      ttsModel: "elevenlabs-flash-v2.5",
+      telephony: "twilio-us-inbound-local",
+    });
+
+    const stt = budget.meterStt(30); // 30 s
+    const tts = budget.meterTts(1_200); // 1.2k chars
+    const tel = budget.meterTelephony(2.5); // 2.5 min
+
+    expect(stt).toBeCloseTo(priceVoiceLeg("stt", 30, { model: "deepgram-nova-3" })!, 12);
+    expect(tts).toBeCloseTo(priceVoiceLeg("tts", 1_200, { model: "elevenlabs-flash-v2.5" })!, 12);
+    expect(tel).toBeCloseTo(priceVoiceLeg("telephony", 2.5, { model: "twilio-us-inbound-local" })!, 12);
+    expect(guard.toolCosts["vapi-stt"]).toBeCloseTo(stt!, 12);
+    expect(guard.toolCosts["vapi-tts"]).toBeCloseTo(tts!, 12);
+    expect(guard.toolCosts["vapi-telephony"]).toBeCloseTo(tel!, 12);
+  });
+
+  it("leaves an unconfigured leg un-metered (token-only contract)", () => {
+    const guard = new BudgetGuard(10.0);
+    const budget = new VapiBudgetGuard(guard); // no voice vendors configured
+    expect(budget.meterStt(30)).toBeNull();
+    expect(guard.spentUsd).toBe(0);
+  });
+
+  it("fails closed on a vendor the voice map cannot price", () => {
+    const guard = new BudgetGuard(10.0);
+    const budget = new VapiBudgetGuard(guard, { sttModel: "no-such-vendor" });
+    expect(() => budget.meterStt(1)).toThrow(UnpriceableVoiceError);
+  });
+});

--- a/js/test/vapi-adapter.test.ts
+++ b/js/test/vapi-adapter.test.ts
@@ -10,7 +10,13 @@
 
 import { describe, expect, it } from "vitest";
 
-import { BudgetExceeded, BudgetGuard, UnpriceableVoiceError, priceVoiceLeg } from "../src/index.js";
+import {
+  BudgetExceeded,
+  BudgetGuard,
+  UnpriceableModelError,
+  UnpriceableVoiceError,
+  priceVoiceLeg,
+} from "../src/index.js";
 import {
   VapiBudgetGuard,
   VapiUsageMissingError,
@@ -252,7 +258,7 @@ describe("VapiBudgetGuard — no double release", () => {
     // Draining triggers settle("mystery-model", …) → UnpriceableModelError, which
     // releases the reservation ITSELF. The finally must not release it again — a
     // double release would drive `reserved` negative and inflate remainingUsd.
-    await expect(drainStream(stream)).rejects.toThrow();
+    await expect(drainStream(stream)).rejects.toThrow(UnpriceableModelError);
     expect(guard.remainingUsd).toBe(before); // released exactly once — ceiling intact
   });
 });

--- a/js/test/vapi-adapter.test.ts
+++ b/js/test/vapi-adapter.test.ts
@@ -237,3 +237,22 @@ describe("VapiBudgetGuard — voice legs price via the cost map", () => {
     expect(() => budget.meterStt(1)).toThrow(UnpriceableVoiceError);
   });
 });
+
+describe("VapiBudgetGuard — no double release", () => {
+  it("does not double-release when a streaming settle throws (non-priceable model)", async () => {
+    const guard = new BudgetGuard(1.0); // failClosed default; "mystery-model" unpriceable
+    guard.recordTool("prior", 0.1); // non-zero next-call estimate → the reserve holds 0.10
+    const before = guard.remainingUsd; // 0.90
+    const budget = new VapiBudgetGuard(guard, { model: "mystery-model" });
+    const stream = budget.guardStream(() =>
+      (async function* () {
+        yield { usage: { prompt_tokens: 100, completion_tokens: 50 } };
+      })(),
+    );
+    // Draining triggers settle("mystery-model", …) → UnpriceableModelError, which
+    // releases the reservation ITSELF. The finally must not release it again — a
+    // double release would drive `reserved` negative and inflate remainingUsd.
+    await expect(drainStream(stream)).rejects.toThrow();
+    expect(guard.remainingUsd).toBe(before); // released exactly once — ceiling intact
+  });
+});

--- a/js/tsup.config.ts
+++ b/js/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: [
+    "src/index.ts",
+    "src/adapters/livekit.ts",
+    "src/adapters/vapi.ts",
+    "src/adapters/retell.ts",
+  ],
   format: ["esm", "cjs"],
   dts: true,
   clean: true,


### PR DESCRIPTION
The three Node voice adapters — the "meat" of the TS-voice-parity ticket, closing **AC2** (a runnable stubbed no-key demo for each of LiveKit / Vapi / Retell showing a per-leg call cost + a pre-call admission decision).

Built in **three isolated git worktrees** (one per adapter, after the shared-tree lesson earlier), each on its verified protocol, each independently reviewed + build/test/demo-run before assembly.

## What each adapter does

All three: reserve-before-turn / settle-on-real-usage / release-on-interrupt around the model leg, meter STT/TTS/telephony via `priceVoiceLeg` (fail-closed), and answer the platform's inbound admission webhook via `gates`. **Pre-turn/pre-call admission + per-turn settlement only — no mid-call cutoff** (verified: no mid-call framing anywhere).

| Import | API | Notes |
|---|---|---|
| `floe-guard/adapters/livekit` | `LiveKitBudgetGuard.attach(session, agent)` | Reserves in `agent.llmNode`, settles on session `metrics_collected`. **Verified against installed `@livekit/agents@1.6.3` types: session-level `metrics_collected` is NOT deprecated in agents-js** (it is in Python 1.5.0). `@livekit/agents` optional peer. |
| `floe-guard/adapters/vapi` | `VapiBudgetGuard` — `guardCompletion`/`guardStream`, `assistantRequest` | `guardStream` reserves eagerly (throws `BudgetExceeded` synchronously before the SSE opens); a stream missing `usage` (no `stream_options.include_usage`) throws `VapiUsageMissingError` rather than metering a silent $0. |
| `floe-guard/adapters/retell` | `RetellBudgetGuard` — `beginTurn`/`settleTurn`, `admitCall` | Keyed by `response_id` (returns an admit/block decision — a WS callback can't throw meaningfully); a newer `response_id` releases the prior hold (barge-in). |

## Honesty notes (carried through review)

- **No mid-call intervention** claim anywhere; `meterTelephony` docstrings clarify "not live line-cutting."
- **Structural typing, no hard runtime SDK deps.** LiveKit pins its structural types against the real `@livekit/agents` types in a type-only test; Vapi/Retell **don't fake a type-pin** because neither ships a canonical typed package (Vapi custom-LLM *is* the OpenAI wire shape; Retell's WS protocol is hand-written JSON) — reported, not invented.
- `VapiUsageMissingError` is **adapter-local** (not added to the shared `errors.ts`) to avoid opening a Python `errors.py` parity gap.

## Verification (combined, run independently)

`tsc --noEmit` clean · `tsup` builds all three (`dist/adapters/{livekit,vapi,retell}`) · **vitest 171 passed** (135 foundation + 12 LiveKit + 10 Retell + 14 Vapi) · all three stubbed demos run offline and print an admission decision + per-leg receipt. js `0.11.0 → 0.12.0`.

## Remaining ticket work (the finishers, next PRs)

- **AC1/AC4 docs:** update the adapter matrix + remove the "no TypeScript voice adapter" statement (now true to remove).
- Migrate the **Python** `integrations/livekit.py` off deprecated session-level `metrics_collected`.
- **AC3:** floe-cookbook guard-line pass on the examples where it's genuinely useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native TypeScript voice adapters for LiveKit, Vapi, and Retell.
  - Added budget admission, usage settlement, interruption handling, and STT, TTS, and telephony metering.
  - Added fail-closed handling for unavailable pricing or usage data.
  - Added offline demos showing voice cost tracking and budget receipts.
  - Published adapter entry points in the JavaScript package.

- **Documentation**
  - Updated the README and changelog with TypeScript voice adapter support and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->