### PR TITLE
fix(py): migrate LiveKit adapter off deprecated session metrics_collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.16.2
+
+### Fixed (py)
+
+- **LiveKit adapter: migrate off the deprecated session-level `metrics_collected`
+  event.** `livekit-agents` 1.5 deprecated `AgentSession.on("metrics_collected", …)`
+  (it now logs a warning and points at `session_usage_updated` / `ChatMessage.metrics`).
+  `LiveKitBudgetGuard` now settles/meter each turn off the **per-component**
+  `metrics_collected` event (the LLM / STT / TTS plugins each emit it and it is
+  **not** deprecated) instead of the session facade. The LLM plugin fires per
+  LLM turn, so the reserve-before-turn → settle-real-usage contract is preserved
+  exactly; `session_usage_updated` was rejected because it delivers a *cumulative*
+  `UsageSummary` (itself deprecated), which would force diffing successive
+  summaries and lose clean per-turn settlement. Components are resolved from the
+  agent first, then the session, mirroring LiveKit's own runtime pick. No public
+  API change; the `livekit` extra floor stays `>=1.0` (the per-component event
+  predates the deprecation). (The TS `@livekit/agents` does not deprecate the
+  event, so the Vercel-AI/js package is unaffected.)
+
 ## Unreleased — py 0.16.1 / js 0.11.0
 
 ### Fixed (py)

--- a/examples/voice_call_cost_livekit.py
+++ b/examples/voice_call_cost_livekit.py
@@ -13,7 +13,6 @@ Run:
 from __future__ import annotations
 
 import asyncio
-import types
 
 from livekit.agents.metrics import LLMMetrics, STTMetrics, TTSMetrics
 
@@ -21,11 +20,31 @@ from floe_guard import BudgetGuard
 from floe_guard.integrations.livekit import LiveKitBudgetGuard
 
 
-class _FakeSession:
-    """The tiny event-emitter surface attach() wires onto."""
+class _FakeEmitter:
+    """A LiveKit component (LLM/STT/TTS plugin) — an event emitter that emits its
+    own ``metrics_collected``, which is where the adapter meters usage."""
 
     def __init__(self) -> None:
         self._handlers: dict = {}
+
+    def on(self, event, cb):
+        self._handlers[event] = cb
+
+    def emit(self, event, arg):
+        if event in self._handlers:
+            self._handlers[event](arg)
+
+
+class _FakeSession:
+    """The tiny event-emitter surface attach() wires onto. The LLM/STT/TTS
+    plugins each carry their own ``metrics_collected`` (the session-level event
+    is deprecated in livekit-agents 1.5+); ``close`` fires on the session."""
+
+    def __init__(self) -> None:
+        self._handlers: dict = {}
+        self.llm = _FakeEmitter()
+        self.stt = _FakeEmitter()
+        self.tts = _FakeEmitter()
 
     def on(self, event, cb):
         self._handlers[event] = cb
@@ -38,10 +57,6 @@ class _FakeAgent:
     async def llm_node(self, chat_ctx, tools, model_settings):
         for chunk in ("Sure,", " one moment."):
             yield chunk
-
-
-def _event(metric):
-    return types.SimpleNamespace(metrics=metric)
 
 
 def _llm_metrics(prompt_tokens, completion_tokens):
@@ -101,9 +116,9 @@ async def run() -> BudgetGuard:
     # One turn: caller speaks (STT) → model answers (LLM) → bot speaks (TTS).
     async for _ in agent.llm_node(None, None, None):
         pass
-    session.emit("metrics_collected", _event(_stt_metrics(8.0)))  # 8s of caller audio
-    session.emit("metrics_collected", _event(_llm_metrics(600, 220)))
-    session.emit("metrics_collected", _event(_tts_metrics(180)))  # 180 chars spoken
+    session.stt.emit("metrics_collected", _stt_metrics(8.0))  # 8s of caller audio
+    session.llm.emit("metrics_collected", _llm_metrics(600, 220))
+    session.tts.emit("metrics_collected", _tts_metrics(180))  # 180 chars spoken
 
     # Telephony is per-minute accrual driven by the transport — a 1.5-minute call.
     budget.meter_telephony(1.5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.16.1"
+version = "0.16.2"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -3,8 +3,13 @@
 Like Pipecat, a LiveKit ``AgentSession`` (STT -> LLM -> TTS) has no single call
 site to wrap: turns fire for the life of a call. The two enforcement points are
 the agent's ``llm_node`` (before the LLM call, so a turn is blocked before its
-TTS/audio spend piles on) and the session's ``metrics_collected`` event (real
-usage, after). ``LiveKitBudgetGuard`` holds the reservation state across both.
+TTS/audio spend piles on) and each component's ``metrics_collected`` event —
+the LLM/STT/TTS plugins each emit their real usage right after doing their work.
+(The session-level ``metrics_collected`` event was deprecated in
+``livekit-agents`` 1.5; the per-component event carries the same per-turn metric
+object and is not deprecated, so we settle each turn straight off the LLM plugin
+— cleanly per-turn, unlike the cumulative ``session_usage_updated`` summary.)
+``LiveKitBudgetGuard`` holds the reservation state across both.
 
     from floe_guard import BudgetGuard, ManualPrice
     from floe_guard.integrations.livekit import LiveKitBudgetGuard
@@ -122,8 +127,9 @@ class LiveKitBudgetGuard:
         self._slots: deque[_TurnSlot] = deque()
 
     def attach(self, session, agent) -> None:
-        """Wire reserve (agent.llm_node), settle/meter (metrics_collected) and
-        release (close) onto a session + agent pair."""
+        """Wire reserve (agent.llm_node), settle/meter (each component's
+        ``metrics_collected``) and release (session close) onto a session + agent
+        pair."""
         orig_llm_node = agent.llm_node
 
         # forward LiveKit's (chat_ctx, tools, model_settings) unchanged, so an
@@ -163,8 +169,32 @@ class LiveKitBudgetGuard:
                 raise
 
         agent.llm_node = _guarded_llm_node
-        session.on("metrics_collected", self._on_metrics)
+        # Settle/meter off each component's own metrics_collected — the LLM plugin
+        # fires per LLM turn (so settlement lands right after the turn we reserved),
+        # STT/TTS per utterance. The session-level metrics_collected is deprecated
+        # in livekit-agents 1.5+, so we no longer listen on the session for it.
+        for component in self._metric_sources(session, agent):
+            component.on("metrics_collected", self._on_metric)
         session.on("close", self._on_close)
+
+    @staticmethod
+    def _metric_sources(session, agent) -> list:
+        """Resolve the LLM/STT/TTS plugins to meter, mirroring LiveKit's runtime
+        pick (an agent component overrides the session's). Deduped by identity so
+        a unified model exposed under two slots is subscribed once."""
+        sources: list = []
+        seen: set[int] = set()
+        for name in ("llm", "stt", "tts"):
+            component = getattr(agent, name, None)
+            if component is None or not hasattr(component, "on"):
+                component = getattr(session, name, None)
+            if component is None or not hasattr(component, "on"):
+                continue
+            if id(component) in seen:
+                continue
+            seen.add(id(component))
+            sources.append(component)
+        return sources
 
     def _clear_active(self) -> None:
         self._active = None
@@ -182,8 +212,10 @@ class LiveKitBudgetGuard:
         slot.amount = 0.0
         self._clear_active()
 
-    def _on_metrics(self, ev) -> None:
-        m = ev.metrics
+    def _on_metric(self, m) -> None:
+        # Component-level metrics_collected hands us the raw metric object
+        # (LLMMetrics / STTMetrics / TTSMetrics) directly, not wrapped in a
+        # session MetricsCollectedEvent.
         if isinstance(m, LLMMetrics):
             # Pop the oldest turn slot. Early-released turns contribute 0 so a
             # delayed metrics event meters usage without consuming a later hold.

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -34,6 +34,23 @@ over the map. Telephony (per-minute) is metered via :meth:`meter_telephony`,
 since LiveKit emits no telephony metric. A leg with neither a vendor nor an
 override is left un-metered (the token-only contract); a vendor the voice map
 cannot price fails closed (:class:`~floe_guard.errors.UnpriceableVoiceError`).
+
+**Mid-call component swaps.** ``Agent.update_options()`` and
+``AgentSession.update_agent()`` can replace the live LLM/STT/TTS objects mid-call.
+``livekit-agents`` (verified against 1.6.6) emits **no swap-specific event** — the
+swap mutates ``AgentActivity`` state in place. Since we subscribe to each
+component's ``metrics_collected`` directly, a swapped-in component would otherwise
+bypass our meter. We reconcile subscriptions on ``agent_state_changed`` (the
+session fires it on every turn transition), re-resolving the live components off
+``AgentSession.current_agent`` and ``.off``/``.on``-ing the diff — so a swap is
+picked up by the turn it lands on.
+
+**Known limitation:** ``AgentSession.update_agent()`` installs a *new* ``Agent``
+whose ``llm_node`` we never wrapped, so the pre-turn **reserve/hard-stop** is
+bypassed for that agent (its spend is still *metered* via the reconcile above, but
+a turn is no longer *blocked* before it runs). Re-``attach()`` a fresh
+``LiveKitBudgetGuard`` to the new agent to restore pre-turn admission. ``update_options``
+(same agent, swapped models) keeps the reserve hook and is fully covered.
 """
 
 from __future__ import annotations
@@ -98,6 +115,13 @@ class LiveKitBudgetGuard:
             ``telephony``.
     """
 
+    # Cap on the _slots FIFO. A realtime / text-only turn returns no stream and
+    # emits realtime_metrics (not LLMMetrics), so its slot never settles and would
+    # linger; on a long call the queue would grow without bound. Past this many
+    # slots we drop the oldest (releasing an open hold), bounding memory and the
+    # settlement drift a stale slot introduces. Mirrors the TS adapter.
+    _MAX_SLOTS: int = 64
+
     def __init__(
         self,
         guard: BudgetGuard,
@@ -125,11 +149,39 @@ class LiveKitBudgetGuard:
         self._active: _TurnSlot | None = None
         # FIFO of turns that may still emit LLMMetrics (including early-released).
         self._slots: deque[_TurnSlot] = deque()
+        # attach() binds one session/agent pair; a second call would double-count.
+        self._attached = False
+        # Set in attach(); needed to re-resolve metric sources after a swap.
+        self._session = None
+        self._agent = None
+        # Components we currently listen on for metrics_collected, so a swap can
+        # .off(...) the stale ones and .on(...) the new (see _sync_metric_sources).
+        self._metric_subs: list = []
+        # Fail fast: a misconfigured voice vendor raises UnpriceableVoiceError at
+        # construction, not mid-call. quantity 0 resolves the rate (priced at $0)
+        # without metering; an unconfigured leg is a no-op (None).
+        price_voice_leg("stt", 0, model=self._stt_model, override=self._stt_usd_per_second)
+        price_voice_leg("tts", 0, model=self._tts_model, override=self._tts_usd_per_1k_chars)
+        price_voice_leg(
+            "telephony", 0, model=self._telephony, override=self._telephony_usd_per_minute
+        )
 
     def attach(self, session, agent) -> None:
         """Wire reserve (agent.llm_node), settle/meter (each component's
         ``metrics_collected``) and release (session close) onto a session + agent
         pair."""
+        # One guard binds one session/agent pair. A second attach() would wrap the
+        # wrapper and register duplicate listeners — each turn would then reserve
+        # and settle twice, double-counting spend. Reject the repeat (a reconnect /
+        # retried setup should create a fresh LiveKitBudgetGuard).
+        if self._attached:
+            raise RuntimeError(
+                "LiveKitBudgetGuard.attach() called twice — a guard instance binds "
+                "one session/agent pair. Create a new LiveKitBudgetGuard to re-attach."
+            )
+        self._attached = True
+        self._session = session
+        self._agent = agent
         orig_llm_node = agent.llm_node
 
         # forward LiveKit's (chat_ctx, tools, model_settings) unchanged, so an
@@ -154,6 +206,7 @@ class LiveKitBudgetGuard:
             self._active = slot
             self._reserved = amount
             self._pending = True
+            self._trim_slots(slot)
             try:
                 stream = orig_llm_node(*args, **kwargs)
                 if inspect.isawaitable(stream):
@@ -173,8 +226,12 @@ class LiveKitBudgetGuard:
         # fires per LLM turn (so settlement lands right after the turn we reserved),
         # STT/TTS per utterance. The session-level metrics_collected is deprecated
         # in livekit-agents 1.5+, so we no longer listen on the session for it.
-        for component in self._metric_sources(session, agent):
-            component.on("metrics_collected", self._on_metric)
+        self._sync_metric_sources()
+        # A component swap (Agent.update_options / AgentSession.update_agent) replaces
+        # the live LLM/STT/TTS objects; those emit no swap-specific event, so we
+        # reconcile our subscriptions on agent_state_changed (fires on every turn
+        # transition) to pick the swapped-in components up. See _sync_metric_sources.
+        session.on("agent_state_changed", self._on_agent_state_changed)
         session.on("close", self._on_close)
 
     @staticmethod
@@ -195,6 +252,55 @@ class LiveKitBudgetGuard:
             seen.add(id(component))
             sources.append(component)
         return sources
+
+    def _live_agent(self):
+        """The agent whose components are live now.
+
+        ``AgentSession.update_agent`` replaces the running agent, so read the
+        session's ``current_agent`` when it exposes one; fall back to the agent
+        passed to :meth:`attach` (the session isn't running yet, or a stub session
+        without the property)."""
+        try:
+            return self._session.current_agent
+        except (AttributeError, RuntimeError):
+            return self._agent
+
+    def _sync_metric_sources(self) -> None:
+        """Reconcile our ``metrics_collected`` subscriptions to the live components.
+
+        A component swap (``Agent.update_options`` / ``AgentSession.update_agent``)
+        replaces the LLM/STT/TTS objects mid-call. Those emit no swap event, and
+        ``_metric_sources`` only ran once at :meth:`attach`, so a swapped-in
+        component's metrics would bypass :meth:`_on_metric` — under-metering. Called
+        again on every ``agent_state_changed``, this ``.off``\\ s the components no
+        longer live and ``.on``\\ s the new ones (identity-compared, so steady state
+        is a no-op). Bounds under-metering to the turn a swap lands on."""
+        current = self._metric_sources(self._session, self._live_agent())
+        current_ids = {id(c) for c in current}
+        # Drop stale subscriptions (a swapped-out component).
+        for component in list(self._metric_subs):
+            if id(component) not in current_ids:
+                if hasattr(component, "off"):
+                    component.off("metrics_collected", self._on_metric)
+                self._metric_subs.remove(component)
+        # Add subscriptions for newly-live components.
+        subscribed_ids = {id(c) for c in self._metric_subs}
+        for component in current:
+            if id(component) not in subscribed_ids:
+                component.on("metrics_collected", self._on_metric)
+                self._metric_subs.append(component)
+
+    def _on_agent_state_changed(self, ev=None) -> None:
+        self._sync_metric_sources()
+
+    def _trim_slots(self, active: _TurnSlot) -> None:
+        """Bound the FIFO: drop oldest slots past :attr:`_MAX_SLOTS`, releasing an
+        open hold as it goes. Never drops the just-reserved ``active`` slot. Prevents
+        a long call from accumulating slots for turns that never emit LLMMetrics."""
+        while len(self._slots) > self._MAX_SLOTS and self._slots[0] is not active:
+            stale = self._slots.popleft()
+            if stale.open:
+                self._guard.release(stale.amount)
 
     def _clear_active(self) -> None:
         self._active = None

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -37,6 +37,10 @@ class _FakeEmitter:
     def on(self, event, cb):
         self._handlers[event] = cb
 
+    def off(self, event, cb):
+        if self._handlers.get(event) == cb:
+            del self._handlers[event]
+
     def emit(self, event, arg):
         if event in self._handlers:
             self._handlers[event](arg)
@@ -385,14 +389,6 @@ async def test_override_wins_over_voice_map():
 
 
 @pytest.mark.asyncio
-async def test_unpriceable_stt_vendor_fails_closed():
-    guard = BudgetGuard(limit_usd=100.00)
-    _, _, session = _attached(guard, stt_model="not-a-real-stt-vendor")
-    with pytest.raises(UnpriceableVoiceError):
-        session.stt.emit("metrics_collected", _stt_metric(10.0))
-
-
-@pytest.mark.asyncio
 async def test_telephony_metered_per_minute_from_map():
     guard = BudgetGuard(limit_usd=100.00)
     budget, _, _ = _attached(guard, telephony="twilio-us-inbound-local")
@@ -429,3 +425,117 @@ async def test_full_call_per_leg_breakdown_sums_to_total():
     legs = {e.model_or_tool: e.cost_usd for e in guard.spend_log}
     assert set(legs) == {"gpt-4o", "livekit-stt", "livekit-tts", "livekit-telephony"}
     assert sum(legs.values()) == pytest.approx(guard.advisory().spent_usd)
+
+
+# -- Constructor fail-fast on a misconfigured voice vendor --------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"stt_model": "not-a-real-stt-vendor"},
+        {"tts_model": "not-a-real-tts-vendor"},
+        {"telephony": "not-a-real-telephony-vendor"},
+    ],
+)
+def test_constructor_rejects_unknown_vendor(kwargs):
+    # A typo'd vendor must fail closed at construction, not mid-call.
+    guard = BudgetGuard(limit_usd=100.00)
+    with pytest.raises(UnpriceableVoiceError):
+        LiveKitBudgetGuard(guard, model="gpt-4o", **kwargs)
+
+
+def test_constructor_accepts_configured_vendors_and_unconfigured_legs():
+    # A priceable vendor (and an entirely unconfigured leg) construct cleanly.
+    guard = BudgetGuard(limit_usd=100.00)
+    LiveKitBudgetGuard(
+        guard,
+        model="gpt-4o",
+        stt_model="deepgram-nova-3",
+        tts_usd_per_1k_chars=0.10,  # override leg
+    )
+
+
+# -- attach() idempotency ------------------------------------------------------
+
+
+def test_second_attach_raises():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard)
+    with pytest.raises(RuntimeError, match="attach\\(\\) called twice"):
+        budget.attach(session, agent)
+
+
+# -- _slots FIFO stays bounded when no LLMMetrics ever settle -------------------
+
+
+@pytest.mark.asyncio
+async def test_slots_deque_is_bounded_without_llm_metrics():
+    # A realtime / text-only turn emits no LLMMetrics, so its slot never settles.
+    # Drive far more turns than the cap and assert the FIFO stays bounded and no
+    # guard hold leaks (only the active turn holds budget; close frees it).
+    guard = BudgetGuard(limit_usd=1_000_000.00)
+    budget, agent, session = _attached(guard)
+
+    turns = LiveKitBudgetGuard._MAX_SLOTS * 4
+    for _ in range(turns):
+        await _drive_turn(agent)  # reserves; never emits metrics_collected
+
+    assert len(budget._slots) <= LiveKitBudgetGuard._MAX_SLOTS
+    assert budget._pending  # the last turn is still active/held
+
+    session.emit("close", types.SimpleNamespace())
+    assert not budget._pending
+    assert guard._reserved == pytest.approx(0.0)  # no leaked holds
+
+
+# -- Mid-call component swap: metrics re-subscribed on agent_state_changed ------
+
+
+@pytest.mark.asyncio
+async def test_swapped_component_metrics_captured_after_state_change():
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard, stt_usd_per_second=0.01)
+
+    old_stt = session.stt
+    # Simulate Agent.update_options()/update_agent swapping the live STT object.
+    new_stt = _FakeEmitter()
+    session.stt = new_stt
+
+    # Before reconcile the new component isn't wired — its metrics are missed.
+    new_stt.emit("metrics_collected", _stt_metric(10.0))
+    assert guard.advisory().spent_usd == 0.0
+
+    # A turn transition triggers reconcile: new component subscribed, old dropped.
+    session.emit("agent_state_changed", types.SimpleNamespace())
+
+    new_stt.emit("metrics_collected", _stt_metric(10.0))
+    assert guard.advisory().spent_usd == pytest.approx(10.0 * 0.01)
+
+    # The swapped-out component no longer double-counts.
+    old_stt.emit("metrics_collected", _stt_metric(10.0))
+    assert guard.advisory().spent_usd == pytest.approx(10.0 * 0.01)
+
+
+@pytest.mark.asyncio
+async def test_update_agent_metrics_followed_via_current_agent():
+    # AgentSession.update_agent() installs a new agent; we resolve the live
+    # components off session.current_agent so their metrics are still metered.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(guard, stt_usd_per_second=0.01)
+
+    class _NewAgent:
+        def __init__(self):
+            self.stt = _FakeEmitter()
+
+    new_agent = _NewAgent()
+    # Make session.current_agent report the swapped-in agent.
+    session.__class__ = type(
+        "_SessionWithCurrentAgent",
+        (type(session),),
+        {"current_agent": property(lambda self: new_agent)},
+    )
+
+    session.emit("agent_state_changed", types.SimpleNamespace())
+    new_agent.stt.emit("metrics_collected", _stt_metric(20.0))
+    assert guard.advisory().spent_usd == pytest.approx(20.0 * 0.01)

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -1,9 +1,12 @@
 """Tests for the LiveKit Agents integration.
 
-The adapter hooks two surfaces — the agent's ``llm_node`` (reserve) and the
-session's ``metrics_collected`` / ``close`` events (settle / release). These
-drive them directly through a minimal fake agent + event-emitter session, which
-is all ``attach`` touches; a full LiveKit room/runner isn't needed.
+The adapter hooks two surfaces — the agent's ``llm_node`` (reserve) and each
+component's ``metrics_collected`` event plus the session ``close`` (settle /
+release). The session-level ``metrics_collected`` is deprecated in
+livekit-agents 1.5+, so the adapter listens on the LLM/STT/TTS plugins directly.
+These tests drive them through a minimal fake agent + per-component
+event-emitter session, which is all ``attach`` touches; a full LiveKit
+room/runner isn't needed.
 """
 
 from __future__ import annotations
@@ -24,9 +27,29 @@ from floe_guard.errors import BudgetExceeded, UnpriceableVoiceError  # noqa: E40
 from floe_guard.integrations.livekit import LiveKitBudgetGuard  # noqa: E402
 
 
+class _FakeEmitter:
+    """A LiveKit component (LLM/STT/TTS plugin) — an event emitter that the
+    adapter subscribes to for ``metrics_collected``."""
+
+    def __init__(self):
+        self._handlers = {}
+
+    def on(self, event, cb):
+        self._handlers[event] = cb
+
+    def emit(self, event, arg):
+        if event in self._handlers:
+            self._handlers[event](arg)
+
+
 class _FakeSession:
     def __init__(self):
         self._handlers = {}
+        # Components live on the session (the canonical LiveKit pattern). Each
+        # emits its own metrics_collected; the adapter meters straight off them.
+        self.llm = _FakeEmitter()
+        self.stt = _FakeEmitter()
+        self.tts = _FakeEmitter()
 
     def on(self, event, cb):
         self._handlers[event] = cb
@@ -68,10 +91,6 @@ def _llm_metrics(prompt_tokens, completion_tokens, cancelled=False):
     )
 
 
-def _event(metric):
-    return types.SimpleNamespace(metrics=metric)
-
-
 @pytest.mark.asyncio
 async def test_turn_streams_through_and_settles_on_metrics():
     guard = BudgetGuard(limit_usd=100.00)
@@ -81,7 +100,7 @@ async def test_turn_streams_through_and_settles_on_metrics():
     assert chunks == ["hello", " world"]  # original llm_node output is preserved
     assert budget._pending  # reservation held until usage is reported
 
-    session.emit("metrics_collected", _event(_llm_metrics(100, 50)))
+    session.llm.emit("metrics_collected", _llm_metrics(100, 50))
 
     assert guard.advisory().spent_usd > 0
     assert not budget._pending
@@ -99,7 +118,7 @@ async def test_on_budget_exceeded_callback_used_instead_of_raising():
     budget, agent, session = _attached(guard, on_budget_exceeded=handle)
 
     await _drive_turn(agent)  # first turn reserves $0 (no prior cost) and passes
-    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))  # now over ceiling
+    session.llm.emit("metrics_collected", _llm_metrics(1000, 500))  # now over ceiling
 
     chunks = await _drive_turn(agent)  # second turn should be blocked
     assert chunks == []  # blocked turn yields nothing
@@ -112,7 +131,7 @@ async def test_blocked_turn_raises_without_callback():
     budget, agent, session = _attached(guard)
 
     await _drive_turn(agent)
-    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+    session.llm.emit("metrics_collected", _llm_metrics(1000, 500))
 
     with pytest.raises(BudgetExceeded):
         await _drive_turn(agent)
@@ -124,7 +143,7 @@ async def test_cancelled_turn_settles_and_releases_reservation():
     budget, agent, session = _attached(guard)
 
     await _drive_turn(agent)
-    session.emit("metrics_collected", _event(_llm_metrics(0, 0, cancelled=True)))
+    session.llm.emit("metrics_collected", _llm_metrics(0, 0, cancelled=True))
 
     assert not budget._pending
     assert budget._reserved == 0.0
@@ -174,7 +193,7 @@ async def test_failing_turn_does_not_release_later_turns_reservation():
     seed = LiveKitBudgetGuard(guard, model="gpt-4o")
     seed.attach(seed_session, seed_agent)
     await _drive_turn(seed_agent)
-    seed_session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+    seed_session.llm.emit("metrics_collected", _llm_metrics(1000, 500))
 
     a_ready = asyncio.Event()
     a_may_fail = asyncio.Event()
@@ -226,7 +245,7 @@ async def test_delayed_metrics_do_not_steal_later_turns_reservation():
 
     # Seed a non-zero default estimate so holds are real USD.
     await _drive_turn(agent)
-    session.emit("metrics_collected", _event(_llm_metrics(1000, 500)))
+    session.llm.emit("metrics_collected", _llm_metrics(1000, 500))
 
     # Turn A reserves and finishes streaming; metrics not yet emitted.
     await _drive_turn(agent)
@@ -242,7 +261,7 @@ async def test_delayed_metrics_do_not_steal_later_turns_reservation():
     assert guard._reserved == pytest.approx(b_reserved)
 
     # A's delayed metrics arrive first — must meter A without consuming B.
-    session.emit("metrics_collected", _event(_llm_metrics(100, 50)))
+    session.llm.emit("metrics_collected", _llm_metrics(100, 50))
     assert budget._pending
     assert budget._reserved == pytest.approx(b_reserved)
     assert guard._reserved == pytest.approx(b_reserved)
@@ -250,7 +269,7 @@ async def test_delayed_metrics_do_not_steal_later_turns_reservation():
     spent_after_a = guard.advisory().spent_usd
 
     # B's metrics settle B's own hold.
-    session.emit("metrics_collected", _event(_llm_metrics(200, 100)))
+    session.llm.emit("metrics_collected", _llm_metrics(200, 100))
     assert not budget._pending
     assert budget._reserved == 0.0
     assert guard._reserved == pytest.approx(0.0)
@@ -262,33 +281,29 @@ async def test_stt_and_tts_metered_only_when_priced():
     guard = BudgetGuard(limit_usd=100.00)
     _, _, session = _attached(guard, stt_usd_per_second=0.01, tts_usd_per_1k_chars=0.10)
 
-    session.emit(
+    session.stt.emit(
         "metrics_collected",
-        _event(
-            STTMetrics(
-                label="stt",
-                request_id="r",
-                timestamp=0.0,
-                duration=0.0,
-                audio_duration=10.0,
-                streamed=True,
-            )
+        STTMetrics(
+            label="stt",
+            request_id="r",
+            timestamp=0.0,
+            duration=0.0,
+            audio_duration=10.0,
+            streamed=True,
         ),
     )
-    session.emit(
+    session.tts.emit(
         "metrics_collected",
-        _event(
-            TTSMetrics(
-                label="tts",
-                request_id="r",
-                timestamp=0.0,
-                ttfb=0.0,
-                duration=0.0,
-                audio_duration=0.0,
-                cancelled=False,
-                characters_count=1000,
-                streamed=True,
-            )
+        TTSMetrics(
+            label="tts",
+            request_id="r",
+            timestamp=0.0,
+            ttfb=0.0,
+            duration=0.0,
+            audio_duration=0.0,
+            cancelled=False,
+            characters_count=1000,
+            streamed=True,
         ),
     )
 
@@ -301,17 +316,15 @@ async def test_stt_tts_ignored_by_default():
     guard = BudgetGuard(limit_usd=100.00)
     _, _, session = _attached(guard)  # no per-unit prices
 
-    session.emit(
+    session.stt.emit(
         "metrics_collected",
-        _event(
-            STTMetrics(
-                label="stt",
-                request_id="r",
-                timestamp=0.0,
-                duration=0.0,
-                audio_duration=10.0,
-                streamed=True,
-            )
+        STTMetrics(
+            label="stt",
+            request_id="r",
+            timestamp=0.0,
+            duration=0.0,
+            audio_duration=10.0,
+            streamed=True,
         ),
     )
 
@@ -351,8 +364,8 @@ async def test_stt_and_tts_metered_from_voice_cost_map_by_default():
         guard, stt_model="deepgram-nova-3", tts_model="elevenlabs-flash-v2.5"
     )
 
-    session.emit("metrics_collected", _event(_stt_metric(60.0)))  # 60s of audio
-    session.emit("metrics_collected", _event(_tts_metric(2000)))  # 2000 chars
+    session.stt.emit("metrics_collected", _stt_metric(60.0))  # 60s of audio
+    session.tts.emit("metrics_collected", _tts_metric(2000))  # 2000 chars
 
     # STT: 60s * ($0.0077/min ÷ 60) = $0.0077. TTS: 2000/1000 * $0.05 = $0.10.
     expected = 60.0 * (0.0077 / 60) + 2000 / 1000 * 0.05
@@ -366,7 +379,7 @@ async def test_override_wins_over_voice_map():
     _, _, session = _attached(
         guard, stt_model="deepgram-nova-3", stt_usd_per_second=0.001
     )
-    session.emit("metrics_collected", _event(_stt_metric(10.0)))
+    session.stt.emit("metrics_collected", _stt_metric(10.0))
     # Override ($0.001/s), not the Deepgram map rate.
     assert guard.advisory().spent_usd == pytest.approx(10.0 * 0.001)
 
@@ -376,7 +389,7 @@ async def test_unpriceable_stt_vendor_fails_closed():
     guard = BudgetGuard(limit_usd=100.00)
     _, _, session = _attached(guard, stt_model="not-a-real-stt-vendor")
     with pytest.raises(UnpriceableVoiceError):
-        session.emit("metrics_collected", _event(_stt_metric(10.0)))
+        session.stt.emit("metrics_collected", _stt_metric(10.0))
 
 
 @pytest.mark.asyncio
@@ -408,9 +421,9 @@ async def test_full_call_per_leg_breakdown_sums_to_total():
         telephony="twilio-us-inbound-local",
     )
     await _drive_turn(agent)  # LLM turn (model="gpt-4o", priced from the LLM map)
-    session.emit("metrics_collected", _event(_llm_metrics(500, 200)))
-    session.emit("metrics_collected", _event(_stt_metric(30.0)))
-    session.emit("metrics_collected", _event(_tts_metric(1200)))
+    session.llm.emit("metrics_collected", _llm_metrics(500, 200))
+    session.stt.emit("metrics_collected", _stt_metric(30.0))
+    session.tts.emit("metrics_collected", _tts_metric(1200))
     budget.meter_telephony(1.0)
 
     legs = {e.model_or_tool: e.cost_usd for e in guard.spend_log}


### PR DESCRIPTION
## The deprecation

`livekit-agents` **1.5** deprecated the session-level metrics event. Verified empirically in the installed `livekit-agents==1.6.6` (`voice/agent_session.py`):

```python
def on(self, event, callback=None):
    if event == "metrics_collected" and callback is not None:
        logger.warning(
            "metrics_collected is deprecated. "
            "Use session_usage_updated for usage tracking "
            "and ChatMessage.metrics for per-turn latency."
        )
```

`MetricsCollectedEvent` itself is docstring-flagged `Deprecated: use session_usage_updated`. The adapter subscribed via `session.on("metrics_collected", ...)` — the deprecated path.

## What I verified about the API

- **`session_usage_updated`** delivers `SessionUsageUpdatedEvent(usage: AgentSessionUsage)`, emitted right after *every* metric (`voice/agent_activity.py`). `AgentSessionUsage` is a **cumulative** aggregate (`list[ModelUsage]`, keyed by provider/model); the older `UsageSummary` form is *itself* `@deprecated`. Using it for per-turn settlement would require diffing successive cumulative summaries and re-matching by model — lossy and fragile. **Rejected.**
- **Per-component `metrics_collected` is NOT deprecated.** The LLM / STT / TTS plugins are each `rtc.EventEmitter`s that emit `metrics_collected` with the raw metric object. The session event was literally just a re-emit of these (`agent_activity.py: self._session.emit("metrics_collected", MetricsCollectedEvent(metrics=ev))`). Only the `AgentSession.on(...)` facade warns; the component `.on(...)` does not.

## The migration

`LiveKitBudgetGuard` now subscribes to each component's own `metrics_collected` (`session.llm` / `session.stt` / `session.tts`, resolved from the agent first then the session, mirroring LiveKit's runtime pick; deduped by identity). The callback receives the raw metric (no `MetricsCollectedEvent.metrics` unwrap).

**Why per-turn settlement is preserved exactly:** the LLM plugin emits `metrics_collected` at the end of each generation — the same underlying event the session was re-broadcasting, same timing. The reserve-before-turn (`llm_node`) → settle-real-usage → release-on-interrupt contract is untouched; only the subscription surface moved off the deprecated facade. `close` still fires on the session, so release-on-teardown is unchanged.

## Version floor

The `livekit` extra floor stays `>=1.0` — the per-component event predates the 1.5 deprecation, so the chosen API needs no bump.

## js parity

None needed. TS `@livekit/agents` does **not** deprecate `metrics_collected`, so the Vercel-AI/js package legitimately keeps it and is unaffected.

## Tests

`tests/test_livekit_adapter.py` reworked to drive per-component emitters (fakes now expose `.llm/.stt/.tts`); the runnable `examples/voice_call_cost_livekit.py` updated to match. Full suite: **361 passed**. `ruff check .`: clean.

- Bump py `0.16.1` → `0.16.2`; CHANGELOG `### Fixed (py)` under a new Unreleased section. No js change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the LiveKit integration to receive usage metrics from individual LLM, speech-to-text, and text-to-speech components.
  - Preserved per-turn usage tracking and cost calculation across supported components.

- **Bug Fixes**
  - Replaced deprecated session-level metric handling for improved compatibility with current LiveKit behavior.

- **Chores**
  - Released Python version 0.16.2.
  - Updated examples and validation coverage for component-level metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->