### PR TITLE
feat(sync): opt-in ledger sync → Reconcile Mode / Coverage Score (py …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   `urlopen` is never called for a guard that hasn't opted in). The **request body**
   is exactly the `export_log()` JSONL — priced spend events (timestamp, kind,
   model/tool, tokens, `cost_usd`, optional `label`/`reserved`) — and `push_ledger`
-  **validates every line, rejecting any field outside that schema**, so no prompts,
-  content, or identifiers can leave even from a hand-supplied ledger. Your key
+  **validates every line, rejecting any field outside that schema**, so no prompts
+  or message content leave even from a hand-supplied ledger. The only
+  caller-controlled string transmitted is the optional `label` you set yourself
+  (keep identifiers out of it). Your key
   travels in the `Authorization` header; redirects are refused so key + ledger
   can't be re-sent to an unapproved host. `disable_sync()` revokes it.
   Budget, not balance: it reports what you already spent for coverage/attribution;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   `floe-guard push ledger.jsonl` (CLI). **Zero-telemetry stays the default** —
   nothing leaves the process without the explicit opt-in *and* an explicit send;
   there is no implicit enablement and no background send (asserted in tests:
-  `urlopen` is never called for a guard that hasn't opted in). What leaves is
-  **exactly the `export_log()` JSONL** — priced spend events (timestamp, kind,
-  model/tool, tokens, `cost_usd`, optional `label`/`reserved`), **no prompts, no
-  content, no identifiers** beyond a `label` you set. `disable_sync()` revokes it.
+  `urlopen` is never called for a guard that hasn't opted in). The **request body**
+  is exactly the `export_log()` JSONL — priced spend events (timestamp, kind,
+  model/tool, tokens, `cost_usd`, optional `label`/`reserved`) — and `push_ledger`
+  **validates every line, rejecting any field outside that schema**, so no prompts,
+  content, or identifiers can leave even from a hand-supplied ledger. Your key
+  travels in the `Authorization` header; redirects are refused so key + ledger
+  can't be re-sent to an unapproved host. `disable_sync()` revokes it.
   Budget, not balance: it reports what you already spent for coverage/attribution;
   it moves no money. New: `push_ledger()`, `LedgerSyncError`, the `floe-guard` CLI
   (`[project.scripts]`). (JS parity + the server ingest endpoint land separately.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.17.0
+
+### Added (py)
+
+- **Opt-in ledger sync → Reconcile Mode / Coverage Score.** A new **explicit,
+  off-by-default** way to push your local spend ledger to Floe so **Coverage
+  Score** can count spend the gateway never routed (BYOK / self-hosted /
+  off-path): `guard.enable_sync(api_key=…)` then `guard.sync()` (programmatic), or
+  `floe-guard push ledger.jsonl` (CLI). **Zero-telemetry stays the default** —
+  nothing leaves the process without the explicit opt-in *and* an explicit send;
+  there is no implicit enablement and no background send (asserted in tests:
+  `urlopen` is never called for a guard that hasn't opted in). What leaves is
+  **exactly the `export_log()` JSONL** — priced spend events (timestamp, kind,
+  model/tool, tokens, `cost_usd`, optional `label`/`reserved`), **no prompts, no
+  content, no identifiers** beyond a `label` you set. `disable_sync()` revokes it.
+  Budget, not balance: it reports what you already spent for coverage/attribution;
+  it moves no money. New: `push_ledger()`, `LedgerSyncError`, the `floe-guard` CLI
+  (`[project.scripts]`). (JS parity + the server ingest endpoint land separately.)
+
 ## Unreleased — py 0.16.2
 
 ### Fixed (py)

--- a/README.md
+++ b/README.md
@@ -959,13 +959,49 @@ metrics, no "zero defaults" claims — it's a free local stop, not a vault.
 ## No telemetry
 
 floe-guard does **not** phone home. It sends no usage events, no install pings,
-no identifiers — nothing leaves your process at runtime except hosted-budget
-reads you explicitly opt into by setting `FLOE_API_KEY` (the
-[hosted Floe](#when-you-outgrow-local-guardrails) path) — never otherwise.
+no identifiers — nothing leaves your process at runtime except **two things you
+explicitly opt into**: hosted-budget reads (set `FLOE_API_KEY` / use
+[`from_floe`](#one-line-to-hosted)) and [ledger sync](#sync-your-ledger-for-coverage-score-opt-in)
+(`enable_sync()` / `floe-guard push`). Never otherwise, and never in the
+background.
 
 This is a choice, not an oversight. A guardrail's whole value is trust: a
 library that silently exfiltrates usage from people's agents is the opposite of
 a tool you hand a budget to.
+
+## Sync your ledger for Coverage Score (opt-in)
+
+Floe's gateway can't see spend it never routed — BYOK, self-hosted, or off-path
+LLM/tool calls. **Ledger sync** is the opt-in that closes that gap: it pushes your
+local spend ledger into Floe's Reconcile Mode so your **Coverage Score** (the
+share of your agent's spend Floe can actually enforce) becomes computable for
+off-path spend. Budget, not balance — it reports what you *already spent* for
+coverage and attribution; it moves no money and changes no wallet balance.
+
+**Off by default, always.** Two explicit steps — opt in, then send — and no
+background send ever:
+
+```python
+guard.enable_sync(api_key="floe_…")   # opt in (read_write agent key). Sends nothing yet.
+...                                    # run your agent; spend accrues on the guard
+n = guard.sync()                       # THE send — POSTs export_log() now; returns events accepted
+guard.disable_sync()                   # revoke; the guard sends nothing after this
+```
+
+Or one-shot from a saved ledger:
+
+```bash
+floe-guard push ledger.jsonl --key floe_…   # or: your_export_log_producer | floe-guard push
+```
+
+**Exactly what leaves your process** is the [`export_log()`](#per-call-spend-log)
+JSONL — one line per priced spend event: `timestamp`, `kind` (`llm`/`tool`),
+`model_or_tool`, `prompt_tokens`, `completion_tokens`, `cost_usd`, and the
+optional `label` / `reserved` you set. **No prompts, no message content, no
+identifiers** beyond a `label` you choose. Re-syncing is safe — the server is
+idempotent, so already-ingested events aren't double-counted. A guard that never
+called `enable_sync()` never sends (a `sync()` on it raises, with zero network) —
+the [no-telemetry](#no-telemetry) default holds.
 
 ## When you outgrow local guardrails
 

--- a/README.md
+++ b/README.md
@@ -994,14 +994,18 @@ Or one-shot from a saved ledger:
 floe-guard push ledger.jsonl --key floe_…   # or: your_export_log_producer | floe-guard push
 ```
 
-**Exactly what leaves your process** is the [`export_log()`](#per-call-spend-log)
-JSONL — one line per priced spend event: `timestamp`, `kind` (`llm`/`tool`),
+**The request body is exactly the [`export_log()`](#per-call-spend-log) JSONL** —
+one line per priced spend event: `timestamp`, `kind` (`llm`/`tool`),
 `model_or_tool`, `prompt_tokens`, `completion_tokens`, `cost_usd`, and the
 optional `label` / `reserved` you set. **No prompts, no message content, no
-identifiers** beyond a `label` you choose. Re-syncing is safe — the server is
-idempotent, so already-ingested events aren't double-counted. A guard that never
-called `enable_sync()` never sends (a `sync()` on it raises, with zero network) —
-the [no-telemetry](#no-telemetry) default holds.
+identifiers** beyond a `label` you choose — and it's *enforced*, not just
+promised: `push_ledger` validates every line and refuses any record with a field
+outside that schema, so nothing extra can leave even from a hand-edited ledger.
+Your key rides the `Authorization` header, and redirects are refused so neither
+key nor ledger can be re-sent to an unapproved host. Re-syncing is safe — the sync
+endpoint is idempotent by design, so already-ingested events aren't
+double-counted. A guard that never called `enable_sync()` never sends (a `sync()`
+on it raises, with zero network) — the [no-telemetry](#no-telemetry) default holds.
 
 ## When you outgrow local guardrails
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.16.2"
+version = "0.17.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -40,6 +40,9 @@ gemini = ["google-genai>=1.0"]
 pipecat = ["pipecat-ai>=1.0"]
 livekit = ["livekit-agents>=1.0"]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
+
+[project.scripts]
+floe-guard = "floe_guard.__main__:main"
 
 [project.urls]
 Homepage = "https://floelabs.xyz"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -24,6 +24,7 @@ from .errors import (
     DeadlineExceeded,
     FloeGuardError,
     HostedEnforcementError,
+    LedgerSyncError,
     TokenBudgetExceeded,
     UnpriceableModelError,
     UnpriceableModelWarning,
@@ -42,6 +43,7 @@ from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
+from .sync import push_ledger
 from .voice_pricing import (
     VoiceRate,
     lookup_voice_rate,
@@ -92,5 +94,7 @@ __all__ = [
     "price_voice_leg",
     "hosted_enforcement_available",
     "hosted_remaining_usd",
+    "push_ledger",
+    "LedgerSyncError",
     "gates",
 ]

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -1,0 +1,75 @@
+"""floe-guard CLI.
+
+One command today: ``floe-guard push`` — the **opt-in** ledger sync. It reads an
+:meth:`~floe_guard.BudgetGuard.export_log` JSONL ledger (from a file or stdin) and
+POSTs it to Floe's Reconcile Mode so your **Coverage Score** can count spend the
+gateway never routed (BYOK / self-hosted / off-path). Nothing runs on import or in
+the background — ``push`` is a one-shot send you invoke, with your key. Zero
+telemetry otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from .errors import LedgerSyncError
+from .sync import push_ledger
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="floe-guard", description="floe-guard CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    push = sub.add_parser(
+        "push",
+        help="Opt-in: push an export_log() JSONL ledger to Floe Reconcile Mode (Coverage Score).",
+        description=(
+            "Push a floe-guard export_log() JSONL ledger to Floe's Reconcile Mode. "
+            "Opt-in and explicit — it sends only the priced spend events in the ledger "
+            "(no prompts, no content), only with your key. Budget, not balance."
+        ),
+    )
+    push.add_argument(
+        "ledger",
+        nargs="?",
+        default="-",
+        help="Ledger JSONL file (export_log() output). Omit or '-' to read stdin.",
+    )
+    push.add_argument(
+        "--key",
+        default=None,
+        help="Floe agent key (floe_<hex>, read_write). Defaults to $FLOE_API_KEY.",
+    )
+    push.add_argument(
+        "--base-url",
+        default=None,
+        help="API base URL. Defaults to $FLOE_API_BASE_URL, else the production host.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "push":
+        try:
+            if args.ledger == "-":
+                jsonl = sys.stdin.read()
+            else:
+                with open(args.ledger, encoding="utf-8") as fh:
+                    jsonl = fh.read()
+        except OSError as exc:
+            print(f"floe-guard push: cannot read {args.ledger!r}: {exc}", file=sys.stderr)
+            return 1
+        try:
+            n = push_ledger(jsonl, args.key, base_url=args.base_url)
+        except LedgerSyncError as exc:
+            print(f"floe-guard push failed: {exc}", file=sys.stderr)
+            return 1
+        print(f"Synced {n} spend event(s) to Floe Reconcile Mode.")
+        return 0
+
+    return 2  # unreachable: subparser is required
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/floe_guard/errors.py
+++ b/src/floe_guard/errors.py
@@ -127,6 +127,17 @@ class HostedEnforcementError(FloeGuardError):
     """
 
 
+class LedgerSyncError(FloeGuardError):
+    """Raised when an **opt-in** ledger sync to Reconcile Mode fails.
+
+    Covers a missing API key, a non-2xx response (401 bad/missing key, 403 agent
+    closed/suspended), a network/timeout failure, or a malformed response. Sync is
+    off by default and only runs when the caller explicitly opts in
+    (:meth:`~floe_guard.BudgetGuard.enable_sync` / ``floe-guard push``) — this error
+    never fires for a guard that hasn't opted in, because such a guard never sends.
+    """
+
+
 class UnpriceableModelWarning(UserWarning):
     """Warned (loudly) whenever an unpriceable model is seen.
 

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -948,17 +948,23 @@ class BudgetGuard:
 
         Revoke: :meth:`disable_sync` turns it back off; the guard sends nothing after.
         """
-        self._sync_enabled = True
-        self._sync_key = api_key
-        self._sync_base = base_url
+        with self._lock:
+            self._sync_enabled = True
+            self._sync_key = api_key
+            self._sync_base = base_url
 
     def disable_sync(self) -> None:
         """Turn ledger sync back off (revoke the opt-in). The guard sends nothing
         after this; :meth:`sync` will raise until :meth:`enable_sync` is called again.
+
+        Thread-safe against a concurrent :meth:`sync`: once this returns, no new
+        upload can start (a ``sync`` that already snapshotted the key while enabled
+        may finish, but one starting after sees the revoked state and raises).
         """
-        self._sync_enabled = False
-        self._sync_key = None
-        self._sync_base = None
+        with self._lock:
+            self._sync_enabled = False
+            self._sync_key = None
+            self._sync_base = None
 
     def sync(self) -> int:
         """Push the current spend ledger to Reconcile Mode; return events accepted.
@@ -973,14 +979,20 @@ class BudgetGuard:
             RuntimeError: sync was not enabled (call :meth:`enable_sync` first).
             LedgerSyncError: the opt-in send failed (missing key, non-2xx, network).
         """
-        if not self._sync_enabled:
-            raise RuntimeError(
-                "ledger sync is not enabled — call guard.enable_sync(api_key=…) first. "
-                "Sync is opt-in and off by default (zero-telemetry)."
-            )
+        # Snapshot opt-in state + key atomically: a concurrent disable_sync() can't
+        # clear the key mid-call (which would silently fall back to $FLOE_API_KEY) or
+        # let an upload start after revocation. A disable happens-before (we raise) or
+        # happens-after (we send the key we snapshotted while still enabled).
+        with self._lock:
+            if not self._sync_enabled:
+                raise RuntimeError(
+                    "ledger sync is not enabled — call guard.enable_sync(api_key=…) "
+                    "first. Sync is opt-in and off by default (zero-telemetry)."
+                )
+            key, base = self._sync_key, self._sync_base
         from .sync import push_ledger
 
-        return push_ledger(self.export_log(), self._sync_key, base_url=self._sync_base)
+        return push_ledger(self.export_log(), key, base_url=base)
 
     @contextmanager
     def step(

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -338,6 +338,11 @@ class BudgetGuard:
         # Wall-clock start of this guard's spend window, for the $/min burn rate
         # (advisory().burn_rate_usd_per_min). One guard per call/turn ⇒ per-call rate.
         self._created_time = time.time()
+        # Opt-in ledger sync — OFF by default (zero-telemetry). No key is stored and
+        # nothing is ever sent until enable_sync() is called; see enable_sync()/sync().
+        self._sync_enabled = False
+        self._sync_key: str | None = None
+        self._sync_base: str | None = None
         self.spent_usd = 0.0
         # Costs of the most recent priced LLM call and tool call, tracked
         # SEPARATELY: the default next-call prediction is the max of the two, so
@@ -918,6 +923,64 @@ class BudgetGuard:
             f"{json.dumps(event.to_dict(), separators=(',', ':'), ensure_ascii=False)}\n"
             for event in self.spend_log
         )
+
+    def enable_sync(self, api_key: str | None = None, *, base_url: str | None = None) -> None:
+        """**Opt in** to pushing this guard's ledger to Floe's Reconcile Mode.
+
+        Off by default — this is the *only* way to turn sync on, and it turns on
+        nothing else: it stores your key/endpoint and does **not** send. Nothing
+        leaves the process until you call :meth:`sync` (or ``floe-guard push``).
+        Zero-telemetry stays the default; there is no background send.
+
+        Why: Floe's gateway can't see spend it never routed (BYOK, self-hosted,
+        off-path). Syncing your local ledger is what makes that spend — and your
+        **Coverage Score** — visible. Budget, not balance: it reports what you
+        already spent for coverage/attribution; it moves no money.
+
+        What will leave the process when you call :meth:`sync`: exactly the
+        :meth:`export_log` JSONL (priced spend events — no prompts, no content, no
+        identifiers beyond a ``label`` you set).
+
+        Args:
+            api_key: Floe agent key (``floe_<hex>``, ``read_write``). Defaults to
+                the ``FLOE_API_KEY`` env var at :meth:`sync` time.
+            base_url: API base. Defaults to ``FLOE_API_BASE_URL``, else production.
+
+        Revoke: :meth:`disable_sync` turns it back off; the guard sends nothing after.
+        """
+        self._sync_enabled = True
+        self._sync_key = api_key
+        self._sync_base = base_url
+
+    def disable_sync(self) -> None:
+        """Turn ledger sync back off (revoke the opt-in). The guard sends nothing
+        after this; :meth:`sync` will raise until :meth:`enable_sync` is called again.
+        """
+        self._sync_enabled = False
+        self._sync_key = None
+        self._sync_base = None
+
+    def sync(self) -> int:
+        """Push the current spend ledger to Reconcile Mode; return events accepted.
+
+        Requires :meth:`enable_sync` first — this is the explicit send, the only
+        thing that transmits the ledger. Raises if sync isn't enabled (so a guard
+        that never opted in can never send). An empty ledger is a no-op (``0``, no
+        network). Re-syncing is safe: the server is idempotent, so already-ingested
+        events are not double-counted.
+
+        Raises:
+            RuntimeError: sync was not enabled (call :meth:`enable_sync` first).
+            LedgerSyncError: the opt-in send failed (missing key, non-2xx, network).
+        """
+        if not self._sync_enabled:
+            raise RuntimeError(
+                "ledger sync is not enabled — call guard.enable_sync(api_key=…) first. "
+                "Sync is opt-in and off by default (zero-telemetry)."
+            )
+        from .sync import push_ledger
+
+        return push_ledger(self.export_log(), self._sync_key, base_url=self._sync_base)
 
     @contextmanager
     def step(

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -26,6 +26,7 @@ coverage/attribution; it does not move money or change any wallet balance.
 from __future__ import annotations
 
 import json
+import math
 import os
 import urllib.error
 import urllib.parse
@@ -37,6 +38,107 @@ FLOE_API_KEY_ENV = "FLOE_API_KEY"
 FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
 DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
 LEDGER_SYNC_PATH = "/v1/agents/ledger/sync"
+
+# The ONLY keys allowed to leave the process — the export_log() schema. Enforced
+# (not just documented) below: a line carrying anything else is rejected, so a
+# hand-supplied file can't smuggle prompts / content / identifiers past the
+# privacy contract.
+_ALLOWED_KEYS = frozenset(
+    {
+        "timestamp",
+        "kind",
+        "model_or_tool",
+        "prompt_tokens",
+        "completion_tokens",
+        "cost_usd",
+        "label",
+        "reserved",
+    }
+)
+_REQUIRED_KEYS = frozenset({"timestamp", "kind", "model_or_tool", "cost_usd"})
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects. urllib re-sends the request — including the
+    ``Authorization: Bearer`` key and the ledger body — across 301/302/303, so a
+    redirect could leak both to a host we never approved. Treat any 3xx as an error."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        raise LedgerSyncError(
+            f"Refusing to follow an HTTP {code} redirect to {newurl!r} — the ledger "
+            "and API key must not leave the approved https origin."
+        )
+
+
+# One opener that never redirects (see _NoRedirect). Stateless; safe to share.
+_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
+def _validate_ledger(jsonl: str) -> None:
+    """Parse and validate every ledger line against the ``export_log()`` schema.
+
+    Raises :class:`LedgerSyncError` on the first malformed / unknown-field / invalid
+    record, **before** anything is sent — so only priced spend events ever leave the
+    process, even when the ledger came from a hand-edited file or the CLI. This is
+    the privacy contract *enforced*, not merely asserted.
+    """
+    for i, raw in enumerate(jsonl.splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (ValueError, TypeError) as exc:
+            raise LedgerSyncError(f"Ledger line {i} is not valid JSON: {exc}") from exc
+        if not isinstance(event, dict):
+            raise LedgerSyncError(f"Ledger line {i} is not a JSON object.")
+        extra = set(event) - _ALLOWED_KEYS
+        if extra:
+            raise LedgerSyncError(
+                f"Ledger line {i} has fields outside the export_log() schema: "
+                f"{sorted(extra)}. Only priced spend events may be synced — no prompts, "
+                "content, or identifiers."
+            )
+        missing = _REQUIRED_KEYS - set(event)
+        if missing:
+            raise LedgerSyncError(
+                f"Ledger line {i} is missing required field(s): {sorted(missing)}."
+            )
+        if event["kind"] not in ("llm", "tool"):
+            raise LedgerSyncError(
+                f"Ledger line {i}: kind must be 'llm' or 'tool', got {event['kind']!r}."
+            )
+        if not isinstance(event["model_or_tool"], str):
+            raise LedgerSyncError(f"Ledger line {i}: model_or_tool must be a string.")
+        cost = event["cost_usd"]
+        if (
+            isinstance(cost, bool)
+            or not isinstance(cost, (int, float))
+            or not math.isfinite(cost)
+            or cost < 0
+        ):
+            raise LedgerSyncError(
+                f"Ledger line {i}: cost_usd must be a finite, non-negative number, got {cost!r}."
+            )
+        ts = event["timestamp"]
+        if isinstance(ts, bool) or not isinstance(ts, (int, float)) or not math.isfinite(ts):
+            raise LedgerSyncError(
+                f"Ledger line {i}: timestamp must be a finite number, got {ts!r}."
+            )
+        for field in ("prompt_tokens", "completion_tokens"):
+            value = event.get(field)
+            if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+                raise LedgerSyncError(f"Ledger line {i}: {field} must be an integer or null.")
+        if "label" in event and not isinstance(event["label"], str):
+            raise LedgerSyncError(f"Ledger line {i}: label must be a string.")
+        if "reserved" in event:
+            reserved = event["reserved"]
+            if (
+                isinstance(reserved, bool)
+                or not isinstance(reserved, (int, float))
+                or not math.isfinite(reserved)
+            ):
+                raise LedgerSyncError(f"Ledger line {i}: reserved must be a finite number.")
 
 
 def push_ledger(
@@ -66,6 +168,10 @@ def push_ledger(
     # An empty ledger never touches the network — nothing to send.
     if not jsonl.strip():
         return 0
+
+    # Enforce the privacy contract BEFORE any network: only export_log() events —
+    # no prompts, content, or identifiers — may leave, even from a hand-supplied file.
+    _validate_ledger(jsonl)
 
     key = (api_key or os.environ.get(FLOE_API_KEY_ENV, "")).strip()
     if not key:
@@ -98,7 +204,9 @@ def push_ledger(
     )
 
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        # _OPENER refuses redirects (see _NoRedirect) so the key/ledger can't be
+        # re-sent to an unapproved host.
+        with _OPENER.open(request, timeout=timeout) as response:
             body = response.read()
     except urllib.error.HTTPError as exc:
         raise LedgerSyncError(_describe_http_error(exc)) from exc
@@ -113,12 +221,14 @@ def push_ledger(
     if not isinstance(payload, dict):
         raise LedgerSyncError(f"Unexpected response shape from Floe at {url}.")
     # "synced" is the count the server accepted (new rows); "duplicates" (already
-    # ingested, idempotent) are not counted here. Absent → 0.
-    synced = payload.get("synced", 0)
-    try:
-        return int(synced)
-    except (ValueError, TypeError):
+    # ingested, idempotent) are not counted here. Absent → 0; present must be a real
+    # non-negative int (reject bool/float/negative/garbage rather than coerce).
+    synced = payload.get("synced")
+    if synced is None:
         return 0
+    if isinstance(synced, bool) or not isinstance(synced, int) or synced < 0:
+        raise LedgerSyncError(f"Invalid 'synced' count from Floe at {url}: {synced!r}.")
+    return synced
 
 
 def _describe_http_error(exc: urllib.error.HTTPError) -> str:

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -1,0 +1,139 @@
+"""Opt-in ledger sync — push the local spend ledger to Floe's Reconcile Mode.
+
+**Zero-telemetry is the default, and stays the default.** Nothing in this module
+runs unless the caller *explicitly* opts in with a Floe API key — via
+:meth:`~floe_guard.BudgetGuard.enable_sync` + :meth:`~floe_guard.BudgetGuard.sync`,
+or the ``floe-guard push`` CLI. There is no implicit enablement and no background
+send: the ledger leaves your process only when you call one of those. Your ledger,
+your key, your choice.
+
+**Why sync at all.** Floe's gateway can't see spend it never routed — BYOK,
+self-hosted, or off-path LLM/tool calls. Pushing your local ledger into Reconcile
+Mode is how that spend lands on the ledger and your **Coverage Score** becomes
+computable. Budget, not balance: this reports *what you already spent* for
+coverage/attribution; it does not move money or change any wallet balance.
+
+**What leaves the process — exactly the** :meth:`~floe_guard.BudgetGuard.export_log`
+**JSONL** and nothing else: one line per spend event, each a priced-cost record —
+``timestamp``, ``kind`` (``"llm"``/``"tool"``), ``model_or_tool``,
+``prompt_tokens``, ``completion_tokens``, ``cost_usd``, and the optional ``label``
+/ ``reserved`` you set. **No prompts, no message content, no identifiers** beyond a
+``label`` you choose.
+
+    Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .errors import LedgerSyncError
+
+FLOE_API_KEY_ENV = "FLOE_API_KEY"
+FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
+DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
+LEDGER_SYNC_PATH = "/v1/agents/ledger/sync"
+
+
+def push_ledger(
+    jsonl: str,
+    api_key: str | None = None,
+    *,
+    base_url: str | None = None,
+    timeout: float = 30.0,
+) -> int:
+    """POST an :meth:`~floe_guard.BudgetGuard.export_log` JSONL ledger to Reconcile
+    Mode and return the number of events the server accepted.
+
+    This is the ONLY function that sends the ledger, and it sends only when called.
+    An empty ledger is a no-op (returns ``0`` without any network call).
+
+    Args:
+        jsonl: the ledger as newline-delimited JSON — ``export_log()`` output.
+        api_key: Floe agent key (``floe_<hex>``, ``read_write``). Defaults to the
+            ``FLOE_API_KEY`` env var.
+        base_url: API base. Defaults to ``FLOE_API_BASE_URL``, else the prod host.
+        timeout: socket timeout in seconds.
+
+    Raises:
+        LedgerSyncError: missing key, a non-2xx response, network/timeout, or a
+            malformed response body.
+    """
+    # An empty ledger never touches the network — nothing to send.
+    if not jsonl.strip():
+        return 0
+
+    key = (api_key or os.environ.get(FLOE_API_KEY_ENV, "")).strip()
+    if not key:
+        raise LedgerSyncError(
+            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV}. "
+            "Sync is opt-in and needs your key."
+        )
+
+    env_base = os.environ.get(FLOE_API_BASE_URL_ENV, "").strip()
+    base = ((base_url or "").strip() or env_base or DEFAULT_BASE_URL).rstrip("/")
+    parsed = urllib.parse.urlparse(base)
+    if parsed.scheme != "https" or not parsed.netloc:
+        # The request carries the Floe agent key as a bearer token AND your spend
+        # ledger — never send either over a non-https or malformed URL.
+        raise LedgerSyncError(
+            f"Refusing to send the ledger to {base!r}: "
+            "the base URL must be an https:// URL with a host."
+        )
+    url = f"{base}{LEDGER_SYNC_PATH}"
+
+    request = urllib.request.Request(
+        url,
+        data=jsonl.encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/x-ndjson",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        raise LedgerSyncError(_describe_http_error(exc)) from exc
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        raise LedgerSyncError(f"Could not reach Floe at {url}: {exc}") from exc
+
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError) as exc:
+        raise LedgerSyncError(f"Malformed JSON from Floe at {url}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise LedgerSyncError(f"Unexpected response shape from Floe at {url}.")
+    # "synced" is the count the server accepted (new rows); "duplicates" (already
+    # ingested, idempotent) are not counted here. Absent → 0.
+    synced = payload.get("synced", 0)
+    try:
+        return int(synced)
+    except (ValueError, TypeError):
+        return 0
+
+
+def _describe_http_error(exc: urllib.error.HTTPError) -> str:
+    detail = ""
+    try:
+        data = json.loads(exc.read())
+        if isinstance(data, dict) and isinstance(data.get("error"), str):
+            detail = f" ({data['error']})"
+    except Exception:
+        pass
+    if exc.code == 401:
+        return f"Floe rejected the API key (401 unauthorized){detail}."
+    if exc.code == 403:
+        return (
+            f"Floe refused the sync (403 forbidden){detail} — the agent may be "
+            "closed/suspended, or the key is read-only (a read_write key is required)."
+        )
+    return f"Floe returned HTTP {exc.code}{detail}."

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -1,7 +1,7 @@
 """Opt-in ledger sync — zero-telemetry stays the default.
 
 The load-bearing test here is that a guard which never opted in makes **zero**
-network calls, ever (``urllib.request.urlopen`` is asserted un-called). Sync sends
+network calls, ever (``floe_guard.sync._OPENER.open`` is asserted un-called). Sync sends
 only the ``export_log()`` JSONL, only under the explicit flag, only with a key.
 """
 
@@ -27,6 +27,9 @@ _LEDGER_KEYS = {
     "reserved",
 }
 
+# One schema-valid ledger line, for tests isolating the key/https/network paths.
+_ONE_EVENT = '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.01}\n'
+
 
 def _ok(payload: dict[str, object]) -> mock.MagicMock:
     resp = mock.MagicMock()
@@ -49,7 +52,7 @@ def test_no_network_without_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
     # A full guard lifecycle with NO enable_sync must never touch the network,
     # and sync() must raise (not silently send) — the zero-telemetry default.
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         guard = BudgetGuard(limit_usd=10.0)
         guard.record_tool("api", 0.05)
         guard.record("gpt-4o", 1200, 350)
@@ -64,7 +67,7 @@ def test_disable_sync_revokes_no_network() -> None:
     guard = _guard_with_spend()
     guard.enable_sync(api_key="floe_abc")
     guard.disable_sync()
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         with pytest.raises(RuntimeError, match="not enabled"):
             guard.sync()
     urlopen.assert_not_called()
@@ -73,7 +76,7 @@ def test_disable_sync_revokes_no_network() -> None:
 def test_empty_ledger_syncs_nothing_no_network() -> None:
     guard = BudgetGuard(limit_usd=10.0)  # no spend recorded
     guard.enable_sync(api_key="floe_abc")
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         assert guard.sync() == 0
     urlopen.assert_not_called()
 
@@ -84,7 +87,7 @@ def test_empty_ledger_syncs_nothing_no_network() -> None:
 def test_sync_posts_export_log_under_key() -> None:
     guard = _guard_with_spend()
     guard.enable_sync(api_key="floe_abc")
-    with mock.patch("urllib.request.urlopen", return_value=_ok({"synced": 1})) as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 1})) as urlopen:
         assert guard.sync() == 1
     request = urlopen.call_args.args[0]
     assert request.get_header("Authorization") == "Bearer floe_abc"
@@ -99,7 +102,7 @@ def test_sync_posts_export_log_under_key() -> None:
 
 def test_sync_requires_enable_first_no_network() -> None:
     guard = _guard_with_spend()
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         with pytest.raises(RuntimeError, match="enable_sync"):
             guard.sync()
     urlopen.assert_not_called()
@@ -110,14 +113,14 @@ def test_sync_requires_enable_first_no_network() -> None:
 
 def test_push_ledger_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         with pytest.raises(LedgerSyncError, match="No Floe API key"):
-            push_ledger('{"cost_usd":0.01}\n')
+            push_ledger(_ONE_EVENT)
     urlopen.assert_not_called()
 
 
 def test_push_ledger_empty_is_noop_no_network() -> None:
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         assert push_ledger("   ") == 0
     urlopen.assert_not_called()
 
@@ -128,9 +131,9 @@ def test_push_ledger_empty_is_noop_no_network() -> None:
 )
 def test_push_ledger_refuses_non_https(bad_base: str) -> None:
     # The request carries the key AND the ledger — never over a non-https/bad URL.
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         with pytest.raises(LedgerSyncError, match="https"):
-            push_ledger('{"cost_usd":0.01}\n', api_key="floe_abc", base_url=bad_base)
+            push_ledger(_ONE_EVENT, api_key="floe_abc", base_url=bad_base)
     urlopen.assert_not_called()
 
 
@@ -143,9 +146,9 @@ def test_push_ledger_http_error_raises(code: int, needle: str) -> None:
         None,  # type: ignore[arg-type]
         io.BytesIO(b'{"error":"x"}'),
     )
-    with mock.patch("urllib.request.urlopen", side_effect=err):
+    with mock.patch("floe_guard.sync._OPENER.open", side_effect=err):
         with pytest.raises(LedgerSyncError, match=needle):
-            push_ledger('{"cost_usd":0.01}\n', api_key="floe_abc")
+            push_ledger(_ONE_EVENT, api_key="floe_abc")
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -159,7 +162,7 @@ def test_cli_push_reads_file_and_posts(tmp_path) -> None:  # type: ignore[no-unt
         '{"timestamp":1.0,"kind":"tool","model_or_tool":"api",'
         '"prompt_tokens":null,"completion_tokens":null,"cost_usd":0.05}\n'
     )
-    with mock.patch("urllib.request.urlopen", return_value=_ok({"synced": 1})) as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 1})) as urlopen:
         rc = main(["push", str(ledger), "--key", "floe_abc"])
     assert rc == 0
     assert urlopen.call_args.args[0].get_header("Authorization") == "Bearer floe_abc"
@@ -171,7 +174,82 @@ def test_cli_push_no_key_returns_1_no_network(tmp_path, monkeypatch: pytest.Monk
     monkeypatch.delenv("FLOE_API_KEY", raising=False)
     ledger = tmp_path / "ledger.jsonl"
     ledger.write_text('{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.05}\n')
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         rc = main(["push", str(ledger)])  # non-empty ledger, no key → LedgerSyncError → rc 1
     assert rc == 1
     urlopen.assert_not_called()
+
+
+# ── privacy contract enforced: validate every record before upload ────────────
+
+
+def test_push_ledger_rejects_smuggled_field_no_network() -> None:
+    # A non-schema field (e.g. a prompt) is refused BEFORE any network — the
+    # privacy contract is enforced, not just documented.
+    bad = (
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.01,"prompt":"secret"}\n'
+    )
+    with mock.patch("floe_guard.sync._OPENER.open") as opener:
+        with pytest.raises(LedgerSyncError, match="outside the export_log"):
+            push_ledger(bad, api_key="floe_abc")
+    opener.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_line",
+    [
+        '{"kind":"tool","model_or_tool":"api","cost_usd":0.01}',  # missing timestamp
+        '{"timestamp":1.0,"kind":"bogus","model_or_tool":"api","cost_usd":0.01}',  # bad kind
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":-1}',  # negative cost
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":"x"}',  # non-numeric cost
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":123,"cost_usd":0.01}',  # non-str model
+        "not json at all",  # malformed
+    ],
+)
+def test_push_ledger_rejects_bad_schema_no_network(bad_line: str) -> None:
+    with mock.patch("floe_guard.sync._OPENER.open") as opener:
+        with pytest.raises(LedgerSyncError):
+            push_ledger(bad_line + "\n", api_key="floe_abc")
+    opener.assert_not_called()
+
+
+def test_no_redirect_handler_refuses() -> None:
+    # urllib would re-send the key + ledger across a redirect; the handler refuses.
+    from floe_guard.sync import _NoRedirect
+
+    with pytest.raises(LedgerSyncError, match="redirect"):
+        _NoRedirect().redirect_request(None, None, 302, "Found", {}, "https://evil.example.com/x")
+
+
+# ── response count validation ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad_synced", [-1, True, "5", 1.9])
+def test_invalid_synced_count_raises(bad_synced: object) -> None:
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_abc")
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": bad_synced})):
+        with pytest.raises(LedgerSyncError, match="Invalid 'synced'"):
+            guard.sync()
+
+
+def test_synced_absent_returns_zero() -> None:
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_abc")
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"duplicates": 1})):
+        assert guard.sync() == 0
+
+
+# ── concurrency: sync uses the snapshotted key, not an env fallback ───────────
+
+
+def test_sync_uses_snapshotted_key_not_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even with a different key in the env, sync() sends the key it was enabled
+    # with (snapshotted under the lock) — a concurrent disable can't cause an
+    # env-fallback send.
+    monkeypatch.setenv("FLOE_API_KEY", "floe_env_MUST_NOT_be_used")
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_explicit")
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 1})) as opener:
+        guard.sync()
+    assert opener.call_args.args[0].get_header("Authorization") == "Bearer floe_explicit"

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -1,0 +1,177 @@
+"""Opt-in ledger sync — zero-telemetry stays the default.
+
+The load-bearing test here is that a guard which never opted in makes **zero**
+network calls, ever (``urllib.request.urlopen`` is asserted un-called). Sync sends
+only the ``export_log()`` JSONL, only under the explicit flag, only with a key.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest import mock
+
+import pytest
+
+from floe_guard import BudgetGuard, LedgerSyncError, push_ledger
+
+_LEDGER_KEYS = {
+    "timestamp",
+    "kind",
+    "model_or_tool",
+    "prompt_tokens",
+    "completion_tokens",
+    "cost_usd",
+    "label",
+    "reserved",
+}
+
+
+def _ok(payload: dict[str, object]) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.read.return_value = json.dumps(payload).encode()
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def _guard_with_spend() -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=10.0)
+    guard.record_tool("api", 0.05)  # exactly one ledger event
+    return guard
+
+
+# ── AC1: zero egress without opt-in ───────────────────────────────────────────
+
+
+def test_no_network_without_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A full guard lifecycle with NO enable_sync must never touch the network,
+    # and sync() must raise (not silently send) — the zero-telemetry default.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        guard = BudgetGuard(limit_usd=10.0)
+        guard.record_tool("api", 0.05)
+        guard.record("gpt-4o", 1200, 350)
+        _ = guard.advisory()
+        _ = guard.export_log()
+        with pytest.raises(RuntimeError, match="not enabled"):
+            guard.sync()
+    urlopen.assert_not_called()
+
+
+def test_disable_sync_revokes_no_network() -> None:
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_abc")
+    guard.disable_sync()
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(RuntimeError, match="not enabled"):
+            guard.sync()
+    urlopen.assert_not_called()
+
+
+def test_empty_ledger_syncs_nothing_no_network() -> None:
+    guard = BudgetGuard(limit_usd=10.0)  # no spend recorded
+    guard.enable_sync(api_key="floe_abc")
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        assert guard.sync() == 0
+    urlopen.assert_not_called()
+
+
+# ── AC2: opt-in send is exactly export_log(), under the key ───────────────────
+
+
+def test_sync_posts_export_log_under_key() -> None:
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_abc")
+    with mock.patch("urllib.request.urlopen", return_value=_ok({"synced": 1})) as urlopen:
+        assert guard.sync() == 1
+    request = urlopen.call_args.args[0]
+    assert request.get_header("Authorization") == "Bearer floe_abc"
+    assert request.method == "POST"
+    assert request.full_url.endswith("/v1/agents/ledger/sync")
+    assert request.get_header("Content-type") == "application/x-ndjson"
+    # The body is EXACTLY export_log() — no prompts, no content, no extra fields.
+    assert request.data.decode("utf-8") == guard.export_log()
+    for line in guard.export_log().splitlines():
+        assert set(json.loads(line)) <= _LEDGER_KEYS
+
+
+def test_sync_requires_enable_first_no_network() -> None:
+    guard = _guard_with_spend()
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(RuntimeError, match="enable_sync"):
+            guard.sync()
+    urlopen.assert_not_called()
+
+
+# ── push_ledger fail-closed ───────────────────────────────────────────────────
+
+
+def test_push_ledger_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(LedgerSyncError, match="No Floe API key"):
+            push_ledger('{"cost_usd":0.01}\n')
+    urlopen.assert_not_called()
+
+
+def test_push_ledger_empty_is_noop_no_network() -> None:
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        assert push_ledger("   ") == 0
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "bad_base",
+    ["http://credit-api.floelabs.xyz", "file:///etc/passwd", "ftp://x", "not-a-url", "https://"],
+)
+def test_push_ledger_refuses_non_https(bad_base: str) -> None:
+    # The request carries the key AND the ledger — never over a non-https/bad URL.
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        with pytest.raises(LedgerSyncError, match="https"):
+            push_ledger('{"cost_usd":0.01}\n', api_key="floe_abc", base_url=bad_base)
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(("code", "needle"), [(401, "401"), (403, "403")])
+def test_push_ledger_http_error_raises(code: int, needle: str) -> None:
+    err = urllib.error.HTTPError(
+        "https://credit-api.floelabs.xyz/v1/agents/ledger/sync",
+        code,
+        "err",
+        None,  # type: ignore[arg-type]
+        io.BytesIO(b'{"error":"x"}'),
+    )
+    with mock.patch("urllib.request.urlopen", side_effect=err):
+        with pytest.raises(LedgerSyncError, match=needle):
+            push_ledger('{"cost_usd":0.01}\n', api_key="floe_abc")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_push_reads_file_and_posts(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from floe_guard.__main__ import main
+
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api",'
+        '"prompt_tokens":null,"completion_tokens":null,"cost_usd":0.05}\n'
+    )
+    with mock.patch("urllib.request.urlopen", return_value=_ok({"synced": 1})) as urlopen:
+        rc = main(["push", str(ledger), "--key", "floe_abc"])
+    assert rc == 0
+    assert urlopen.call_args.args[0].get_header("Authorization") == "Bearer floe_abc"
+
+
+def test_cli_push_no_key_returns_1_no_network(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:  # type: ignore[no-untyped-def]
+    from floe_guard.__main__ import main
+
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text('{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.05}\n')
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        rc = main(["push", str(ledger)])  # non-empty ledger, no key → LedgerSyncError → rc 1
+    assert rc == 1
+    urlopen.assert_not_called()

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -253,3 +253,34 @@ def test_sync_uses_snapshotted_key_not_env(monkeypatch: pytest.MonkeyPatch) -> N
     with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 1})) as opener:
         guard.sync()
     assert opener.call_args.args[0].get_header("Authorization") == "Bearer floe_explicit"
+
+
+def test_no_upload_starts_after_disable_returns() -> None:
+    # The disable_sync() ordering guarantee: once it returns, no NEW upload starts.
+    # An in-flight sync (started before disable) may finish; a sync after does not.
+    import threading
+
+    guard = _guard_with_spend()
+    guard.enable_sync(api_key="floe_abc")
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocking_open(request, timeout=None):  # type: ignore[no-untyped-def]
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait(timeout=5)
+        return _ok({"synced": 1})
+
+    with mock.patch("floe_guard.sync._OPENER.open", side_effect=blocking_open):
+        first = threading.Thread(target=guard.sync)
+        first.start()
+        assert started.wait(timeout=5)  # the first sync is now inside open()
+        guard.disable_sync()  # returns — no new upload may start after this
+        with pytest.raises(RuntimeError, match="not enabled"):
+            guard.sync()  # a NEW sync post-disable raises, with no second open()
+        assert calls == 1
+        release.set()
+        first.join(timeout=5)
+    assert calls == 1  # still just the one in-flight call


### PR DESCRIPTION
…0.17.0)

Explicit, off-by-default way to push the local spend ledger to Floe so Coverage Score can count spend the gateway never routed (BYOK/self-hosted/off-path).

- guard.enable_sync(api_key=…) opts in (stores key/endpoint, sends nothing); guard.sync() is THE send (POSTs export_log() JSONL now, returns count); disable_sync() revokes. floe-guard push CLI for a saved ledger.
- Zero-telemetry stays the DEFAULT: no send without the explicit opt-in AND an explicit sync; no background send. Tests assert urlopen is never called for a guard that hasn't opted in, and sync() on such a guard raises with no network.
- What leaves = exactly export_log() (8 priced-cost fields; no prompts, no content, no identifiers beyond a caller label). https-only, fail-closed.
- Budget, not balance: reports already-spent for coverage; moves no money.

New: sync.py (push_ledger), LedgerSyncError, floe_guard.__main__ + [project.scripts] floe-guard entry. Docs: README 'Sync your ledger for Coverage Score (opt-in)'. 16 new tests; full suite 384 passed, ruff clean. py 0.16.2 -> 0.17.0.

JS parity + the server ingest endpoint (POST /v1/agents/ledger/sync) land separately.

## Summary
Brief description of what this PR does.

## Changes
-

## Testing
How was this tested?

- [ ] `pytest` passes (Python changes)
- [ ] `ruff check .` and `ruff format .` are clean (Python changes)
- [ ] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [ ] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [ ] CHANGELOG.md updated (user-facing changes)

## Related issues
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional ledger synchronization with explicit opt-in and revocation controls.
  * Added the `floe-guard push` command for synchronizing exported spend events.
  * Added configurable authentication and API endpoints with clear synchronization error reporting.
  * Empty ledgers and disabled synchronization perform no network activity.
  * Added validation that limits synchronization to approved spend-event data and refuses redirects.

* **Documentation**
  * Documented setup, privacy safeguards, accepted data, and network behavior.
  * Updated the project version to 0.17.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->