### PR TITLE
feat(js): opt-in ledger sync (parity with the Python client)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,23 +46,32 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 - **Opt-in ledger sync — `BudgetGuard.enableSync()` / `disableSync()` / `sync()`
   + `pushLedger()`** (parity with the Python client). Pushes the guard's
-  `exportLog()` JSONL to Floe's Reconcile Mode (`POST /v1/agents/ledger/sync`,
-  `Content-Type: application/x-ndjson`, `Authorization: Bearer`) so BYOK /
-  self-hosted / off-path spend the gateway never routed still lands on the ledger
-  and your **Coverage Score** becomes computable. **Budget, not balance:** it
-  reports what you already spent for coverage/attribution; it moves no money and
-  changes no wallet balance.
+  `exportLog()` JSONL to Floe's Reconcile Mode (`POST /v1/agents/ledger/sync`) so
+  BYOK / self-hosted / off-path spend the gateway never routed still lands on the
+  ledger and your **Coverage Score** becomes computable. **Budget, not balance:**
+  it reports what you already spent for coverage/attribution; it moves no money
+  and changes no wallet balance. Re-syncing is safe — the sync endpoint is
+  idempotent by design (already-ingested events aren't double-counted).
   - **Zero-telemetry is preserved as the default.** Sync is OFF until you call
     `enableSync(apiKey)`, and even then nothing leaves the process until you call
     `sync()` — there is no implicit enablement and no background send. `sync()` on
     a guard that never opted in throws (no network); `disableSync()` revokes it.
+    `sync()` snapshots the opt-in key atomically before any `await`, so a racing
+    `disableSync()` can't cause a post-revocation send or an env-key fallback.
+  - **The request body is exactly `exportLog()`, validated.** Before any network,
+    every ledger line is checked against the `exportLog()` schema and **any
+    non-schema / unknown field is rejected** (`LedgerSyncError`) — a hand-supplied
+    file can't smuggle prompts, content, or identifiers past the privacy contract.
+    The key rides the `Authorization: Bearer` header (`Content-Type:
+    application/x-ndjson`).
   - **Fail-closed.** `pushLedger(jsonl, apiKey?, { baseUrl?, timeoutMs? })` (over
     `fetch`) refuses to send without a key (arg or `FLOE_API_KEY`) or over a
     non-https / malformed base URL — the key and ledger are never transmitted in
-    those cases — and throws `LedgerSyncError` on a non-2xx / network / malformed
-    response. An empty ledger is a no-op (`0`, no network). Only the priced spend
-    events leave the process — no prompts, no content, no identifiers beyond a
-    `label` you set. (The `floe-guard push` CLI stays Python-only for now.)
+    those cases — **refuses redirects** (`redirect: "error"`, so a 3xx can't
+    re-send the key/ledger to another host), and throws `LedgerSyncError` on a
+    non-2xx / network / malformed response or an invalid (non-integer / negative)
+    `synced` count. An empty ledger is a no-op (`0`, no network). (The `floe-guard
+    push` CLI stays Python-only for now.)
 
 ## Unreleased — js 0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,30 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   pre-turn hard-stop is bypassed until you re-`attach()`; `update_options` (same
   agent, swapped models) keeps the reserve hook.
 
+## Unreleased — js 0.13.0
+
+### Added (js)
+
+- **Opt-in ledger sync — `BudgetGuard.enableSync()` / `disableSync()` / `sync()`
+  + `pushLedger()`** (parity with the Python client). Pushes the guard's
+  `exportLog()` JSONL to Floe's Reconcile Mode (`POST /v1/agents/ledger/sync`,
+  `Content-Type: application/x-ndjson`, `Authorization: Bearer`) so BYOK /
+  self-hosted / off-path spend the gateway never routed still lands on the ledger
+  and your **Coverage Score** becomes computable. **Budget, not balance:** it
+  reports what you already spent for coverage/attribution; it moves no money and
+  changes no wallet balance.
+  - **Zero-telemetry is preserved as the default.** Sync is OFF until you call
+    `enableSync(apiKey)`, and even then nothing leaves the process until you call
+    `sync()` — there is no implicit enablement and no background send. `sync()` on
+    a guard that never opted in throws (no network); `disableSync()` revokes it.
+  - **Fail-closed.** `pushLedger(jsonl, apiKey?, { baseUrl?, timeoutMs? })` (over
+    `fetch`) refuses to send without a key (arg or `FLOE_API_KEY`) or over a
+    non-https / malformed base URL — the key and ledger are never transmitted in
+    those cases — and throws `LedgerSyncError` on a non-2xx / network / malformed
+    response. An empty ledger is a no-op (`0`, no network). Only the priced spend
+    events leave the process — no prompts, no content, no identifiers beyond a
+    `label` you set. (The `floe-guard push` CLI stays Python-only for now.)
+
 ## Unreleased — js 0.12.0
 
 ### Added (js)

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -128,6 +128,25 @@ export class UnpriceableVoiceError extends FloeGuardError {
 }
 
 /**
+ * Thrown when an **opt-in** ledger sync to Reconcile Mode fails.
+ *
+ * Covers a missing API key, a non-https/malformed base URL, a non-2xx response
+ * (401 bad/missing key, 403 agent closed/suspended), a network/timeout failure, or
+ * a malformed response. Sync is off by default and only runs when the caller
+ * explicitly opts in ({@link BudgetGuard.enableSync} + {@link BudgetGuard.sync}) —
+ * this error never fires for a guard that hasn't opted in, because such a guard
+ * never sends.
+ *
+ * Mirrors `LedgerSyncError` in `src/floe_guard/errors.py`.
+ */
+export class LedgerSyncError extends FloeGuardError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LedgerSyncError";
+  }
+}
+
+/**
  * Thrown before a call whose projected duration would blow the SLA.
  *
  * The latency twin of {@link BudgetExceeded}: `LatencyBudget.check()` throws this

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -684,15 +684,21 @@ export class BudgetGuard {
    * @throws {LedgerSyncError} the opt-in send failed (missing key, non-2xx, network).
    */
   async sync(): Promise<number> {
-    if (!this.syncEnabled) {
+    // Snapshot opt-in state + key/base synchronously, before any await: a
+    // disableSync() interleaved on a later microtask can't clear the key mid-call
+    // (which would silently fall back to $FLOE_API_KEY) or let an upload start
+    // after revocation. A disable happens-before (we throw) or happens-after (we
+    // send the key we captured while still enabled).
+    const enabled = this.syncEnabled;
+    const key = this.syncKey;
+    const base = this.syncBase;
+    if (!enabled) {
       throw new Error(
         "ledger sync is not enabled — call guard.enableSync(apiKey) first. " +
           "Sync is opt-in and off by default (zero-telemetry).",
       );
     }
-    return pushLedger(this.exportLog(), this.syncKey ?? undefined, {
-      baseUrl: this.syncBase ?? undefined,
-    });
+    return pushLedger(this.exportLog(), key ?? undefined, { baseUrl: base ?? undefined });
   }
 
   /**

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -24,6 +24,7 @@
  */
 
 import { BudgetExceeded, TokenBudgetExceeded, UnpriceableModelError } from "./errors.js";
+import { pushLedger } from "./sync.js";
 import {
   type ManualPrice,
   priceTokens,
@@ -239,6 +240,14 @@ export class BudgetGuard {
    * plain data instead of mutating the object's prototype.
    */
   private readonly toolCostTotals: Record<string, number> = Object.create(null);
+
+  /**
+   * Opt-in ledger sync — OFF by default (zero-telemetry). No key is stored and
+   * nothing is ever sent until enableSync() is called; see enableSync()/sync().
+   */
+  private syncEnabled = false;
+  private syncKey: string | null = null;
+  private syncBase: string | null = null;
 
   /**
    * @param limitUsd the spend ceiling, in USD. `0` blocks the very first call.
@@ -620,6 +629,70 @@ export class BudgetGuard {
         return `${JSON.stringify(row)}\n`;
       })
       .join("");
+  }
+
+  /**
+   * **Opt in** to pushing this guard's ledger to Floe's Reconcile Mode.
+   *
+   * Off by default — this is the *only* way to turn sync on, and it turns on
+   * nothing else: it stores your key/endpoint and does **not** send. Nothing
+   * leaves the process until you call {@link BudgetGuard.sync}. Zero-telemetry
+   * stays the default; there is no background send.
+   *
+   * Why: Floe's gateway can't see spend it never routed (BYOK, self-hosted,
+   * off-path). Syncing your local ledger is what makes that spend — and your
+   * **Coverage Score** — visible. Budget, not balance: it reports what you already
+   * spent for coverage/attribution; it moves no money.
+   *
+   * What will leave the process when you call {@link BudgetGuard.sync}: exactly the
+   * {@link BudgetGuard.exportLog} JSONL (priced spend events — no prompts, no
+   * content, no identifiers beyond a `label` you set).
+   *
+   * @param apiKey Floe agent key (`floe_<hex>`, `read_write`). Defaults to the
+   *   `FLOE_API_KEY` env var at `sync()` time.
+   * @param options.baseUrl API base. Defaults to `FLOE_API_BASE_URL`, else prod.
+   *
+   * Revoke with {@link BudgetGuard.disableSync}; the guard sends nothing after.
+   */
+  enableSync(apiKey?: string, options: { baseUrl?: string } = {}): void {
+    this.syncEnabled = true;
+    this.syncKey = apiKey ?? null;
+    this.syncBase = options.baseUrl ?? null;
+  }
+
+  /**
+   * Turn ledger sync back off (revoke the opt-in). The guard sends nothing after
+   * this; {@link BudgetGuard.sync} throws until {@link BudgetGuard.enableSync} is
+   * called again.
+   */
+  disableSync(): void {
+    this.syncEnabled = false;
+    this.syncKey = null;
+    this.syncBase = null;
+  }
+
+  /**
+   * Push the current spend ledger to Reconcile Mode; resolve with events accepted.
+   *
+   * Requires {@link BudgetGuard.enableSync} first — this is the explicit send, the
+   * only thing that transmits the ledger. Throws if sync isn't enabled (so a guard
+   * that never opted in can never send). An empty ledger is a no-op (`0`, no
+   * network). Re-syncing is safe: the server is idempotent, so already-ingested
+   * events are not double-counted.
+   *
+   * @throws {Error} sync was not enabled (call {@link BudgetGuard.enableSync} first).
+   * @throws {LedgerSyncError} the opt-in send failed (missing key, non-2xx, network).
+   */
+  async sync(): Promise<number> {
+    if (!this.syncEnabled) {
+      throw new Error(
+        "ledger sync is not enabled — call guard.enableSync(apiKey) first. " +
+          "Sync is opt-in and off by default (zero-telemetry).",
+      );
+    }
+    return pushLedger(this.exportLog(), this.syncKey ?? undefined, {
+      baseUrl: this.syncBase ?? undefined,
+    });
   }
 
   /**

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -26,7 +26,9 @@ export {
   DeadlineExceeded,
   UnpriceableModelError,
   UnpriceableVoiceError,
+  LedgerSyncError,
 } from "./errors.js";
+export { pushLedger } from "./sync.js";
 export {
   budgetGuardMiddleware,
   type BudgetGuardMiddleware,

--- a/js/src/sync.ts
+++ b/js/src/sync.ts
@@ -34,6 +34,22 @@ const DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz";
 const LEDGER_SYNC_PATH = "/v1/agents/ledger/sync";
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+// The ONLY keys allowed to leave the process — the exportLog() schema. Enforced
+// (not just documented) in validateLedger(): a line carrying anything else is
+// rejected, so a hand-supplied file can't smuggle prompts / content / identifiers
+// past the privacy contract.
+const ALLOWED_KEYS = new Set([
+  "timestamp",
+  "kind",
+  "model_or_tool",
+  "prompt_tokens",
+  "completion_tokens",
+  "cost_usd",
+  "label",
+  "reserved",
+]);
+const REQUIRED_KEYS = ["timestamp", "kind", "model_or_tool", "cost_usd"];
+
 /**
  * Read an environment variable without a hard `process` reference — the package
  * compiles with `types: []` (no `@types/node`), so `process` is untyped. Reads
@@ -42,6 +58,90 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 function envVar(name: string): string {
   const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
   return proc?.env?.[name] ?? "";
+}
+
+/**
+ * Parse and validate every ledger line against the `exportLog()` schema.
+ *
+ * Throws {@link LedgerSyncError} on the first malformed / unknown-field / invalid
+ * record, **before** anything is sent — so only priced spend events ever leave the
+ * process, even when the ledger came from a hand-edited file. This is the privacy
+ * contract *enforced*, not merely asserted: an **extra/unknown key** (a smuggled
+ * `prompt`, `user_id`, …) is rejected outright. Mirrors `_validate_ledger` in the
+ * Python client.
+ *
+ * (JS `typeof x === "number"` already excludes booleans and `Number.isInteger`
+ * rejects them too, so — unlike Python, where `bool` is an `int` subclass — no
+ * explicit boolean guards are needed.)
+ */
+function validateLedger(jsonl: string): void {
+  let i = 0;
+  for (const raw of jsonl.split("\n")) {
+    i += 1;
+    const line = raw.trim();
+    if (!line) continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch (err) {
+      throw new LedgerSyncError(`Ledger line ${i} is not valid JSON: ${describeCause(err)}`);
+    }
+    if (typeof event !== "object" || event === null || Array.isArray(event)) {
+      throw new LedgerSyncError(`Ledger line ${i} is not a JSON object.`);
+    }
+    const ev = event as Record<string, unknown>;
+    const extra = Object.keys(ev).filter((k) => !ALLOWED_KEYS.has(k));
+    if (extra.length) {
+      throw new LedgerSyncError(
+        `Ledger line ${i} has fields outside the exportLog() schema: ` +
+          `${JSON.stringify(extra.sort())}. Only priced spend events may be synced — ` +
+          "no prompts, content, or identifiers.",
+      );
+    }
+    const missing = REQUIRED_KEYS.filter((k) => !(k in ev));
+    if (missing.length) {
+      throw new LedgerSyncError(
+        `Ledger line ${i} is missing required field(s): ${JSON.stringify(missing)}.`,
+      );
+    }
+    if (ev.kind !== "llm" && ev.kind !== "tool") {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: kind must be 'llm' or 'tool', got ${JSON.stringify(ev.kind)}.`,
+      );
+    }
+    if (typeof ev.model_or_tool !== "string") {
+      throw new LedgerSyncError(`Ledger line ${i}: model_or_tool must be a string.`);
+    }
+    const cost = ev.cost_usd;
+    if (typeof cost !== "number" || !Number.isFinite(cost) || cost < 0) {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: cost_usd must be a finite, non-negative number, got ${JSON.stringify(cost)}.`,
+      );
+    }
+    const ts = ev.timestamp;
+    if (typeof ts !== "number" || !Number.isFinite(ts)) {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: timestamp must be a finite number, got ${JSON.stringify(ts)}.`,
+      );
+    }
+    for (const field of ["prompt_tokens", "completion_tokens"] as const) {
+      const value = ev[field];
+      // Absent (undefined) or explicit null are fine — tool events carry null; a
+      // present value must be an integer.
+      if (value !== undefined && value !== null && !Number.isInteger(value)) {
+        throw new LedgerSyncError(`Ledger line ${i}: ${field} must be an integer or null.`);
+      }
+    }
+    if ("label" in ev && typeof ev.label !== "string") {
+      throw new LedgerSyncError(`Ledger line ${i}: label must be a string.`);
+    }
+    if ("reserved" in ev) {
+      const reserved = ev.reserved;
+      if (typeof reserved !== "number" || !Number.isFinite(reserved)) {
+        throw new LedgerSyncError(`Ledger line ${i}: reserved must be a finite number.`);
+      }
+    }
+  }
 }
 
 /**
@@ -67,6 +167,10 @@ export async function pushLedger(
 ): Promise<number> {
   // An empty ledger never touches the network — nothing to send.
   if (!jsonl.trim()) return 0;
+
+  // Enforce the privacy contract BEFORE any network: only exportLog() events —
+  // no prompts, content, or identifiers — may leave, even from a hand-supplied file.
+  validateLedger(jsonl);
 
   const key = ((apiKey ?? "") || envVar(FLOE_API_KEY_ENV)).trim();
   if (!key) {
@@ -104,6 +208,11 @@ export async function pushLedger(
   try {
     response = await fetch(url, {
       method: "POST",
+      // Refuse redirects: a 3xx would otherwise let the key + ledger be re-sent to
+      // another host. (The Fetch spec strips `Authorization` on a cross-origin
+      // redirect, but `redirect: "error"` is the belt-and-suspenders — nothing is
+      // re-sent anywhere, same-origin or not.)
+      redirect: "error",
       headers: {
         Authorization: `Bearer ${key}`,
         "Content-Type": "application/x-ndjson",
@@ -132,10 +241,14 @@ export async function pushLedger(
     throw new LedgerSyncError(`Unexpected response shape from Floe at ${url}.`);
   }
   // "synced" is the count the server accepted (new rows); "duplicates" (already
-  // ingested, idempotent) are not counted here. Absent / non-numeric → 0.
+  // ingested, idempotent) are not counted here. Absent → 0; present must be a real
+  // non-negative integer — reject bool/float/negative/garbage rather than coerce.
   const synced = (payload as Record<string, unknown>).synced;
-  const n = typeof synced === "number" ? synced : Number(synced);
-  return Number.isFinite(n) ? Math.trunc(n) : 0;
+  if (synced === undefined || synced === null) return 0;
+  if (typeof synced !== "number" || !Number.isInteger(synced) || synced < 0) {
+    throw new LedgerSyncError(`Invalid 'synced' count from Floe at ${url}: ${JSON.stringify(synced)}.`);
+  }
+  return synced;
 }
 
 function describeCause(err: unknown): string {

--- a/js/src/sync.ts
+++ b/js/src/sync.ts
@@ -1,0 +1,168 @@
+/**
+ * Opt-in ledger sync — push the local spend ledger to Floe's Reconcile Mode.
+ *
+ * **Zero-telemetry is the default, and stays the default.** Nothing in this module
+ * runs unless the caller *explicitly* opts in with a Floe API key — via
+ * {@link BudgetGuard.enableSync} + {@link BudgetGuard.sync}. There is no implicit
+ * enablement and no background send: the ledger leaves your process only when you
+ * call one of those. Your ledger, your key, your choice.
+ *
+ * **Why sync at all.** Floe's gateway can't see spend it never routed — BYOK,
+ * self-hosted, or off-path LLM/tool calls. Pushing your local ledger into Reconcile
+ * Mode is how that spend lands on the ledger and your **Coverage Score** becomes
+ * computable. Budget, not balance: this reports *what you already spent* for
+ * coverage/attribution; it does not move money or change any wallet balance.
+ *
+ * **What leaves the process — exactly the {@link BudgetGuard.exportLog} JSONL** and
+ * nothing else: one line per spend event, each a priced-cost record — `timestamp`,
+ * `kind` (`"llm"`/`"tool"`), `model_or_tool`, `prompt_tokens`, `completion_tokens`,
+ * `cost_usd`, and the optional `label` / `reserved` you set. **No prompts, no
+ * message content, no identifiers** beyond a `label` you choose.
+ *
+ * Mirrors `src/floe_guard/sync.py` in the Python package — same behaviour
+ * (https-only, key-required, fail-closed), transported over `fetch` instead of
+ * `urllib`.
+ *
+ *     Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+ */
+
+import { LedgerSyncError } from "./errors.js";
+
+const FLOE_API_KEY_ENV = "FLOE_API_KEY";
+const FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL";
+const DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz";
+const LEDGER_SYNC_PATH = "/v1/agents/ledger/sync";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Read an environment variable without a hard `process` reference — the package
+ * compiles with `types: []` (no `@types/node`), so `process` is untyped. Reads
+ * live at call time so tests that mutate the env are honoured.
+ */
+function envVar(name: string): string {
+  const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  return proc?.env?.[name] ?? "";
+}
+
+/**
+ * POST an {@link BudgetGuard.exportLog} JSONL ledger to Reconcile Mode and resolve
+ * with the number of events the server accepted.
+ *
+ * This is the ONLY function that sends the ledger, and it sends only when called.
+ * An empty ledger is a no-op (resolves `0` with **no** `fetch` call).
+ *
+ * @param jsonl the ledger as newline-delimited JSON — `exportLog()` output.
+ * @param apiKey Floe agent key (`floe_<hex>`, `read_write`). Defaults to the
+ *   `FLOE_API_KEY` env var.
+ * @param opts.baseUrl API base. Defaults to `FLOE_API_BASE_URL`, else the prod host.
+ * @param opts.timeoutMs request timeout in milliseconds (default 30_000).
+ * @throws {LedgerSyncError} missing key, a non-https/malformed base URL, a non-2xx
+ *   response, network/timeout, or a malformed response body. The key and ledger are
+ *   never sent over a non-https or malformed URL.
+ */
+export async function pushLedger(
+  jsonl: string,
+  apiKey?: string,
+  opts: { baseUrl?: string; timeoutMs?: number } = {},
+): Promise<number> {
+  // An empty ledger never touches the network — nothing to send.
+  if (!jsonl.trim()) return 0;
+
+  const key = ((apiKey ?? "") || envVar(FLOE_API_KEY_ENV)).trim();
+  if (!key) {
+    throw new LedgerSyncError(
+      `No Floe API key: pass apiKey or set ${FLOE_API_KEY_ENV}. ` +
+        "Sync is opt-in and needs your key.",
+    );
+  }
+
+  const envBase = envVar(FLOE_API_BASE_URL_ENV).trim();
+  const base = ((opts.baseUrl ?? "").trim() || envBase || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  let parsed: URL;
+  try {
+    parsed = new URL(base);
+  } catch {
+    // The request carries the Floe agent key as a bearer token AND your spend
+    // ledger — never send either over a malformed URL.
+    throw new LedgerSyncError(
+      `Refusing to send the ledger to '${base}': ` +
+        "the base URL must be an https:// URL with a host.",
+    );
+  }
+  if (parsed.protocol !== "https:" || !parsed.host) {
+    // Same guard for a well-formed but non-https (or hostless) URL.
+    throw new LedgerSyncError(
+      `Refusing to send the ledger to '${base}': ` +
+        "the base URL must be an https:// URL with a host.",
+    );
+  }
+  const url = `${base}${LEDGER_SYNC_PATH}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/x-ndjson",
+        Accept: "application/json",
+      },
+      body: jsonl,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new LedgerSyncError(`Could not reach Floe at ${url}: ${describeCause(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    throw new LedgerSyncError(await describeHttpError(response));
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(await response.text());
+  } catch (err) {
+    throw new LedgerSyncError(`Malformed JSON from Floe at ${url}: ${describeCause(err)}`);
+  }
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new LedgerSyncError(`Unexpected response shape from Floe at ${url}.`);
+  }
+  // "synced" is the count the server accepted (new rows); "duplicates" (already
+  // ingested, idempotent) are not counted here. Absent / non-numeric → 0.
+  const synced = (payload as Record<string, unknown>).synced;
+  const n = typeof synced === "number" ? synced : Number(synced);
+  return Number.isFinite(n) ? Math.trunc(n) : 0;
+}
+
+function describeCause(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function describeHttpError(response: Response): Promise<string> {
+  let detail = "";
+  try {
+    const data: unknown = JSON.parse(await response.text());
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      typeof (data as Record<string, unknown>).error === "string"
+    ) {
+      detail = ` (${(data as Record<string, unknown>).error as string})`;
+    }
+  } catch {
+    // Non-JSON / empty error body — the status code alone is the message.
+  }
+  const code = response.status;
+  if (code === 401) return `Floe rejected the API key (401 unauthorized)${detail}.`;
+  if (code === 403) {
+    return (
+      `Floe refused the sync (403 forbidden)${detail} — the agent may be ` +
+      "closed/suspended, or the key is read-only (a read_write key is required)."
+    );
+  }
+  return `Floe returned HTTP ${code}${detail}.`;
+}

--- a/js/test/ledger-sync.test.ts
+++ b/js/test/ledger-sync.test.ts
@@ -27,6 +27,11 @@ const LEDGER_KEYS = new Set([
   "reserved",
 ]);
 
+// A single valid exportLog() event — the fail-closed tests use this so ledger
+// validation (which runs before the key/URL/HTTP checks) passes and the specific
+// guard under test is what fires.
+const ONE_EVENT = '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.01}\n';
+
 function ok(payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
     status: 200,
@@ -111,6 +116,8 @@ describe("opt-in send", () => {
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(String(url)).toMatch(/\/v1\/agents\/ledger\/sync$/);
     expect(init.method).toBe("POST");
+    // Redirects refused — the key + ledger can't be re-sent to another host on a 3xx.
+    expect(init.redirect).toBe("error");
     const headers = init.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer floe_abc");
     expect(headers["Content-Type"]).toBe("application/x-ndjson");
@@ -129,6 +136,84 @@ describe("opt-in send", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ synced: 3 }));
     await expect(guard.sync()).resolves.toBe(3);
   });
+
+  it("sends the key it was enabled with, not $FLOE_API_KEY (atomic opt-in snapshot)", async () => {
+    // A different key in the env must not win over the one passed to enableSync,
+    // and can't leak in if disableSync races the fetch.
+    process.env.FLOE_API_KEY = "floe_env_key";
+    const guard = guardWithSpend();
+    guard.enableSync("floe_explicit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ synced: 1 }));
+    await guard.sync();
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer floe_explicit");
+  });
+
+  it("an absent synced count resolves 0", async () => {
+    const guard = guardWithSpend();
+    guard.enableSync("floe_abc");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({}));
+    await expect(guard.sync()).resolves.toBe(0);
+  });
+
+  it.each([
+    ["fractional", { synced: 1.5 }],
+    ["negative", { synced: -1 }],
+    ["boolean", { synced: true }],
+    ["string", { synced: "3" }],
+  ])("rejects a %s synced count (no coercion)", async (_label, payload) => {
+    const guard = guardWithSpend();
+    guard.enableSync("floe_abc");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok(payload));
+    await expect(guard.sync()).rejects.toThrow(LedgerSyncError);
+  });
+});
+
+// ── AC3: the request body is validated against exportLog() before any send ─────
+
+describe("pushLedger validates the ledger before sending", () => {
+  it("rejects a line with a smuggled `prompt` field and NEVER calls fetch", async () => {
+    const smuggled =
+      '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":0.05,"prompt":"leak me"}\n';
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(pushLedger(smuggled, "floe_abc")).rejects.toThrow(LedgerSyncError);
+    await expect(pushLedger(smuggled, "floe_abc")).rejects.toThrow(/outside the exportLog\(\) schema/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unknown identifier field", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":0.05,"user_id":"u1"}'],
+    ["missing timestamp", '{"kind":"tool","model_or_tool":"api","cost_usd":0.05}'],
+    ["missing kind", '{"timestamp":1,"model_or_tool":"api","cost_usd":0.05}'],
+    ["missing model_or_tool", '{"timestamp":1,"kind":"tool","cost_usd":0.05}'],
+    ["missing cost_usd", '{"timestamp":1,"kind":"tool","model_or_tool":"api"}'],
+    ["bad kind", '{"timestamp":1,"kind":"other","model_or_tool":"api","cost_usd":0.05}'],
+    ["non-string model_or_tool", '{"timestamp":1,"kind":"tool","model_or_tool":123,"cost_usd":0.05}'],
+    ["negative cost_usd", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":-1}'],
+    ["non-number cost_usd", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":"x"}'],
+    ["boolean cost_usd", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":true}'],
+    ["non-number timestamp", '{"timestamp":"x","kind":"tool","model_or_tool":"api","cost_usd":0.05}'],
+    [
+      "fractional prompt_tokens",
+      '{"timestamp":1,"kind":"llm","model_or_tool":"m","prompt_tokens":1.5,"completion_tokens":null,"cost_usd":0.05}',
+    ],
+    ["non-string label", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":0.05,"label":5}'],
+    ["non-number reserved", '{"timestamp":1,"kind":"tool","model_or_tool":"api","cost_usd":0.05,"reserved":"x"}'],
+    ["malformed JSON", "not json"],
+    ["not a JSON object", "[1,2,3]"],
+  ])("rejects a bad-schema line (%s) before any fetch", async (_label, line) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(pushLedger(`${line}\n`, "floe_abc")).rejects.toThrow(LedgerSyncError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid tool + llm ledger (with optional label/reserved)", async () => {
+    const valid =
+      '{"timestamp":1,"kind":"tool","model_or_tool":"api","prompt_tokens":null,"completion_tokens":null,"cost_usd":0.05,"label":"x"}\n' +
+      '{"timestamp":2,"kind":"llm","model_or_tool":"gpt-4o","prompt_tokens":10,"completion_tokens":5,"cost_usd":0.01,"reserved":0.02}\n';
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ synced: 2 }));
+    await expect(pushLedger(valid, "floe_abc")).resolves.toBe(2);
+  });
 });
 
 // ── pushLedger fail-closed ────────────────────────────────────────────────────
@@ -136,8 +221,8 @@ describe("opt-in send", () => {
 describe("pushLedger fail-closed", () => {
   it("missing key throws LedgerSyncError with no network", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    await expect(pushLedger('{"cost_usd":0.01}\n')).rejects.toThrow(LedgerSyncError);
-    await expect(pushLedger('{"cost_usd":0.01}\n')).rejects.toThrow(/No Floe API key/);
+    await expect(pushLedger(ONE_EVENT)).rejects.toThrow(LedgerSyncError);
+    await expect(pushLedger(ONE_EVENT)).rejects.toThrow(/No Floe API key/);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -152,7 +237,7 @@ describe("pushLedger fail-closed", () => {
     async (badBase) => {
       const fetchSpy = vi.spyOn(globalThis, "fetch");
       await expect(
-        pushLedger('{"cost_usd":0.01}\n', "floe_abc", { baseUrl: badBase }),
+        pushLedger(ONE_EVENT, "floe_abc", { baseUrl: badBase }),
       ).rejects.toThrow(LedgerSyncError);
       expect(fetchSpy).not.toHaveBeenCalled();
     },
@@ -165,11 +250,11 @@ describe("pushLedger fail-closed", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response('{"error":"x"}', { status: code as number }),
     );
-    await expect(pushLedger('{"cost_usd":0.01}\n', "floe_abc")).rejects.toThrow(needle as RegExp);
+    await expect(pushLedger(ONE_EVENT, "floe_abc")).rejects.toThrow(needle as RegExp);
   });
 
   it("a network failure throws LedgerSyncError", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed"));
-    await expect(pushLedger('{"cost_usd":0.01}\n', "floe_abc")).rejects.toThrow(LedgerSyncError);
+    await expect(pushLedger(ONE_EVENT, "floe_abc")).rejects.toThrow(LedgerSyncError);
   });
 });

--- a/js/test/ledger-sync.test.ts
+++ b/js/test/ledger-sync.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Opt-in ledger sync — zero-telemetry stays the default.
+ *
+ * The load-bearing test here is that a guard which never opted in makes **zero**
+ * network calls, ever (`fetch` is asserted un-called). Sync sends only the
+ * `exportLog()` JSONL, only under the explicit flag, only with a key. Mirrors
+ * `tests/test_ledger_sync.py` in the Python package.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BudgetGuard, LedgerSyncError, pushLedger } from "../src/index.js";
+
+// The package compiles with `types: []` (no @types/node), so `process` is not
+// globally typed. Declare the minimal shape the tests touch (real `process` is
+// present at runtime under vitest's node environment).
+declare const process: { env: Record<string, string | undefined> };
+
+const LEDGER_KEYS = new Set([
+  "timestamp",
+  "kind",
+  "model_or_tool",
+  "prompt_tokens",
+  "completion_tokens",
+  "cost_usd",
+  "label",
+  "reserved",
+]);
+
+function ok(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function guardWithSpend(): BudgetGuard {
+  const guard = new BudgetGuard(10.0);
+  guard.recordTool("api", 0.05); // exactly one ledger event
+  return guard;
+}
+
+// Sync reads FLOE_API_KEY / FLOE_API_BASE_URL from the env — clear both so a real
+// machine key can't leak into the "no key" / default-base assertions.
+let savedKey: string | undefined;
+let savedBase: string | undefined;
+beforeEach(() => {
+  savedKey = process.env.FLOE_API_KEY;
+  savedBase = process.env.FLOE_API_BASE_URL;
+  delete process.env.FLOE_API_KEY;
+  delete process.env.FLOE_API_BASE_URL;
+});
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.FLOE_API_KEY;
+  else process.env.FLOE_API_KEY = savedKey;
+  if (savedBase === undefined) delete process.env.FLOE_API_BASE_URL;
+  else process.env.FLOE_API_BASE_URL = savedBase;
+  vi.restoreAllMocks();
+});
+
+// ── AC1: zero egress without opt-in ───────────────────────────────────────────
+
+describe("zero egress without opt-in", () => {
+  it("a full guard lifecycle with no enableSync never touches the network, and sync() rejects", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const guard = new BudgetGuard(10.0);
+    guard.recordTool("api", 0.05);
+    guard.record("gpt-4o", 1200, 350);
+    guard.advisory();
+    guard.exportLog();
+    await expect(guard.sync()).rejects.toThrow(/not enabled/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("disableSync revokes the opt-in: sync() rejects with no network", async () => {
+    const guard = guardWithSpend();
+    guard.enableSync("floe_abc");
+    guard.disableSync();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(guard.sync()).rejects.toThrow(/not enabled/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("an empty ledger syncs nothing and makes no network call", async () => {
+    const guard = new BudgetGuard(10.0); // no spend recorded
+    guard.enableSync("floe_abc");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(guard.sync()).resolves.toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sync() before any enableSync rejects with no network", async () => {
+    const guard = guardWithSpend();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(guard.sync()).rejects.toThrow(/enableSync/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── AC2: opt-in send is exactly exportLog(), under the key ────────────────────
+
+describe("opt-in send", () => {
+  it("sync() POSTs exactly exportLog() under the Bearer key to the sync path", async () => {
+    const guard = guardWithSpend();
+    guard.enableSync("floe_abc");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ synced: 1 }));
+
+    await expect(guard.sync()).resolves.toBe(1);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toMatch(/\/v1\/agents\/ledger\/sync$/);
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer floe_abc");
+    expect(headers["Content-Type"]).toBe("application/x-ndjson");
+    // The body is EXACTLY exportLog() — no prompts, no content, no extra fields.
+    expect(init.body).toBe(guard.exportLog());
+    for (const line of guard.exportLog().split("\n").filter(Boolean)) {
+      for (const k of Object.keys(JSON.parse(line))) {
+        expect(LEDGER_KEYS.has(k)).toBe(true);
+      }
+    }
+  });
+
+  it("parses the server's {synced} count", async () => {
+    const guard = guardWithSpend();
+    guard.enableSync("floe_abc");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ synced: 3 }));
+    await expect(guard.sync()).resolves.toBe(3);
+  });
+});
+
+// ── pushLedger fail-closed ────────────────────────────────────────────────────
+
+describe("pushLedger fail-closed", () => {
+  it("missing key throws LedgerSyncError with no network", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(pushLedger('{"cost_usd":0.01}\n')).rejects.toThrow(LedgerSyncError);
+    await expect(pushLedger('{"cost_usd":0.01}\n')).rejects.toThrow(/No Floe API key/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("an empty/whitespace ledger is a no-op with no network", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(pushLedger("   ")).resolves.toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(["http://credit-api.floelabs.xyz", "file:///etc/passwd", "ftp://x", "not-a-url", "https://"])(
+    "refuses a non-https / malformed base URL (%s) — never sends the key or ledger",
+    async (badBase) => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      await expect(
+        pushLedger('{"cost_usd":0.01}\n', "floe_abc", { baseUrl: badBase }),
+      ).rejects.toThrow(LedgerSyncError);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [401, /401/],
+    [403, /403/],
+  ])("a non-2xx response (%i) throws LedgerSyncError", async (code, needle) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"error":"x"}', { status: code as number }),
+    );
+    await expect(pushLedger('{"cost_usd":0.01}\n', "floe_abc")).rejects.toThrow(needle as RegExp);
+  });
+
+  it("a network failure throws LedgerSyncError", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+    await expect(pushLedger('{"cost_usd":0.01}\n', "floe_abc")).rejects.toThrow(LedgerSyncError);
+  });
+});


### PR DESCRIPTION
## What

Ports floe-guard's **opt-in ledger sync** to the TypeScript/npm package, reaching parity with the shipped Python client (PR #79). BYOK / self-hosted / off-path spend the gateway never routed can now be pushed to Reconcile Mode so it lands on the ledger and the **Coverage Score** becomes computable. **Budget, not balance:** this reports what was already spent for coverage/attribution — it moves no money and changes no wallet balance.

## Public API

- `pushLedger(jsonl: string, apiKey?: string, opts?: { baseUrl?: string; timeoutMs?: number }): Promise<number>` — over `fetch` (mirrors the Python `push_ledger` behaviour, not its `urllib` transport).
  - Empty ledger → resolves `0` with **no** `fetch` call.
  - Missing key (arg or `FLOE_API_KEY`) → throws `LedgerSyncError`.
  - Non-https / malformed base URL → throws (the key and ledger are never sent).
  - Non-2xx / network / malformed response → `LedgerSyncError`.
  - POSTs to `/v1/agents/ledger/sync`, `Content-Type: application/x-ndjson`, `Authorization: Bearer`; returns parsed `{ synced }`.
- `BudgetGuard.enableSync(apiKey?, { baseUrl? })` / `disableSync()` / `sync(): Promise<number>` — off by default; `enableSync` stores key/endpoint and sends nothing; `sync()` is the only send; `sync()` on a guard that never opted in throws with **no** network; `disableSync` revokes.
- `LedgerSyncError` (extends `FloeGuardError`), exported alongside `pushLedger`.

## Zero-telemetry is the default

Nothing leaves the process without an explicit `enableSync()` **and** an explicit `sync()`. There is no background/auto send. The new test suite proves it: `fetch` is asserted un-called across a full `record` / `advisory` / `exportLog` lifecycle plus a rejecting `sync()`, and across every fail-closed path (missing key, non-https base). The opt-in send body is asserted **exactly equal** to `exportLog()`.

## Version / changelog

- `js` `0.12.0 → 0.13.0` (js/src changed).
- CHANGELOG: new `## Unreleased — js 0.13.0` / `### Added (js)` entry (Python version/sections untouched).

## Notes / handoffs

- **CLI parity:** the `floe-guard push` CLI stays **Python-only** for now — the npm package ships no `bin`, so a CLI was out of scope per the task's "only if it fits cleanly" guidance.
- **Cross-repo parity:** this closes the JS side of the sync feature against the Python `floe_guard.sync` / `enable_sync` / `disable_sync` / `sync` surface; schemas and endpoint match.

## Checks (from `js/`)

- `npm run typecheck` — clean
- `npm run build` — ok
- `npm test` — 190 passed (16 files); the new `test/ledger-sync.test.ts` is 16 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in ledger synchronization with Reconcile Mode.
  * Added controls to enable, disable, and manually trigger synchronization.
  * Added secure API-key authentication, HTTPS validation, and redirect protection.
  * Added reporting of accepted spend events.

* **Bug Fixes**
  * Synchronization remains disabled by default and sends no data for empty ledgers.
  * Invalid ledger data, credentials, network failures, and server errors now fail safely.

* **Chores**
  * Updated the JavaScript package to version 0.13.0.
  * Documented synchronization behavior and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->