### PR TITLE
feat(js): floe-guard push CLI + ledger sync client (js 0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — js 0.14.0
+
+### Added (js)
+
+- **Opt-in ledger sync → Reconcile Mode / Coverage Score (JS parity).** Ports the
+  Python opt-in sync to the npm package: a new **explicit, off-by-default** way to
+  push your local spend ledger to Floe so **Coverage Score** can count spend the
+  gateway never routed (BYOK / self-hosted / off-path). New exports `pushLedger()`
+  and `LedgerSyncError`, plus a `floe-guard` **bin** with one subcommand:
+  `floe-guard push [ledger.jsonl]` (reads a file, or stdin when the arg is omitted
+  or `-`, so `producer | floe-guard push` works), with `--key` (defaults to
+  `$FLOE_API_KEY`) and `--base-url` (defaults to `$FLOE_API_BASE_URL`, else the
+  prod host). On success it prints `Synced N spend event(s) to Floe Reconcile
+  Mode.` and exits 0; a `LedgerSyncError` prints to stderr and exits 1.
+  **Zero-telemetry stays the default** — nothing leaves the process without the
+  explicit opt-in *and* an explicit send; there is no implicit enablement and no
+  background send (asserted in tests: `fetch` is never called for a no-key push).
+  The **request body** is exactly the `exportLog()` JSONL — priced spend events
+  (timestamp, kind, model/tool, tokens, `cost_usd`, optional `label`/`reserved`) —
+  and `pushLedger` **validates every line, rejecting any field outside that
+  schema**, so no prompts or message content leave even from a hand-supplied
+  ledger. Your key travels in the `Authorization` header; redirects are refused
+  (`redirect: "error"`) so key + ledger can't be re-sent to an unapproved host.
+  Budget, not balance: it reports what you already spent for coverage/attribution;
+  it moves no money. Matches the Python `push_ledger()` / `LedgerSyncError` /
+  `floe-guard push` shipped in py 0.17.0.
+
 ## Unreleased — py 0.17.0
 
 ### Added (py)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "floe-guard",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "license": "MIT",
+      "bin": {
+        "floe-guard": "dist/cli.js"
+      },
       "devDependencies": {
         "@livekit/agents": "^1.6.3",
         "ai": "^4.0.0",
@@ -19,7 +22,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@livekit/agents": ">=1.5.0",
+        "@livekit/agents": ">=1.5.0 <2.0.0",
         "ai": ">=4.0.0 <6.0.0"
       },
       "peerDependenciesMeta": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",
@@ -46,6 +46,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "floe-guard": "./dist/cli.js"
+  },
   "files": [
     "dist",
     "src/cost_map.json"

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -1,0 +1,168 @@
+/**
+ * floe-guard CLI.
+ *
+ * One command today: `floe-guard push` — the **opt-in** ledger sync. It reads a
+ * {@link BudgetGuard.exportLog} JSONL ledger (from a file or stdin) and POSTs it to
+ * Floe's Reconcile Mode so your **Coverage Score** can count spend the gateway
+ * never routed (BYOK / self-hosted / off-path). Nothing runs on import or in the
+ * background — `push` is a one-shot send you invoke, with your key. Zero telemetry
+ * otherwise.
+ *
+ * Mirrors `src/floe_guard/__main__.py` in the Python package — same flags, same
+ * exit codes, same messages.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { LedgerSyncError } from "./errors.js";
+import { pushLedger } from "./sync.js";
+
+const USAGE = `floe-guard — a local budget guardrail for AI agents
+
+Usage:
+  floe-guard push [ledger.jsonl] [--key <floe_...>] [--base-url <url>]
+
+Commands:
+  push    Opt-in: push an exportLog() JSONL ledger to Floe Reconcile Mode
+          (Coverage Score). Sends only priced spend events — no prompts,
+          no content, only with your key. Budget, not balance.
+
+Run 'floe-guard push --help' for push options.`;
+
+const PUSH_USAGE = `Usage: floe-guard push [ledger.jsonl] [options]
+
+Push a floe-guard exportLog() JSONL ledger to Floe's Reconcile Mode. Opt-in and
+explicit — it sends only the priced spend events in the ledger (no prompts, no
+content), only with your key.
+
+Arguments:
+  ledger          Ledger JSONL file (exportLog() output). Omit or '-' to read stdin.
+
+Options:
+  --key <key>     Floe agent key (floe_<hex>, read_write). Defaults to $FLOE_API_KEY.
+  --base-url <url>  API base URL. Defaults to $FLOE_API_BASE_URL, else the prod host.
+  -h, --help      Show this help.`;
+
+interface ParsedPush {
+  ledger: string;
+  key?: string;
+  baseUrl?: string;
+  help: boolean;
+}
+
+/**
+ * Hand-rolled parse for `push` args — positional `ledger` (default `-`), plus
+ * `--key`, `--base-url`, `-h/--help`. Dependency-free by design.
+ */
+function parsePushArgs(args: string[]): ParsedPush {
+  const parsed: ParsedPush = { ledger: "-", help: false };
+  let sawLedger = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      parsed.help = true;
+    } else if (arg === "--key") {
+      const value = args[i + 1];
+      if (value === undefined) throw new Error("--key needs a value");
+      parsed.key = value;
+      i += 1;
+    } else if (arg?.startsWith("--key=")) {
+      parsed.key = arg.slice("--key=".length);
+    } else if (arg === "--base-url") {
+      const value = args[i + 1];
+      if (value === undefined) throw new Error("--base-url needs a value");
+      parsed.baseUrl = value;
+      i += 1;
+    } else if (arg?.startsWith("--base-url=")) {
+      parsed.baseUrl = arg.slice("--base-url=".length);
+    } else if (arg !== undefined && !sawLedger) {
+      // First positional (including "-") is the ledger path.
+      parsed.ledger = arg;
+      sawLedger = true;
+    } else {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of globalThis.process.stdin) {
+    chunks.push(chunk);
+  }
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    joined.set(c, offset);
+    offset += c.length;
+  }
+  return new TextDecoder().decode(joined);
+}
+
+/**
+ * CLI entry. Returns a process exit code (0 success, 1 read/sync failure, 2 usage
+ * error) — the caller maps it to `process.exit`. Import-safe: it does not exit or
+ * touch the network on its own.
+ */
+export async function main(argv: string[]): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (command === undefined) {
+    globalThis.process.stderr.write(`${USAGE}\n`);
+    return 2;
+  }
+  if (command === "-h" || command === "--help") {
+    globalThis.process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  if (command !== "push") {
+    globalThis.process.stderr.write(`floe-guard: unknown command ${JSON.stringify(command)}\n${USAGE}\n`);
+    return 2;
+  }
+
+  let parsed: ParsedPush;
+  try {
+    parsed = parsePushArgs(rest);
+  } catch (exc) {
+    const detail = exc instanceof Error ? exc.message : String(exc);
+    globalThis.process.stderr.write(`floe-guard push: ${detail}\n${PUSH_USAGE}\n`);
+    return 2;
+  }
+  if (parsed.help) {
+    globalThis.process.stdout.write(`${PUSH_USAGE}\n`);
+    return 0;
+  }
+
+  let jsonl: string;
+  try {
+    jsonl = parsed.ledger === "-" ? await readStdin() : readFileSync(parsed.ledger, "utf-8");
+  } catch (exc) {
+    const detail = exc instanceof Error ? exc.message : String(exc);
+    globalThis.process.stderr.write(`floe-guard push: cannot read ${JSON.stringify(parsed.ledger)}: ${detail}\n`);
+    return 1;
+  }
+
+  try {
+    const n = await pushLedger(jsonl, parsed.key, { baseUrl: parsed.baseUrl });
+    globalThis.process.stdout.write(`Synced ${n} spend event(s) to Floe Reconcile Mode.\n`);
+    return 0;
+  } catch (exc) {
+    if (exc instanceof LedgerSyncError) {
+      globalThis.process.stderr.write(`floe-guard push failed: ${exc.message}\n`);
+      return 1;
+    }
+    throw exc;
+  }
+}
+
+// Auto-run only when invoked as the CLI entry (dist/cli.js), NOT when imported by
+// tests — mirrors Python's `if __name__ == "__main__"`.
+const entry = globalThis.process.argv[1];
+if (entry !== undefined && import.meta.url === pathToFileURL(entry).href) {
+  void main(globalThis.process.argv.slice(2)).then((code) => globalThis.process.exit(code));
+}

--- a/js/src/errors.ts
+++ b/js/src/errors.ts
@@ -75,6 +75,24 @@ export class TokenBudgetExceeded extends BudgetExceeded {
 }
 
 /**
+ * Thrown when an opt-in ledger sync to Reconcile Mode fails.
+ *
+ * Covers a missing API key, a non-2xx response (401 bad/missing key, 403 agent
+ * closed/suspended, or a read-only key), a network/timeout failure, or a
+ * malformed response. Sync is off by default and only runs when the caller
+ * explicitly opts in (`pushLedger` / the `floe-guard push` CLI) — this error
+ * never fires for a guard that hasn't opted in, because such a guard never sends.
+ *
+ * Mirrors `LedgerSyncError` in `src/floe_guard/errors.py`.
+ */
+export class LedgerSyncError extends FloeGuardError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LedgerSyncError";
+  }
+}
+
+/**
  * Thrown when a model cannot be priced and the guard is fail-closed.
  *
  * We refuse rather than silently accrue $0 — "we cannot cap what we cannot price".

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -26,7 +26,12 @@ export {
   DeadlineExceeded,
   UnpriceableModelError,
   UnpriceableVoiceError,
+  LedgerSyncError,
 } from "./errors.js";
+export {
+  pushLedger,
+  type PushLedgerOptions,
+} from "./sync.js";
 export {
   budgetGuardMiddleware,
   type BudgetGuardMiddleware,

--- a/js/src/node-runtime.d.ts
+++ b/js/src/node-runtime.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal ambient types for the handful of Node built-ins the CLI + sync client
+ * touch. The package ships with `types: []` (no `@types/node`) so it stays a lean
+ * browser-and-server library; this file declares only the exact surface used —
+ * `node:fs` readFileSync, `node:url` pathToFileURL, and the `process` global
+ * (env / argv / stdin / std{out,err} / exit) — rather than pulling in the whole
+ * Node typings. Keep it to what is actually imported.
+ */
+
+declare module "node:fs" {
+  export function readFileSync(path: string, encoding: "utf-8"): string;
+}
+
+declare module "node:url" {
+  export function pathToFileURL(path: string): { readonly href: string };
+}
+
+interface FloeNodeWritable {
+  write(chunk: string): boolean;
+}
+
+interface FloeNodeProcess {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+  stdin: AsyncIterable<Uint8Array>;
+  stdout: FloeNodeWritable;
+  stderr: FloeNodeWritable;
+}
+
+// A global `var` declaration is added to `typeof globalThis`, so both `process`
+// and `globalThis.process` type-check. The sync client + CLI read it via
+// `globalThis.process` to make the runtime dependency explicit at the call site.
+declare var process: FloeNodeProcess;

--- a/js/src/sync.ts
+++ b/js/src/sync.ts
@@ -1,0 +1,263 @@
+/**
+ * Opt-in ledger sync — push the local spend ledger to Floe's Reconcile Mode.
+ *
+ * **Zero-telemetry is the default, and stays the default.** Nothing in this module
+ * runs unless the caller *explicitly* opts in with a Floe API key — via
+ * {@link pushLedger} or the `floe-guard push` CLI. There is no implicit enablement
+ * and no background send: the ledger leaves your process only when you call it.
+ * Your ledger, your key, your choice.
+ *
+ * **Why sync at all.** Floe's gateway can't see spend it never routed — BYOK,
+ * self-hosted, or off-path LLM/tool calls. Pushing your local ledger into Reconcile
+ * Mode is how that spend lands on the ledger and your **Coverage Score** becomes
+ * computable. Budget, not balance: this reports *what you already spent* for
+ * coverage/attribution; it does not move money or change any wallet balance.
+ *
+ * **What leaves the process — exactly the {@link BudgetGuard.exportLog} JSONL** and
+ * nothing else: one line per spend event, each a priced-cost record — `timestamp`,
+ * `kind` (`"llm"`/`"tool"`), `model_or_tool`, `prompt_tokens`, `completion_tokens`,
+ * `cost_usd`, and the optional `label` / `reserved` you set. **No prompts, no
+ * message content, no identifiers** beyond a `label` you choose.
+ *
+ * Mirrors `src/floe_guard/sync.py` in the Python package — same schema, same
+ * validation, same fail-closed contract.
+ *
+ *     Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+ */
+
+import { LedgerSyncError } from "./errors.js";
+
+const FLOE_API_KEY_ENV = "FLOE_API_KEY";
+const FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL";
+const DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz";
+const LEDGER_SYNC_PATH = "/v1/agents/ledger/sync";
+
+/** Options for {@link pushLedger}. */
+export interface PushLedgerOptions {
+  /** API base. Defaults to `$FLOE_API_BASE_URL`, else the prod host. */
+  baseUrl?: string;
+  /** Socket timeout in milliseconds. Defaults to 30_000. */
+  timeoutMs?: number;
+}
+
+// The ONLY keys allowed to leave the process — the exportLog() schema. Enforced
+// (not just documented) below: a line carrying anything else is rejected, so a
+// hand-supplied file can't smuggle prompts / content / identifiers past the
+// privacy contract.
+const ALLOWED_KEYS = new Set([
+  "timestamp",
+  "kind",
+  "model_or_tool",
+  "prompt_tokens",
+  "completion_tokens",
+  "cost_usd",
+  "label",
+  "reserved",
+]);
+const REQUIRED_KEYS = ["timestamp", "kind", "model_or_tool", "cost_usd"];
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Parse and validate every ledger line against the `exportLog()` schema.
+ *
+ * Throws {@link LedgerSyncError} on the first malformed / unknown-field / invalid
+ * record, **before** anything is sent — so only priced spend events ever leave the
+ * process, even when the ledger came from a hand-edited file or the CLI. This is
+ * the privacy contract *enforced*, not merely asserted.
+ */
+function validateLedger(jsonl: string): void {
+  const lines = jsonl.split("\n");
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = (lines[idx] ?? "").trim();
+    if (!line) continue;
+    const i = idx + 1;
+
+    let event: unknown;
+    try {
+      event = JSON.parse(line);
+    } catch (exc) {
+      const detail = exc instanceof Error ? exc.message : String(exc);
+      throw new LedgerSyncError(`Ledger line ${i} is not valid JSON: ${detail}`);
+    }
+    if (typeof event !== "object" || event === null || Array.isArray(event)) {
+      throw new LedgerSyncError(`Ledger line ${i} is not a JSON object.`);
+    }
+    const record = event as Record<string, unknown>;
+
+    const extra = Object.keys(record).filter((k) => !ALLOWED_KEYS.has(k));
+    if (extra.length > 0) {
+      throw new LedgerSyncError(
+        `Ledger line ${i} has fields outside the exportLog() schema: ` +
+          `${JSON.stringify(extra.sort())}. Only priced spend events may be synced — no prompts, ` +
+          `content, or identifiers.`,
+      );
+    }
+    const missing = REQUIRED_KEYS.filter((k) => !(k in record));
+    if (missing.length > 0) {
+      throw new LedgerSyncError(
+        `Ledger line ${i} is missing required field(s): ${JSON.stringify(missing.sort())}.`,
+      );
+    }
+    if (record.kind !== "llm" && record.kind !== "tool") {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: kind must be 'llm' or 'tool', got ${JSON.stringify(record.kind)}.`,
+      );
+    }
+    if (typeof record.model_or_tool !== "string") {
+      throw new LedgerSyncError(`Ledger line ${i}: model_or_tool must be a string.`);
+    }
+    const cost = record.cost_usd;
+    if (!isFiniteNumber(cost) || cost < 0) {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: cost_usd must be a finite, non-negative number, got ${JSON.stringify(cost)}.`,
+      );
+    }
+    if (!isFiniteNumber(record.timestamp)) {
+      throw new LedgerSyncError(
+        `Ledger line ${i}: timestamp must be a finite number, got ${JSON.stringify(record.timestamp)}.`,
+      );
+    }
+    for (const field of ["prompt_tokens", "completion_tokens"] as const) {
+      const value = record[field];
+      if (value !== undefined && value !== null && !Number.isInteger(value)) {
+        throw new LedgerSyncError(`Ledger line ${i}: ${field} must be an integer or null.`);
+      }
+    }
+    if ("label" in record && typeof record.label !== "string") {
+      throw new LedgerSyncError(`Ledger line ${i}: label must be a string.`);
+    }
+    if ("reserved" in record && !isFiniteNumber(record.reserved)) {
+      throw new LedgerSyncError(`Ledger line ${i}: reserved must be a finite number.`);
+    }
+  }
+}
+
+function describeHttpError(status: number, body: string): string {
+  let detail = "";
+  try {
+    const data: unknown = JSON.parse(body);
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      typeof (data as Record<string, unknown>).error === "string"
+    ) {
+      detail = ` (${(data as Record<string, unknown>).error as string})`;
+    }
+  } catch {
+    // non-JSON error body — no extra detail.
+  }
+  if (status === 401) {
+    return `Floe rejected the API key (401 unauthorized)${detail}.`;
+  }
+  if (status === 403) {
+    return (
+      `Floe refused the sync (403 forbidden)${detail} — the agent may be ` +
+      `closed/suspended, or the key is read-only (a read_write key is required).`
+    );
+  }
+  return `Floe returned HTTP ${status}${detail}.`;
+}
+
+/**
+ * POST an {@link BudgetGuard.exportLog} JSONL ledger to Reconcile Mode and return
+ * the number of events the server accepted.
+ *
+ * This is the ONLY function that sends the ledger, and it sends only when called.
+ * An empty ledger is a no-op (returns `0` without any network call).
+ *
+ * @param jsonl - the ledger as newline-delimited JSON — `exportLog()` output.
+ * @param apiKey - Floe agent key (`floe_<hex>`, `read_write`). Defaults to the
+ *   `FLOE_API_KEY` env var.
+ * @param options - `baseUrl` (defaults to `FLOE_API_BASE_URL`, else the prod host)
+ *   and `timeoutMs` (default 30_000).
+ * @throws {@link LedgerSyncError} on a missing key, a non-2xx response, a
+ *   network/timeout failure, or a malformed response body.
+ */
+export async function pushLedger(
+  jsonl: string,
+  apiKey?: string,
+  options: PushLedgerOptions = {},
+): Promise<number> {
+  // An empty ledger never touches the network — nothing to send.
+  if (!jsonl.trim()) return 0;
+
+  // Enforce the privacy contract BEFORE any network: only exportLog() events —
+  // no prompts, content, or identifiers — may leave, even from a hand-supplied file.
+  validateLedger(jsonl);
+
+  const env = globalThis.process.env;
+  const key = (apiKey ?? env[FLOE_API_KEY_ENV] ?? "").trim();
+  if (!key) {
+    throw new LedgerSyncError(
+      `No Floe API key: pass apiKey or set ${FLOE_API_KEY_ENV}. ` +
+        `Sync is opt-in and needs your key.`,
+    );
+  }
+
+  const envBase = (env[FLOE_API_BASE_URL_ENV] ?? "").trim();
+  const base = ((options.baseUrl ?? "").trim() || envBase || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  let parsed: URL;
+  try {
+    parsed = new URL(base);
+  } catch {
+    parsed = new URL("http://");
+  }
+  if (parsed.protocol !== "https:" || !parsed.host) {
+    // The request carries the Floe agent key as a bearer token AND your spend
+    // ledger — never send either over a non-https or malformed URL.
+    throw new LedgerSyncError(
+      `Refusing to send the ledger to ${JSON.stringify(base)}: ` +
+        `the base URL must be an https:// URL with a host.`,
+    );
+  }
+  const url = `${base}${LEDGER_SYNC_PATH}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      // Refuse redirects: a 3xx could re-send the bearer key + ledger to a host
+      // we never approved. Treat any redirect as an error.
+      redirect: "error",
+      signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/x-ndjson",
+        Accept: "application/json",
+      },
+      body: jsonl,
+    });
+  } catch (exc) {
+    const detail = exc instanceof Error ? exc.message : String(exc);
+    throw new LedgerSyncError(`Could not reach Floe at ${url}: ${detail}`);
+  }
+
+  if (!response.ok) {
+    const errBody = await response.text().catch(() => "");
+    throw new LedgerSyncError(describeHttpError(response.status, errBody));
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (exc) {
+    const detail = exc instanceof Error ? exc.message : String(exc);
+    throw new LedgerSyncError(`Malformed JSON from Floe at ${url}: ${detail}`);
+  }
+
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new LedgerSyncError(`Unexpected response shape from Floe at ${url}.`);
+  }
+  // "synced" is the count the server accepted (new rows); "duplicates" (already
+  // ingested, idempotent) are not counted here. Absent → 0; present must be a real
+  // non-negative int (reject bool/float/negative/garbage rather than coerce).
+  const synced = (payload as Record<string, unknown>).synced;
+  if (synced === undefined || synced === null) return 0;
+  if (typeof synced !== "number" || !Number.isInteger(synced) || synced < 0) {
+    throw new LedgerSyncError(`Invalid 'synced' count from Floe at ${url}: ${JSON.stringify(synced)}.`);
+  }
+  return synced;
+}

--- a/js/test/cli.test.ts
+++ b/js/test/cli.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `floe-guard push` CLI — mirrors the CLI cases in the Python
+ * `tests/test_ledger_sync.py`:
+ *
+ *   - a valid ledger FILE + --key → `pushLedger` runs, POSTs under the key,
+ *     prints the synced count, exits 0;
+ *   - a non-empty ledger with NO key → LedgerSyncError → exit 1, **zero** network
+ *     (fetch never called) — the zero-telemetry / opt-in contract.
+ *
+ * `fetch` is stubbed (never a live call); the real `pushLedger` runs end-to-end.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { main } from "../src/cli.js";
+
+const ONE_EVENT =
+  '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","prompt_tokens":null,' +
+  '"completion_tokens":null,"cost_usd":0.05}\n';
+
+let dir: string;
+let savedKey: string | undefined;
+let savedBase: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "floe-guard-cli-"));
+  savedKey = globalThis.process.env.FLOE_API_KEY;
+  savedBase = globalThis.process.env.FLOE_API_BASE_URL;
+  delete globalThis.process.env.FLOE_API_KEY;
+  delete globalThis.process.env.FLOE_API_BASE_URL;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(dir, { recursive: true, force: true });
+  if (savedKey === undefined) delete globalThis.process.env.FLOE_API_KEY;
+  else globalThis.process.env.FLOE_API_KEY = savedKey;
+  if (savedBase === undefined) delete globalThis.process.env.FLOE_API_BASE_URL;
+  else globalThis.process.env.FLOE_API_BASE_URL = savedBase;
+});
+
+function writeLedger(contents: string): string {
+  const path = join(dir, "ledger.jsonl");
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("floe-guard push", () => {
+  it("reads a ledger file and POSTs it under the key, printing the synced count", async () => {
+    const ledger = writeLedger(ONE_EVENT);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ synced: 1 }), { status: 200 }));
+    const stdout = vi.spyOn(globalThis.process.stdout, "write").mockReturnValue(true);
+
+    const rc = await main(["push", ledger, "--key", "floe_abc"]);
+
+    expect(rc).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/v1/agents/ledger/sync");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer floe_abc");
+    expect(stdout).toHaveBeenCalledWith("Synced 1 spend event(s) to Floe Reconcile Mode.\n");
+  });
+
+  it("with a non-empty ledger and NO key: exits 1 and makes zero network calls", async () => {
+    const ledger = writeLedger(ONE_EVENT);
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const stderr = vi.spyOn(globalThis.process.stderr, "write").mockReturnValue(true);
+
+    const rc = await main(["push", ledger]); // no --key, $FLOE_API_KEY unset
+
+    expect(rc).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("floe-guard push failed: No Floe API key"),
+    );
+  });
+
+  it("--help prints usage and exits 0 without touching the network", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const stdout = vi.spyOn(globalThis.process.stdout, "write").mockReturnValue(true);
+
+    const rc = await main(["push", "--help"]);
+
+    expect(rc).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining("floe-guard push"));
+  });
+});

--- a/js/test/node-test-shims.d.ts
+++ b/js/test/node-test-shims.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Test-only ambient types for Node built-ins used by the CLI/sync tests (temp
+ * files, env). Kept out of `src/node-runtime.d.ts` so the shipped library shim
+ * stays limited to what production code imports. Ambient `declare module` blocks
+ * merge, so this augments the `node:fs` surface declared there.
+ */
+
+declare module "node:fs" {
+  export function writeFileSync(path: string, data: string): void;
+  export function mkdtempSync(prefix: string): string;
+  export function rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
+}
+
+declare module "node:os" {
+  export function tmpdir(): string;
+}
+
+declare module "node:path" {
+  export function join(...parts: string[]): string;
+}

--- a/js/test/sync.test.ts
+++ b/js/test/sync.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `pushLedger` — the opt-in ledger sync client. Mirrors the `push_ledger` cases in
+ * the Python `tests/test_ledger_sync.py`: an empty ledger is a no-op with zero
+ * network; a missing key / non-https base / smuggled field all fail-closed BEFORE
+ * any send; a non-2xx is surfaced; the happy path returns the server's `synced`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LedgerSyncError } from "../src/errors.js";
+import { pushLedger } from "../src/sync.js";
+
+const ONE_EVENT = '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.01}\n';
+
+let savedKey: string | undefined;
+let savedBase: string | undefined;
+
+beforeEach(() => {
+  savedKey = globalThis.process.env.FLOE_API_KEY;
+  savedBase = globalThis.process.env.FLOE_API_BASE_URL;
+  delete globalThis.process.env.FLOE_API_KEY;
+  delete globalThis.process.env.FLOE_API_BASE_URL;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (savedKey === undefined) delete globalThis.process.env.FLOE_API_KEY;
+  else globalThis.process.env.FLOE_API_KEY = savedKey;
+  if (savedBase === undefined) delete globalThis.process.env.FLOE_API_BASE_URL;
+  else globalThis.process.env.FLOE_API_BASE_URL = savedBase;
+});
+
+describe("pushLedger", () => {
+  it("an empty ledger is a no-op and never touches the network", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    expect(await pushLedger("   ")).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a missing key fails closed before any network", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(pushLedger(ONE_EVENT)).rejects.toBeInstanceOf(LedgerSyncError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-https base URL (key + ledger must not leave over http)", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    await expect(
+      pushLedger(ONE_EVENT, "floe_abc", { baseUrl: "http://evil.test" }),
+    ).rejects.toThrow(/must be an https/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a smuggled non-schema field BEFORE any network (privacy contract)", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const bad =
+      '{"timestamp":1.0,"kind":"tool","model_or_tool":"api","cost_usd":0.01,"prompt":"secret"}\n';
+    await expect(pushLedger(bad, "floe_abc")).rejects.toThrow(/outside the exportLog/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 401 as a LedgerSyncError", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "bad key" }), { status: 401 }),
+    );
+    await expect(pushLedger(ONE_EVENT, "floe_abc")).rejects.toThrow(/401 unauthorized/);
+  });
+
+  it("returns the server's accepted count on success", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ synced: 3 }), { status: 200 }),
+    );
+    expect(await pushLedger(ONE_EVENT, "floe_abc")).toBe(3);
+  });
+
+  it("treats an absent 'synced' as zero", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+    expect(await pushLedger(ONE_EVENT, "floe_abc")).toBe(0);
+  });
+});

--- a/js/tsup.config.ts
+++ b/js/tsup.config.ts
@@ -1,15 +1,31 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: [
-    "src/index.ts",
-    "src/adapters/livekit.ts",
-    "src/adapters/vapi.ts",
-    "src/adapters/retell.ts",
-  ],
-  format: ["esm", "cjs"],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  target: "es2022",
-});
+export default defineConfig([
+  {
+    entry: [
+      "src/index.ts",
+      "src/adapters/livekit.ts",
+      "src/adapters/vapi.ts",
+      "src/adapters/retell.ts",
+    ],
+    format: ["esm", "cjs"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: "es2022",
+  },
+  {
+    // The `floe-guard` bin — a standalone Node CLI. Built separately so the
+    // shebang banner lands ONLY on dist/cli.js (not the importable library
+    // entries). ESM-only; no d.ts (it is executed, not imported).
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    dts: false,
+    clean: false,
+    sourcemap: true,
+    target: "es2022",
+    banner: { js: "#!/usr/bin/env node" },
+    // Make the emitted bin executable for direct `./dist/cli.js` invocation.
+    onSuccess: "chmod +x dist/cli.js",
+  },
+]);


### PR DESCRIPTION
## What

Ports the opt-in **ledger sync** to the TypeScript/npm `floe-guard` package at parity with the Python CLI (shipped in py 0.17.0). The Python side landed the client + CLI and noted *"JS parity + the server ingest endpoint land separately"* — this is that JS parity landing.

## Public surface (new)

- **`pushLedger(jsonl, apiKey?, { baseUrl?, timeoutMs? })`** — `Promise<number>`. Exported from the package root. POSTs the `exportLog()` JSONL to Floe's Reconcile Mode and returns the server's accepted `synced` count. Empty ledger is a no-op (zero network).
- **`LedgerSyncError`** — exported; extends `FloeGuardError`.
- **`floe-guard` bin** — one subcommand:
  - `floe-guard push [ledger.jsonl]` — reads the file, or **stdin** when the arg is omitted or `-` (so `producer | floe-guard push` works).
  - `--key <floe_…>` (defaults to `$FLOE_API_KEY`), `--base-url <url>` (defaults to `$FLOE_API_BASE_URL`, else the prod host), `-h/--help`.
  - On success: prints `Synced N spend event(s) to Floe Reconcile Mode.`, exit 0. On `LedgerSyncError`: prints to stderr, exit 1. Usage error: exit 2.

## Privacy / safety contract (mirrors Python `sync.py`)

- Validates **every** ledger line against the `exportLog()` schema **before** any network — rejects any field outside the schema, so no prompts/content/identifiers leave even from a hand-supplied file.
- Refuses non-`https://` base URLs and refuses redirects (`fetch` `redirect: "error"`) so the bearer key + ledger can't be re-sent to an unapproved host.
- Zero-telemetry stays the default: nothing sends without an explicit key **and** an explicit push (asserted in tests: `fetch` is never called for a no-key push).

## Implementation notes

- **Dependency-free.** `types: []` is preserved — `process`/`argv`/`fs`/`url` are typed via a minimal ambient shim (`src/node-runtime.d.ts`), not `@types/node`. HTTP is `fetch` (Node 18+ global).
- `tsup.config.ts` builds the CLI in a **separate config** so the `#!/usr/bin/env node` banner lands only on `dist/cli.js` (library entries stay shebang-free); an `onSuccess` `chmod +x` makes the bin executable.
- `cli.ts` exports `main(argv)` (import-safe, returns an exit code) and auto-runs only when invoked as the entry script (`import.meta.url` guard) — the ESM analogue of `if __name__ == "__main__"`.

## Version

`js/package.json` **0.12.0 → 0.14.0** (the target end-state), CHANGELOG under a new `## Unreleased — js 0.14.0`. Note: the JS sync **client itself was never shipped** (PR #79 was Python-only), so this PR ports both the client and the CLI — the JS package was at 0.12.0, not the 0.13.0 the task assumed.

## Tests

`npm test` → **184 passed** (17 files). New: `test/cli.test.ts` (file+key happy path POSTs under the key & prints the count; no-key non-empty ledger → exit 1, zero network; `--help` → exit 0) and `test/sync.test.ts` (empty no-op, missing key / non-https / smuggled-field fail-closed before network, 401 surfaced, happy-path count, absent `synced` → 0). `npm run typecheck` clean; `npm run build` emits `dist/cli.js` with a shebang, executable, and runs (`node dist/cli.js push --help`).

## Parity

TS ↔ Python agentkit-style parity: this brings the npm package to feature parity with the Python `push_ledger()` / `LedgerSyncError` / `floe-guard push` (py 0.17.0). No drift introduced.

## Handoffs

- **Server / backend:** the ingest endpoint `POST /v1/agents/ledger/sync` is a separate landing (per the py 0.17.0 changelog note); this PR is client-only.
- No schema/ABI/deploy changes.