### PR TITLE
chore: README anchor link-check + record Beta-classifier decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased — py 0.17.0
 
+### Internal (py)
+
+- **README anchor link-check in CI** (`tests/test_readme_links.py`) — asserts every
+  in-README `](#anchor)` resolves, using GitHub's exact slug algorithm (each space
+  becomes its own hyphen, so `stt -> llm -> tts` headings keep their double hyphens).
+  Prevents the naive-checker false positive that flagged the live
+  `#voice-adapters-stt--llm--tts` / `#latencybudget--deadlines-the-same-way` anchors
+  as dead. Current status: **0 dead anchors**.
+- **Release maturity: kept at `Development Status :: 4 - Beta`** for 0.17.0. The
+  documented enforcement caveats (estimate-based, cold-start concurrency, shared-file
+  persistence, approximate stream cut-offs) make `5 - Production/Stable` an overclaim;
+  rationale recorded inline in `pyproject.toml`.
+
 ### Added (py)
 
 - **Opt-in ledger sync → Reconcile Mode / Coverage Score.** A new **explicit,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,12 @@ license = { file = "LICENSE" }
 authors = [{ name = "Floe Labs" }]
 keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini", "voice", "stt", "tts", "livekit", "deepgram", "elevenlabs", "twilio"]
 classifiers = [
+    # Kept at Beta for 0.17.0 (decided 2026-08): the README's "Honest about what
+    # this is" caveats — estimate-based enforcement, cold-start concurrency not
+    # bounding the first parallel wave, cross-process persistence needing a shared
+    # SQLite file with reliable locking (not serverless-safe), and approximate
+    # stream cut-offs — are load-bearing limits. "5 - Production/Stable" would
+    # overclaim maturity. Revisit once those are closed or clearly acceptable.
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,55 @@
+"""In-README anchor link-check.
+
+Every `](#anchor)` link in the README must resolve to a heading. The slug is
+computed with GitHub's algorithm — critically, each space becomes its own hyphen
+(no collapsing), so a heading like `## Voice adapters (STT -> LLM -> TTS)` yields
+`voice-adapters-stt--llm--tts` with *double* hyphens. A naive checker that
+collapses `--` to `-` reports those live anchors as dead (a false positive); this
+one does not.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+READMES = [REPO_ROOT / "README.md", REPO_ROOT / "js" / "README.md"]
+
+
+def github_slug(heading: str) -> str:
+    """Match GitHub's heading-anchor slugifier (github-slugger)."""
+    text = heading.strip().lower()
+    text = re.sub(r"[^\w\s-]", "", text)  # keep word chars, whitespace, hyphens
+    return text.replace(" ", "-")  # each space -> one hyphen; NO collapse
+
+
+def heading_anchors(markdown: str) -> set[str]:
+    slugs: list[str] = [
+        github_slug(m) for m in re.findall(r"^#{1,6}\s+(.*)$", markdown, re.M)
+    ]
+    # GitHub disambiguates repeated headings with -1, -2, ... suffixes.
+    seen: dict[str, int] = {}
+    resolved: set[str] = set()
+    for slug in slugs:
+        if slug in seen:
+            seen[slug] += 1
+            resolved.add(f"{slug}-{seen[slug]}")
+        else:
+            seen[slug] = 0
+            resolved.add(slug)
+    return resolved
+
+
+def internal_links(markdown: str) -> list[str]:
+    return re.findall(r"\]\(#([\w-]+)\)", markdown)
+
+
+@pytest.mark.parametrize("path", READMES, ids=lambda p: p.relative_to(REPO_ROOT).as_posix())
+def test_readme_internal_anchors_resolve(path: Path) -> None:
+    markdown = path.read_text(encoding="utf-8")
+    anchors = heading_anchors(markdown)
+    dead = sorted({link for link in internal_links(markdown) if link not in anchors})
+    assert not dead, f"{path.name}: dead in-README anchors: {dead}"


### PR DESCRIPTION
Launch-hygiene bundle — floe-guard parts (Parts 2 & 3). Part 1 (llms.txt voice positioning) is a separate PR in floe-labs-docs.

## Part 2 — README anchor link-check (dead-anchor premise was a false positive)
The reported "two dead anchors" (\`#voice-adapters-stt--llm--tts\`, \`#latencybudget--deadlines-the-same-way\`) are **live** — a naive link-checker that collapses \`--\`→\`-\` misreads them, but GitHub turns each space into its own hyphen, so the double hyphens are correct. **Actual dead count across README.md + js/README.md: 0.**

- Adds \`tests/test_readme_links.py\` using GitHub's exact slug algorithm; runs in the existing pytest CI ("a link-check passes in CI"). Guards against future real breakage without re-raising the false positive.

## Part 3 — Beta vs Production/Stable
**Decision: keep \`Development Status :: 4 - Beta\` for 0.17.0.** The README's documented enforcement caveats — estimate-based, cold-start concurrency not bounding the first parallel wave, cross-process persistence needing a shared SQLite file with reliable locking (not serverless-safe), approximate stream cut-offs — make \`5 - Production/Stable\` an overclaim. Rationale recorded inline at the classifier in \`pyproject.toml\` and in CHANGELOG.

## Notes
- Metadata comment only, no version bump — hence \`skip-version-guard\`.
- Branched off \`main\`, independent of #83 (not stacked).