### PR TITLE
fix: repair no-API-key examples on Windows and add smoke test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,35 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   `llm_node` isn't wrapped, so its turns are still metered (reconcile) but the
   pre-turn hard-stop is bypassed until you re-`attach()`; `update_options` (same
   agent, swapped models) keeps the reserve hook.
+- **Windows-safe example output.** Replace non-cp1252 characters (`U+2192 →`,
+  `U+2248 ≈`) with ASCII equivalents (`->`, `~=`) in the printed strings of
+  `examples/budget_aware.py`, `examples/context_size.py`,
+  `examples/retrieval_depth.py`, and `examples/streaming_guard.py`. The
+  Unicode-only characters caused `UnicodeEncodeError` on Windows consoles using
+  the default cp1252 encoding. Characters that appear only in docstrings or
+  comments (not printed at runtime) are left unchanged.
+- **Deterministic stdout/stderr ordering for redirected demo output.** Added
+  `flush=True` to every `print()` status line in
+  `examples/runaway_loop.py`, `examples/budget_aware.py`,
+  `examples/tool_budget.py`, `examples/step_budget.py`,
+  `examples/streaming_guard.py`, `examples/openai_adapter.py`,
+  `examples/anthropic_adapter.py`, `examples/budget_retry.py`, and
+  `examples/plan_complexity.py`. When stdout is redirected or piped the OS
+  buffers it while stderr (where the library's block banner goes) is
+  unbuffered, producing output in the wrong order. Flushing each status print
+  ensures the logical sequence is preserved. The library's own stderr behavior
+  is unchanged.
+- **Subprocess smoke tests for the no-API-key examples.** New
+  `tests/test_examples_smoke.py` executes each README-promoted example as a
+  real subprocess (no import tricks), strips `FLOE_API_KEY` and
+  `OPENAI_API_KEY` from the environment, asserts `returncode == 0`, and
+  checks for a meaningful output marker. Covers: `runaway_loop.py`,
+  `budget_aware.py`, `context_size.py`, `retrieval_depth.py`,
+  `plan_complexity.py`, `tool_budget.py`, `step_budget.py`,
+  `streaming_guard.py`, `budget_retry.py`, `openai_adapter.py`, and
+  `anthropic_adapter.py`. The ordering test for `runaway_loop.py` merges
+  stdout and stderr and asserts that "Starting a runaway loop" precedes the
+  "BUDGET EXCEEDED" banner.
 
 ## Unreleased — js 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 - **Windows-safe example output.** Replace non-cp1252 characters (`U+2192 →`,
   `U+2248 ≈`) with ASCII equivalents (`->`, `~=`) in the printed strings of
   `examples/budget_aware.py`, `examples/context_size.py`,
-  `examples/retrieval_depth.py`, and `examples/streaming_guard.py`. The
+  `examples/retrieval_depth.py`, `examples/streaming_guard.py`, and
+  `examples/langgraph_budget_aware.py`. The
   Unicode-only characters caused `UnicodeEncodeError` on Windows consoles using
   the default cp1252 encoding. Characters that appear only in docstrings or
   comments (not printed at runtime) are left unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 - **Deterministic stdout/stderr ordering for redirected demo output.** Added
   `flush=True` to every `print()` status line in
   `examples/runaway_loop.py`, `examples/budget_aware.py`,
+  `examples/context_size.py`, `examples/retrieval_depth.py`,
   `examples/tool_budget.py`, `examples/step_budget.py`,
   `examples/streaming_guard.py`, `examples/openai_adapter.py`,
   `examples/anthropic_adapter.py`, `examples/budget_retry.py`, and

--- a/examples/anthropic_adapter.py
+++ b/examples/anthropic_adapter.py
@@ -85,7 +85,10 @@ def _call(guard: BudgetGuard, usage: _Usage) -> float:
 def main() -> None:
     guard = BudgetGuard(limit_usd=1.00)
 
-    print(f"Simulating a conversation that re-sends a {CONTEXT_TOKENS}-token context...\n")
+    print(
+        f"Simulating a conversation that re-sends a {CONTEXT_TOKENS}-token context...\n",
+        flush=True,
+    )
 
     # Turn 1: nothing cached yet — write the context to the 5m-TTL cache.
     cold_usage = _Usage(
@@ -95,7 +98,7 @@ def main() -> None:
         cache_creation=_CacheCreation(ephemeral_5m_input_tokens=CONTEXT_TOKENS),
     )
     cold_cost = _call(guard, cold_usage)
-    print(f"  turn 1 (cache write): ${cold_cost:.5f}")
+    print(f"  turn 1 (cache write): ${cold_cost:.5f}", flush=True)
 
     # Turns 2-3: same context, now served from cache.
     warm_usage = _Usage(
@@ -104,9 +107,9 @@ def main() -> None:
         cache_read_input_tokens=CONTEXT_TOKENS,
     )
     warm_cost = _call(guard, warm_usage)
-    print(f"  turn 2 (cache read):  ${warm_cost:.5f}")
+    print(f"  turn 2 (cache read):  ${warm_cost:.5f}", flush=True)
     warm_cost_2 = _call(guard, warm_usage)
-    print(f"  turn 3 (cache read):  ${warm_cost_2:.5f}")
+    print(f"  turn 3 (cache read):  ${warm_cost_2:.5f}", flush=True)
 
     # Probe: what would turn 2 have cost if it re-sent the context uncached
     # (no cache_read_input_tokens — just a plain, full-price input)? Measured
@@ -120,9 +123,12 @@ def main() -> None:
 
     savings = uncached_cost - warm_cost
     multiple = uncached_cost / warm_cost if warm_cost else float("inf")
-    print(f"\nSame turn, uncached: ${uncached_cost:.5f}")
-    print(f"Cached read was ${savings:.5f} cheaper ({multiple:.1f}x less) than resending fresh.")
-    print(f"\nTotal spent over 3 turns: ${guard.spent_usd:.5f}")
+    print(f"\nSame turn, uncached: ${uncached_cost:.5f}", flush=True)
+    print(
+        f"Cached read was ${savings:.5f} cheaper ({multiple:.1f}x less) than resending fresh.",
+        flush=True,
+    )
+    print(f"\nTotal spent over 3 turns: ${guard.spent_usd:.5f}", flush=True)
 
 
 if __name__ == "__main__":

--- a/examples/budget_aware.py
+++ b/examples/budget_aware.py
@@ -11,6 +11,7 @@ vendor/cap with server-truth balances — your taper logic ports unchanged.)
 
 Run:  python examples/budget_aware.py
 """
+
 from __future__ import annotations
 
 from floe_guard import BudgetExceeded, BudgetGuard
@@ -28,7 +29,10 @@ def stub_llm(model: tuple[str, int, int]) -> dict[str, object]:
 def main() -> None:
     # Taper at 70% used so there's room to downshift before the ceiling.
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
-    print(f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n")
+    print(
+        f"Budget ${guard.limit_usd:.2f} · taper at {guard.near_limit_bps / 100:.0f}% used\n",
+        flush=True,
+    )
 
     step = 0
     tapered = False
@@ -41,7 +45,8 @@ def main() -> None:
             tapered = True
             print(
                 f"  [advisory] {adv.used_bps / 100:.0f}% used, "
-                f"${adv.remaining_usd:.4f} left → tapering to {model[0]}\n"
+                f"${adv.remaining_usd:.4f} left -> tapering to {model[0]}\n",
+                flush=True,
             )
 
         try:
@@ -49,7 +54,8 @@ def main() -> None:
         except BudgetExceeded:
             print(
                 f"\nStopped at step {step}. "
-                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f}).",
+                flush=True,
             )
             break
 
@@ -59,7 +65,10 @@ def main() -> None:
             int(response["prompt_tokens"]),  # type: ignore[arg-type]
             int(response["completion_tokens"]),  # type: ignore[arg-type]
         )
-        print(f"  step {step:>2}: {model[0]:<12} +${cost:.4f}  (total ${guard.spent_usd:.4f})")
+        print(
+            f"  step {step:>2}: {model[0]:<12} +${cost:.4f}  (total ${guard.spent_usd:.4f})",
+            flush=True,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/budget_retry.py
+++ b/examples/budget_retry.py
@@ -42,8 +42,8 @@ def main() -> None:
         on_degrade=degrade,
     )
 
-    print(result)
-    print(calls)
+    print(result, flush=True)
+    print(calls, flush=True)
 
 
 if __name__ == "__main__":

--- a/examples/context_size.py
+++ b/examples/context_size.py
@@ -58,10 +58,14 @@ def main() -> None:
     """Run the context size adaptation example."""
     # Taper at 70% used so there's room to trim before the ceiling.
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
-    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · context size adapts")
     print(
-        f"  full transcript + max_tokens {MAX_TOKENS_FULL} → last {KEEP_RECENT_TURNS} turns "
-        f"+ max_tokens {MAX_TOKENS_TAPER} at {guard.near_limit_bps / 100:.0f}% used\n"
+        f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · context size adapts",
+        flush=True,
+    )
+    print(
+        f"  full transcript + max_tokens {MAX_TOKENS_FULL} -> last {KEEP_RECENT_TURNS} turns "
+        f"+ max_tokens {MAX_TOKENS_TAPER} at {guard.near_limit_bps / 100:.0f}% used\n",
+        flush=True,
     )
 
     history: list[str] = []
@@ -76,8 +80,9 @@ def main() -> None:
             trimmed = True
             print(
                 f"  [advisory] {adv.used_bps / 100:.0f}% used, "
-                f"${adv.remaining_usd:.4f} left → trimming to the last "
-                f"{turns_sent} turns, max_tokens {max_tokens}\n"
+                f"${adv.remaining_usd:.4f} left -> trimming to the last "
+                f"{turns_sent} turns, max_tokens {max_tokens}\n",
+                flush=True,
             )
 
         # Request-sized: the prompt grows with the transcript, so the last call's
@@ -88,7 +93,8 @@ def main() -> None:
         except BudgetExceeded:
             print(
                 f"\nStopped at turn {turn}. "
-                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f}).",
+                flush=True,
             )
             break
 
@@ -100,7 +106,8 @@ def main() -> None:
         )
         print(
             f"  turn {turn:>2}: {turns_sent:>2} of {len(history):>2} turns sent · "
-            f"max_tokens {max_tokens:>3}  +${cost:.4f}  (total ${guard.spent_usd:.4f})"
+            f"max_tokens {max_tokens:>3}  +${cost:.4f}  (total ${guard.spent_usd:.4f})",
+            flush=True,
         )
 
 

--- a/examples/langgraph_budget_aware.py
+++ b/examples/langgraph_budget_aware.py
@@ -86,7 +86,7 @@ def main() -> None:
     for step, model in enumerate(final["log"], start=1):
         if model == CHEAP[0] and not tapered:
             tapered = True
-            print("  [advisory] near_limit tripped → tapering to", model, "\n")
+            print("  [advisory] near_limit tripped -> tapering to", model, "\n")
         print(f"  step {step:>2}: {model}")
 
     print(

--- a/examples/openai_adapter.py
+++ b/examples/openai_adapter.py
@@ -67,7 +67,10 @@ def main() -> None:
     guard = BudgetGuard(limit_usd=0.05)
     client = _Client()
 
-    print(f"Starting with a ${guard.limit_usd:.2f} budget against a stub OpenAI client...\n")
+    print(
+        f"Starting with a ${guard.limit_usd:.2f} budget against a stub OpenAI client...\n",
+        flush=True,
+    )
     call = 0
     while True:
         call += 1
@@ -76,10 +79,16 @@ def main() -> None:
             response = guarded_completion(guard, client, model=MODEL, messages=messages)
         except BudgetExceeded:
             calls_made = client.chat.completions.call_count
-            print(f"\nCall #{call} blocked before reaching the client.")
-            print(f"client.chat.completions.create was invoked {calls_made} times (not {call}).")
+            print(f"\nCall #{call} blocked before reaching the client.", flush=True)
+            print(
+                f"client.chat.completions.create was invoked {calls_made} times (not {call}).",
+                flush=True,
+            )
             break
-        print(f"  call #{call}: served by {response.model}  (running total ${guard.spent_usd:.4f})")
+        print(
+            f"  call #{call}: served by {response.model}  (running total ${guard.spent_usd:.4f})",
+            flush=True,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/plan_complexity.py
+++ b/examples/plan_complexity.py
@@ -69,11 +69,15 @@ def main() -> None:
     # Reasoning thins at 40% used (TAPER_BPS), optional tasks drop at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
     required = sum(1 for _, is_required, _ in PLAN if is_required)
-    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · plan complexity adapts")
+    print(
+        f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · plan complexity adapts",
+        flush=True,
+    )
     print(
         f"  {len(PLAN)} sub-tasks ({required} required) · thinner reasoning at "
         f"{TAPER_BPS / 100:.0f}% used · optional dropped at "
-        f"{guard.near_limit_bps / 100:.0f}%\n"
+        f"{guard.near_limit_bps / 100:.0f}%\n",
+        flush=True,
     )
 
     round_no = 0
@@ -87,12 +91,13 @@ def main() -> None:
         print(
             f"  round {round_no}: {planned} of {len(PLAN)} sub-tasks · "
             f"{'full' if full_reasoning else 'reduced'} reasoning  "
-            f"[{adv.used_bps / 100:.0f}% used, ${adv.remaining_usd:.4f} left]"
+            f"[{adv.used_bps / 100:.0f}% used, ${adv.remaining_usd:.4f} left]",
+            flush=True,
         )
 
         for name, is_required, steps in PLAN:
             if not is_required and not run_optional:
-                print(f"    {name:<19} [skipped — optional]")
+                print(f"    {name:<19} [skipped — optional]", flush=True)
                 continue
 
             reasoning_steps = reasoning_steps_for(steps, full_reasoning)
@@ -102,7 +107,7 @@ def main() -> None:
             try:
                 guard.check(est)  # the hard guarantee — simplified or not, this holds the line
             except BudgetExceeded:
-                print(f"    {name:<19} [blocked — would cross the ceiling]")
+                print(f"    {name:<19} [blocked — would cross the ceiling]", flush=True)
                 stopped = True
                 break
 
@@ -116,11 +121,15 @@ def main() -> None:
                 completed_required += 1
             plural = "s" if reasoning_steps > 1 else ""
             steps_label = f"{reasoning_steps} reasoning step{plural}"
-            print(f"    {name:<19} {steps_label:<18} +${cost:.4f}  (total ${guard.spent_usd:.4f})")
+            print(
+                f"    {name:<19} {steps_label:<18} +${cost:.4f}  (total ${guard.spent_usd:.4f})",
+                flush=True,
+            )
 
     print(
         f"\nStopped in round {round_no} after {completed_required} required sub-tasks. "
-        f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+        f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f}).",
+        flush=True,
     )
 
 

--- a/examples/retrieval_depth.py
+++ b/examples/retrieval_depth.py
@@ -59,10 +59,14 @@ def main() -> None:
     """Run the retrieval depth adaptation example."""
     # First downshift at 40% used (TAPER_BPS), final floor at 70% (near_limit).
     guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)
-    print(f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · retrieval depth adapts")
     print(
-        f"  {TOP_K_FULL} chunks → {TOP_K_TAPER} at {TAPER_BPS / 100:.0f}% used "
-        f"→ {TOP_K_FLOOR} at {guard.near_limit_bps / 100:.0f}%\n"
+        f"Budget ${guard.limit_usd:.2f} · model fixed at {MODEL} · retrieval depth adapts",
+        flush=True,
+    )
+    print(
+        f"  {TOP_K_FULL} chunks -> {TOP_K_TAPER} at {TAPER_BPS / 100:.0f}% used "
+        f"-> {TOP_K_FLOOR} at {guard.near_limit_bps / 100:.0f}%\n",
+        flush=True,
     )
 
     step = 0
@@ -74,7 +78,8 @@ def main() -> None:
         if top_k != depth:
             print(
                 f"  [advisory] {adv.used_bps / 100:.0f}% used, "
-                f"${adv.remaining_usd:.4f} left → retrieving {top_k} chunks, not {depth}\n"
+                f"${adv.remaining_usd:.4f} left -> retrieving {top_k} chunks, not {depth}\n",
+                flush=True,
             )
             depth = top_k
 
@@ -86,7 +91,8 @@ def main() -> None:
         except BudgetExceeded:
             print(
                 f"\nStopped at step {step}. "
-                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f})."
+                f"Final spend ${guard.spent_usd:.4f} (held under ${guard.limit_usd:.2f}).",
+                flush=True,
             )
             break
 
@@ -98,7 +104,8 @@ def main() -> None:
         )
         print(
             f"  step {step:>2}: {MODEL:<8} {top_k:>2} chunks  "
-            f"+${cost:.4f}  (total ${guard.spent_usd:.4f})"
+            f"+${cost:.4f}  (total ${guard.spent_usd:.4f})",
+            flush=True,
         )
 
 

--- a/examples/runaway_loop.py
+++ b/examples/runaway_loop.py
@@ -31,18 +31,21 @@ def stub_llm(prompt: str) -> dict[str, object]:
 
 
 def main() -> None:
-    # $0.10 ceiling. gpt-4o at 1k in + 1k out ≈ $0.0125/call, so the guard should
+    # $0.10 ceiling. gpt-4o at 1k in + 1k out ~= $0.0125/call, so the guard should
     # stop the loop after a handful of iterations — well before any real damage.
     guard = BudgetGuard(limit_usd=0.10)
 
-    print(f"Starting a runaway loop with a ${guard.limit_usd:.2f} budget...\n")
+    print(f"Starting a runaway loop with a ${guard.limit_usd:.2f} budget...\n", flush=True)
     call = 0
     while True:  # a real runaway loop never decides to stop on its own
         call += 1
         try:
             guard.check()  # <-- the kill-switch: raises before the crossing call
         except BudgetExceeded:
-            print(f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.")
+            print(
+                f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.",
+                flush=True,
+            )
             break
 
         response = stub_llm("keep going")
@@ -51,7 +54,7 @@ def main() -> None:
             int(response["prompt_tokens"]),  # type: ignore[arg-type]
             int(response["completion_tokens"]),  # type: ignore[arg-type]
         )
-        print(f"  call #{call}: +${cost:.4f}  (running total ${guard.spent_usd:.4f})")
+        print(f"  call #{call}: +${cost:.4f}  (running total ${guard.spent_usd:.4f})", flush=True)
 
 
 if __name__ == "__main__":

--- a/examples/step_budget.py
+++ b/examples/step_budget.py
@@ -29,7 +29,8 @@ def main() -> None:
         adv = g.advisory()
         print(
             f"step 1 (plan): used {adv.step_remaining_tokens} tokens of headroom left, "
-            f"near_limit={adv.near_limit}"
+            f"near_limit={adv.near_limit}",
+            flush=True,
         )
 
     # Step 2 — retrieval: a 5_000-token cap, and a call that would blow it.
@@ -37,21 +38,27 @@ def main() -> None:
         with guard.step(max_tokens=5_000) as g:
             g.record(MODEL, 3_000, 1_500)  # 4_500 into the step
             g.check(estimated_tokens=1_000)  # 4_500 + 1_000 > 5_000 → blocked
-            print("step 2: this line should not print")
+            print("step 2: this line should not print", flush=True)
     except TokenBudgetExceeded as exc:
-        print(f"step 2 (retrieve): hard-stopped at the step cap — {exc} (scope={exc.scope})")
+        print(
+            f"step 2 (retrieve): hard-stopped at the step cap — {exc} (scope={exc.scope})",
+            flush=True,
+        )
 
     # The blocked call consumed no tokens, but Step 2's already-recorded 4,500
     # tokens still count against the global ceiling — the step cap stopped the
     # overshoot, not the run, so the loop keeps going.
-    print(f"global tokens spent so far: {guard.spent_tokens} / {guard.token_limit}")
+    print(f"global tokens spent so far: {guard.spent_tokens} / {guard.token_limit}", flush=True)
 
     # Step 3 — synthesis: fits comfortably.
     with guard.step(max_tokens=3_000) as g:
         g.record(MODEL, 1_000, 800)
-        print(f"step 3 (synthesize): done, {g.advisory().step_remaining_tokens} step tokens left")
+        print(
+            f"step 3 (synthesize): done, {g.advisory().step_remaining_tokens} step tokens left",
+            flush=True,
+        )
 
-    print(f"run complete — {guard.spent_tokens} total tokens across all steps")
+    print(f"run complete — {guard.spent_tokens} total tokens across all steps", flush=True)
 
 
 if __name__ == "__main__":

--- a/examples/streaming_guard.py
+++ b/examples/streaming_guard.py
@@ -37,30 +37,36 @@ def stub_llm_stream() -> Iterator[str]:
 
 
 def main() -> None:
-    guard = BudgetGuard(limit_usd=0.01)  # ≙ 1_000 gpt-4o output tokens
+    guard = BudgetGuard(limit_usd=0.01)  # ~= 1_000 gpt-4o output tokens
 
-    # ── 1. the oversized FIRST call is blocked pre-flight ──────────────────────
-    print(f"Budget: ${guard.limit_usd:.2f}\n")
-    print("1) First call asks for 100k output tokens (≈ $1.00):")
+    # -- 1. the oversized FIRST call is blocked pre-flight ──────────────────────
+    print(f"Budget: ${guard.limit_usd:.2f}\n", flush=True)
+    print("1) First call asks for 100k output tokens (~= $1.00):", flush=True)
     estimate = guard.estimate_call(MODEL, prompt_tokens=1_000, max_completion_tokens=100_000)
     try:
         guard.reserve(estimate)  # request-sized, so call #1 has no free pass
     except BudgetExceeded:
-        print("   blocked BEFORE the request was sent — $0.00 spent.\n")
+        print("   blocked BEFORE the request was sent — $0.00 spent.\n", flush=True)
 
-    # ── 2. a stream that starts cheap but runs long is cut off mid-flight ──────
-    print("2) Streaming a response that never wants to stop:")
+    # -- 2. a stream that starts cheap but runs long is cut off mid-flight ──────
+    print("2) Streaming a response that never wants to stop:", flush=True)
     chunks = 0
     try:
         for _ in guard_stream(guard, MODEL, stub_llm_stream()):
             chunks += 1
     except BudgetExceeded:
-        print(f"   stream cut off mid-generation after {chunks} chunks.")
-        print(f"   spent ${guard.spent_usd:.4f} of the ${guard.limit_usd:.2f} ceiling — "
-              "the partial spend is settled, not lost:")
+        print(f"   stream cut off mid-generation after {chunks} chunks.", flush=True)
+        print(
+            f"   spent ${guard.spent_usd:.4f} of the ${guard.limit_usd:.2f} ceiling — "
+            "the partial spend is settled, not lost:",
+            flush=True,
+        )
         for event in guard.spend_log:
-            print(f"     ledger: {event.kind} {event.model_or_tool} "
-                  f"{event.completion_tokens} tokens → ${event.cost_usd:.4f}")
+            print(
+                f"     ledger: {event.kind} {event.model_or_tool} "
+                f"{event.completion_tokens} tokens -> ${event.cost_usd:.4f}",
+                flush=True,
+            )
 
 
 if __name__ == "__main__":

--- a/examples/tool_budget.py
+++ b/examples/tool_budget.py
@@ -36,10 +36,10 @@ def stub_exa_search(query: str) -> list[str]:
 
 def main() -> None:
     guard = BudgetGuard(limit_usd=0.10)
-    print(f"Budget: ${guard.limit_usd:.2f} — shared by tokens AND tools\n")
+    print(f"Budget: ${guard.limit_usd:.2f} — shared by tokens AND tools\n", flush=True)
 
-    # ── 1. pre-call hard-stop: reserve the KNOWN price before the call ─────────
-    print("Prospecting until the budget says stop...")
+    # -- 1. pre-call hard-stop: reserve the KNOWN price before the call ─────────
+    print("Prospecting until the budget says stop...", flush=True)
     companies = 0
     try:
         while True:
@@ -52,12 +52,12 @@ def main() -> None:
                 guard.record_tool("exa.search", EXA_COST)
             companies += 1
     except BudgetExceeded:
-        print(f"  stopped after {companies} companies — the crossing call never ran.\n")
+        print(f"  stopped after {companies} companies — the crossing call never ran.\n", flush=True)
 
-    # ── 2. attribution: where did the money go? ────────────────────────────────
-    print(f"spent ${guard.spent_usd:.4f} of ${guard.limit_usd:.2f}, by tool:")
+    # -- 2. attribution: where did the money go? ────────────────────────────────
+    print(f"spent ${guard.spent_usd:.4f} of ${guard.limit_usd:.2f}, by tool:", flush=True)
     for tool, total in sorted(guard.tool_costs.items()):
-        print(f"  {tool:<22} ${total:.4f}")
+        print(f"  {tool:<22} ${total:.4f}", flush=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -1,0 +1,136 @@
+"""Subprocess smoke tests for the no-API-key examples.
+
+Each test runs an example as a real subprocess (no import tricks), removes
+FLOE_API_KEY and OPENAI_API_KEY from the environment, asserts a zero exit
+code, and checks for a meaningful output marker.
+
+The ordering test for runaway_loop.py additionally verifies that the
+"Starting a runaway loop" line appears *before* the budget-exceeded banner
+when stdout and stderr are interleaved — the flush=True on every status print
+guarantees this even when stdout is redirected/piped.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+TIMEOUT = 60  # seconds
+
+
+def _run(name: str, *, merge_stderr: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run an example as a subprocess without any API keys."""
+    env = {k: v for k, v in os.environ.items() if k not in {"FLOE_API_KEY", "OPENAI_API_KEY"}}
+    return subprocess.run(
+        [sys.executable, str(EXAMPLES / name)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
+        text=True,
+        timeout=TIMEOUT,
+        env=env,
+    )
+
+
+def test_runaway_loop() -> None:
+    result = _run("runaway_loop.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Loop stopped at call" in combined
+
+
+def test_runaway_loop_output_ordering() -> None:
+    """Starting message must appear before the budget-exceeded banner.
+
+    Merges stdout and stderr into a single stream (the same way a terminal
+    or ``2>&1`` pipe would) and checks the relative positions.
+    """
+    result = _run("runaway_loop.py", merge_stderr=True)
+    assert result.returncode == 0, result.stdout
+    combined = result.stdout
+
+    assert "Starting a runaway loop" in combined, "expected startup message in output"
+    assert "Loop stopped at call" in combined, "expected stop message in output"
+
+    start_pos = combined.index("Starting a runaway loop")
+    # The budget-exceeded banner is written to stderr by the library.
+    # After merging, it must come AFTER the startup line.
+    if "BUDGET EXCEEDED" in combined:
+        banner_pos = combined.index("BUDGET EXCEEDED")
+        assert start_pos < banner_pos, (
+            "startup message must appear before the BUDGET EXCEEDED banner; "
+            f"got start_pos={start_pos}, banner_pos={banner_pos}"
+        )
+
+
+def test_budget_aware() -> None:
+    result = _run("budget_aware.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Stopped at step" in combined
+
+
+def test_context_size() -> None:
+    result = _run("context_size.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Stopped at turn" in combined
+
+
+def test_retrieval_depth() -> None:
+    result = _run("retrieval_depth.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Stopped at step" in combined
+
+
+def test_plan_complexity() -> None:
+    result = _run("plan_complexity.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Stopped in round" in combined
+
+
+def test_tool_budget() -> None:
+    result = _run("tool_budget.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "stopped after" in combined
+
+
+def test_step_budget() -> None:
+    result = _run("step_budget.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "run complete" in combined
+
+
+def test_streaming_guard() -> None:
+    result = _run("streaming_guard.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "stream cut off" in combined
+
+
+def test_budget_retry() -> None:
+    result = _run("budget_retry.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "retried on cheaper model" in combined
+
+
+def test_openai_adapter() -> None:
+    result = _run("openai_adapter.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "blocked before reaching the client" in combined.lower()
+
+
+def test_anthropic_adapter() -> None:
+    result = _run("anthropic_adapter.py")
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "cache" in combined.lower()

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -56,14 +56,16 @@ def test_runaway_loop_output_ordering() -> None:
     assert "Loop stopped at call" in combined, "expected stop message in output"
 
     start_pos = combined.index("Starting a runaway loop")
-    # The budget-exceeded banner is written to stderr by the library.
+    # The budget-exceeded banner is written to stderr by the library and is
+    # deterministic for this demo (the loop always crosses the ceiling), so
+    # require it — its absence is a regression, not a pass.
+    assert "BUDGET EXCEEDED" in combined, "expected the BUDGET EXCEEDED banner in output"
+    banner_pos = combined.index("BUDGET EXCEEDED")
     # After merging, it must come AFTER the startup line.
-    if "BUDGET EXCEEDED" in combined:
-        banner_pos = combined.index("BUDGET EXCEEDED")
-        assert start_pos < banner_pos, (
-            "startup message must appear before the BUDGET EXCEEDED banner; "
-            f"got start_pos={start_pos}, banner_pos={banner_pos}"
-        )
+    assert start_pos < banner_pos, (
+        "startup message must appear before the BUDGET EXCEEDED banner; "
+        f"got start_pos={start_pos}, banner_pos={banner_pos}"
+    )
 
 
 def test_budget_aware() -> None:


### PR DESCRIPTION
## Summary

Fixes three bugs in the README-promoted no-API-key examples: a hard crash on Windows consoles (non-cp1252 Unicode in printed strings), wrong stdout/stderr ordering when output is redirected, and no CI coverage for these code paths.

## Changes

- **Windows encoding fix** : replace `→` (U+2192) and `≈` (U+2248) with ASCII equivalents (`->`, `~=`) in printed strings in `budget_aware.py`,  `context_size.py`, `retrieval_depth.py`, and `streaming_guard.py`. Characters that appear only in docstrings or comments are left unchanged.
- **Deterministic stdout flushing** : add `flush=True` to every status `print()` in `runaway_loop.py`, `budget_aware.py`, `tool_budget.py`, `step_budget.py`, `streaming_guard.py`, `openai_adapter.py`, `anthropic_adapter.py`, `budget_retry.py`, and `plan_complexity.py`. Prevents the library's unbuffered stderr banner from appearing before buffered stdout lines when output is piped.
- **Subprocess smoke tests** : new `tests/test_examples_smoke.py` runs all eleven no-API-key examples as real subprocesses, strips API keys from the environment, asserts `returncode == 0`, and checks for a meaningful output marker. Includes
  an ordering regression test for `runaway_loop.py`.
- **CHANGELOG** : three bullets added under `Unreleased - py 0.16.2 / Fixed (py)`.

## Testing

- [x] `pytest` passes (Python changes) : 388 passed, 3 skipped
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [ ] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes) : N/A, no JS changes
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)
- [x] Manually verified on Windows: `budget_aware.py`, `context_size.py`, `retrieval_depth.py`, `streaming_guard.py`, `runaway_loop.py` all exit 0 with no encoding errors
- [x] Redirected ordering verified: `python examples/runaway_loop.py 2>&1 | Out-File out.txt` : "Starting a runaway loop" precedes "BUDGET EXCEEDED" in the file

## Related issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved example output reliability when redirected, ensuring status messages appear in the correct order.
  * Replaced non-ASCII symbols with Windows-safe ASCII equivalents in example output.

* **Tests**
  * Added smoke tests covering no-API-key examples, successful execution, expected output, timeouts, and output ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->