### PR TITLE
fix: retry safety and step-USD diagnostics parity (py/js)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,27 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.17.0
+## Unreleased — py 0.17.1
+
+### Fixed (py)
+
+- **Retry predicate: block the entire `FloeGuardError` family, not just
+  `BudgetExceeded`.** The previous default predicate (`not isinstance(exc,
+  BudgetExceeded)`) would retry deterministic guard errors such as
+  `UnpriceableModelError`, potentially multiplying LLM spend on errors that
+  retrying cannot fix. The new default (`not isinstance(exc, FloeGuardError)`)
+  treats every `FloeGuardError` — `BudgetExceeded`, `UnpriceableModelError`,
+  `UnpriceableVoiceError`, `HostedEnforcementError`, `DeadlineExceeded`, etc. —
+  as terminal. Since `BudgetExceeded` is already a `FloeGuardError` subclass,
+  its existing no-retry behavior is preserved with no wiring changes.
+- **Step-USD diagnostics: `BudgetExceeded` now carries the step ceiling and
+  step committed spend, not the aggregate guard values.** When a per-step USD
+  budget (`guard.step(max_usd=…)`) was crossed, the resulting `BudgetExceeded`
+  reported the aggregate guard figures (`spent $X of $Y`), even though the
+  violated ceiling was the (much smaller) step cap. The blocking cross-check now
+  snapshots and returns the step's own `s_committed` and `step.max_usd`, so
+  `exc.spent_usd` / `exc.limit_usd` and the message reflect the step boundary.
+  Token-step and aggregate-budget behavior are unchanged.
 
 ### Added (py)
 
@@ -64,7 +84,25 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   pre-turn hard-stop is bypassed until you re-`attach()`; `update_options` (same
   agent, swapped models) keeps the reserve hook.
 
-## Unreleased — js 0.13.0
+## Unreleased — js 0.13.1
+
+### Fixed (js)
+
+- **Retry predicate: block the entire `FloeGuardError` family, not just
+  `BudgetExceeded`.** The previous default predicate (`!(error instanceof
+  BudgetExceeded)`) would retry deterministic guard errors such as
+  `UnpriceableModelError`, potentially multiplying LLM spend on errors that
+  retrying cannot fix. The new default (`!(error instanceof FloeGuardError)`)
+  treats every `FloeGuardError` as terminal. Since `BudgetExceeded` is already
+  a `FloeGuardError` subclass, its existing no-retry behavior is preserved.
+- **Step-USD diagnostics: `BudgetExceeded` now carries the step ceiling and
+  step committed spend, not the aggregate guard values.** When a per-step USD
+  budget (`guard.step({ maxUsd: … })`) was crossed, `BudgetExceeded` reported
+  the aggregate guard figures. The blocking cross now captures the step's own
+  `sCommitted` and `step.maxUsd` and returns them in a 4-element tuple (matching
+  Python's `(dimension, scope, spent, limit)` shape), so `error.spentUsd` /
+  `error.limitUsd` and the message reflect the step boundary. Token-step and
+  aggregate-budget behavior are unchanged.
 
 ### Added (js)
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.12.0",
+      "version": "0.13.1",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",
@@ -19,7 +19,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@livekit/agents": ">=1.5.0",
+        "@livekit/agents": ">=1.5.0 <2.0.0",
         "ai": ">=4.0.0 <6.0.0"
       },
       "peerDependenciesMeta": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -805,24 +805,26 @@ export class BudgetGuard {
 
   /**
    * The ONE choke point, across two dimensions and two scopes. Returns the first
-   * ceiling that blocks as `[dimension, scope]` — dimension `"usd" | "tokens"`,
-   * scope `"aggregate" | "step"` — or `null` if the call fits everywhere.
-   * Aggregate is checked before step (the guard-wide ceiling is the hard limit).
+   * ceiling that blocks as `[dimension, scope, spent, limit]` — dimension
+   * `"usd" | "tokens"`, scope `"aggregate" | "step"` — or `null` if the call
+   * fits everywhere. Aggregate is checked before step (the guard-wide ceiling
+   * is the hard limit). `spent` / `limit` are captured here so `raiseBlock`
+   * (called outside the lock) reads no shared state and stays race-free.
    */
   private blockingCross(
     estimateUsd: number,
     estimateTokens: number,
-  ): ["usd" | "tokens", "aggregate" | "step"] | null {
+  ): ["usd" | "tokens", "aggregate" | "step", number, number] | null {
     // Aggregate USD — same comparison the original check/reserve used.
     const committed = this.spentUsd + this.reserved;
     if (committed > this.limitUsd - EPS || committed + estimateUsd > this.limitUsd + EPS) {
-      return ["usd", "aggregate"];
+      return ["usd", "aggregate", this.spentUsd, this.limitUsd];
     }
     // Aggregate tokens (integers — no epsilon).
     if (this.tokenLimit !== null) {
       const committedT = this.spentTokens + this.reservedTokens;
       if (committedT >= this.tokenLimit || committedT + estimateTokens > this.tokenLimit) {
-        return ["tokens", "aggregate"];
+        return ["tokens", "aggregate", committedT, this.tokenLimit];
       }
     }
     // Innermost active step's caps (crossing an outer step requires first
@@ -832,37 +834,31 @@ export class BudgetGuard {
       if (step.maxUsd !== null) {
         const sCommitted = step.spentUsd + step.reservedUsd;
         if (sCommitted > step.maxUsd - EPS || sCommitted + estimateUsd > step.maxUsd + EPS) {
-          return ["usd", "step"];
+          // Report the step's own committed spend and ceiling so BudgetExceeded
+          // names the actual violated boundary, not the aggregate values.
+          return ["usd", "step", sCommitted, step.maxUsd];
         }
       }
       if (step.maxTokens !== null) {
         const sCommittedT = step.spentTokens + step.reservedTokens;
         if (sCommittedT >= step.maxTokens || sCommittedT + estimateTokens > step.maxTokens) {
-          return ["tokens", "step"];
+          return ["tokens", "step", sCommittedT, step.maxTokens];
         }
       }
     }
     return null;
   }
 
-  /** Notify + throw the right error for a [dimension, scope] block. */
-  private raiseBlock(blocked: ["usd" | "tokens", "aggregate" | "step"]): never {
-    const [dimension, scope] = blocked;
+  /** Notify + throw the right error for a [dimension, scope, spent, limit] block. */
+  private raiseBlock(blocked: ["usd" | "tokens", "aggregate" | "step", number, number]): never {
+    const [dimension, scope, spent, limit] = blocked;
     if (dimension === "usd") {
-      this.onBlock(this.spentUsd, this.limitUsd);
-      throw new BudgetExceeded(this.spentUsd, this.limitUsd);
+      this.onBlock(spent, limit);
+      throw new BudgetExceeded(spent, limit);
     }
-    let spentT: number;
-    let limitT: number;
-    if (scope === "step") {
-      const step = this.steps[this.steps.length - 1];
-      spentT = step.spentTokens + step.reservedTokens;
-      limitT = step.maxTokens ?? 0;
-    } else {
-      spentT = this.spentTokens + this.reservedTokens;
-      limitT = this.tokenLimit ?? 0;
-    }
-    throw new TokenBudgetExceeded(spentT, limitT, scope);
+    // Token block — counts came from blockingCross; on_block is dollar-shaped
+    // so a token block skips it.
+    throw new TokenBudgetExceeded(Math.trunc(spent), Math.trunc(limit), scope);
   }
 
   /**

--- a/js/src/retry.ts
+++ b/js/src/retry.ts
@@ -1,4 +1,4 @@
-import { BudgetExceeded } from "./errors.js";
+import { FloeGuardError } from "./errors.js";
 import { type BudgetAdvisory, BudgetGuard } from "./guard.js";
 
 export interface RetryPlan<T> {
@@ -21,12 +21,26 @@ export interface BudgetRetryOptions<T> {
     error: unknown,
     advisory: BudgetAdvisory,
   ) => RetryPlan<T> | Promise<RetryPlan<T> | undefined> | undefined;
-  /** Decide whether an error is retryable. Defaults to all non-budget errors. */
+  /**
+   * Decide whether an error is retryable.
+   *
+   * Defaults to all non-{@link FloeGuardError} errors — every
+   * {@link FloeGuardError} (including {@link BudgetExceeded} and
+   * {@link UnpriceableModelError}) is treated as terminal because retrying a
+   * deterministic guard error cannot fix it and would only multiply LLM spend.
+   */
   retryIf?: (error: unknown) => boolean;
 }
 
+/**
+ * Return `true` only for transient, non-{@link FloeGuardError} errors.
+ *
+ * Every {@link FloeGuardError} — including {@link BudgetExceeded} and
+ * {@link UnpriceableModelError} — is considered terminal: retrying cannot fix
+ * a deterministic guard error and would only multiply LLM spend.
+ */
 function defaultRetryIf(error: unknown): boolean {
-  return !(error instanceof BudgetExceeded);
+  return !(error instanceof FloeGuardError);
 }
 
 /**

--- a/js/test/retry.test.ts
+++ b/js/test/retry.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { BudgetExceeded, BudgetGuard, type RetryPlan, withBudgetRetry } from "../src/index.js";
+import {
+  BudgetExceeded,
+  BudgetGuard,
+  type RetryPlan,
+  withBudgetRetry,
+} from "../src/index.js";
+import {
+  DeadlineExceeded,
+  FloeGuardError,
+  UnpriceableModelError,
+  UnpriceableVoiceError,
+} from "../src/errors.js";
 
 class RetryableError extends Error {}
 
@@ -99,4 +110,79 @@ describe("withBudgetRetry", () => {
       withBudgetRetry(new BudgetGuard(1.0), () => "ok", { maxAttempts: 0 }),
     ).rejects.toBeInstanceOf(RangeError);
   });
+});
+
+// ── FloeGuardError family is non-retryable ────────────────────────────────────
+
+describe("FloeGuardError family is non-retryable", () => {
+  it("does not retry UnpriceableModelError (call count == 1)", async () => {
+    const guard = new BudgetGuard(1.0);
+    let calls = 0;
+    await expect(
+      withBudgetRetry(
+        guard,
+        () => {
+          calls += 1;
+          throw new UnpriceableModelError("mystery-model");
+        },
+        { estimatedCost: 0.01, maxAttempts: 3 },
+      ),
+    ).rejects.toBeInstanceOf(UnpriceableModelError);
+    expect(calls).toBe(1);
+  });
+
+  it("still retries ordinary (non-FloeGuard) errors", async () => {
+    const guard = new BudgetGuard(1.0);
+    let calls = 0;
+    const result = await withBudgetRetry(
+      guard,
+      () => {
+        calls += 1;
+        if (calls < 3) throw new Error("transient");
+        return "ok";
+      },
+      { estimatedCost: 0.01, maxAttempts: 3 },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("does not retry BudgetExceeded (FloeGuardError subclass)", async () => {
+    const guard = new BudgetGuard(1.0, { onBlock: () => undefined });
+    guard.recordTool("seed", 0.99);
+    let calls = 0;
+    await expect(
+      withBudgetRetry(
+        guard,
+        () => {
+          calls += 1;
+          throw new RetryableError("fail");
+        },
+        { estimatedCost: 0.02, maxAttempts: 3 },
+      ),
+    ).rejects.toBeInstanceOf(BudgetExceeded);
+    expect(calls).toBe(1);
+  });
+
+  it.each([
+    ["UnpriceableVoiceError", new UnpriceableVoiceError("elevenlabs", "tts")],
+    ["DeadlineExceeded", new DeadlineExceeded(500, 300)],
+  ] as [string, FloeGuardError][])(
+    "does not retry %s",
+    async (_name, exc) => {
+      const guard = new BudgetGuard(1.0);
+      let calls = 0;
+      await expect(
+        withBudgetRetry(
+          guard,
+          () => {
+            calls += 1;
+            throw exc;
+          },
+          { estimatedCost: 0.01, maxAttempts: 3 },
+        ),
+      ).rejects.toBeInstanceOf(FloeGuardError);
+      expect(calls).toBe(1);
+    },
+  );
 });

--- a/js/test/token-step-budgets.test.ts
+++ b/js/test/token-step-budgets.test.ts
@@ -84,6 +84,29 @@ describe("per-step caps", () => {
     });
   });
 
+  it("step USD block reports step ceiling, not aggregate values", () => {
+    // aggregate = $100; step = $1.00
+    const guard = new BudgetGuard(100, { ...silent });
+    guard.step({ maxUsd: 1.0 }, (g) => {
+      // Spend ~$0.75 inside the step (gpt-4o: 100k input + 50k output tokens)
+      g.record(MODEL, 100_000, 50_000);
+      let caught: BudgetExceeded | undefined;
+      try {
+        g.reserve(0.30); // step ceiling crossed: 0.75 + 0.30 > 1.00
+      } catch (err) {
+        caught = err as BudgetExceeded;
+      }
+      expect(caught).toBeInstanceOf(BudgetExceeded);
+      expect(caught).not.toBeInstanceOf(TokenBudgetExceeded);
+      // Must report the step ceiling ($1.00), not the $100 aggregate.
+      expect(caught!.limitUsd).toBeCloseTo(1.0);
+      // spent must be the step-committed amount, not the aggregate spent.
+      expect(caught!.spentUsd).toBeLessThanOrEqual(1.0 + 1e-6);
+      // The message should contain the step ceiling.
+      expect(caught!.message).toContain("1.000000");
+    });
+  });
+
   it("frees the step cap on exit", () => {
     const guard = new BudgetGuard(100, silent);
     guard.step({ maxTokens: 100 }, (g) => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.17.0"
+version = "0.17.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/guard.py
+++ b/src/floe_guard/guard.py
@@ -571,9 +571,7 @@ class BudgetGuard:
                 # holds the estimate in one transaction, so overlapping processes
                 # can't both clear a stale total. It returns the fresh snapshot.
                 window_id = self._current_window_id_locked()
-                accepted, spent, reserved = self._store.reserve(
-                    window_id, self.limit_usd, estimate
-                )
+                accepted, spent, reserved = self._store.reserve(window_id, self.limit_usd, estimate)
                 self.spent_usd, self._reserved = spent, reserved
                 if accepted:
                     return _PersistentReservation(estimate, window_id)
@@ -863,9 +861,7 @@ class BudgetGuard:
             if self._store is not None:
                 self._apply_persistent_terminal_locked(
                     reserved,
-                    lambda window_id: self._store.release(
-                        window_id, self.limit_usd, reserved_usd
-                    ),
+                    lambda window_id: self._store.release(window_id, self.limit_usd, reserved_usd),
                 )
             else:
                 self._consume_reservation_locked(reserved)
@@ -1394,10 +1390,11 @@ class BudgetGuard:
                     s_committed > step.max_usd - _EPS
                     or s_committed + estimate_usd > step.max_usd + _EPS
                 ):
-                    # USD message stays aggregate-shaped (matches the original
-                    # _raise_block, which reported spent_usd/limit_usd for a step
-                    # USD block too).
-                    return ("usd", "step", self.spent_usd, self.limit_usd)
+                    # Report the step's own committed spend and ceiling so the
+                    # BudgetExceeded message names the actual violated boundary,
+                    # not the aggregate guard values (which are much larger and
+                    # misleading when only the step ceiling was crossed).
+                    return ("usd", "step", s_committed, step.max_usd)
             if step.max_tokens is not None:
                 s_committed_t = step.spent_tokens + step.reserved_tokens
                 if (

--- a/src/floe_guard/retry.py
+++ b/src/floe_guard/retry.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
-from .errors import BudgetExceeded
+from .errors import FloeGuardError
 from .guard import BudgetAdvisory, BudgetGuard
 
 T = TypeVar("T")
@@ -42,16 +42,21 @@ AsyncDegradeCallback = Callable[
 
 
 def _default_retry_if(exc: Exception) -> bool:
-    return not isinstance(exc, BudgetExceeded)
+    """Return ``True`` only for transient, non-FloeGuard errors.
+
+    Every :class:`~floe_guard.errors.FloeGuardError` — including
+    :class:`~floe_guard.errors.BudgetExceeded`,
+    :class:`~floe_guard.errors.UnpriceableModelError`, and all other
+    deterministic guard errors — is considered terminal: retrying cannot fix
+    it and would only multiply spend. Only errors from outside the guard
+    (e.g. transient network failures) are retryable by default.
+    """
+    return not isinstance(exc, FloeGuardError)
 
 
 def _validate_max_attempts(max_attempts: int) -> None:
     # Same int-not-bool contract as BudgetGuard.near_limit_bps.
-    if (
-        isinstance(max_attempts, bool)
-        or not isinstance(max_attempts, int)
-        or max_attempts < 1
-    ):
+    if isinstance(max_attempts, bool) or not isinstance(max_attempts, int) or max_attempts < 1:
         raise ValueError(f"max_attempts must be an int >= 1, got {max_attempts!r}")
 
 
@@ -78,6 +83,13 @@ def with_budget_retry(
     ``max_attempts`` includes the first attempt. The last retryable exception is
     re-raised when attempts are exhausted. Control-flow exceptions
     (``KeyboardInterrupt``, ``SystemExit``, ``CancelledError``) are not caught.
+
+    By default only transient, non-:class:`~floe_guard.errors.FloeGuardError`
+    exceptions are retried. Every :class:`~floe_guard.errors.FloeGuardError`
+    (including :class:`~floe_guard.errors.BudgetExceeded` and
+    :class:`~floe_guard.errors.UnpriceableModelError`) is terminal — retrying
+    a deterministic guard error cannot fix it and would only multiply spend.
+    Supply ``retry_if`` to override.
     """
 
     _validate_max_attempts(max_attempts)

--- a/tests/test_budget_retry.py
+++ b/tests/test_budget_retry.py
@@ -13,6 +13,13 @@ from floe_guard import (
     async_with_budget_retry,
     with_budget_retry,
 )
+from floe_guard.errors import (
+    DeadlineExceeded,
+    FloeGuardError,
+    HostedEnforcementError,
+    UnpriceableModelError,
+    UnpriceableVoiceError,
+)
 
 
 class RetryableError(RuntimeError):
@@ -163,3 +170,78 @@ async def test_async_helper_degrades_near_limit() -> None:
 
     assert result == "cheap-ok"
     assert calls == {"primary": 1, "cheap": 1}
+
+
+# ── FloeGuardError family is non-retryable ────────────────────────────────────
+
+
+def test_unpriceable_model_error_is_not_retried() -> None:
+    """UnpriceableModelError must NOT be retried — it is deterministic."""
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"count": 0}
+
+    def call() -> str:
+        calls["count"] += 1
+        raise UnpriceableModelError("some-mystery-model")
+
+    with pytest.raises(UnpriceableModelError):
+        with_budget_retry(guard, call, estimated_cost=0.01, max_attempts=3)
+
+    assert calls["count"] == 1
+
+
+def test_plain_value_error_is_retried_by_default() -> None:
+    """Ordinary non-FloeGuard exceptions should still retry."""
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"count": 0}
+
+    def call() -> str:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ValueError("transient")
+        return "ok"
+
+    result = with_budget_retry(guard, call, estimated_cost=0.01, max_attempts=3)
+    assert result == "ok"
+    assert calls["count"] == 3
+
+
+def test_budget_exceeded_is_not_retried() -> None:
+    """BudgetExceeded (a FloeGuardError subclass) must remain non-retryable."""
+    guard = BudgetGuard(limit_usd=1.00, on_block=lambda *_: None)
+    guard.record_tool("seed", 0.99)
+    calls = {"count": 0}
+
+    def call() -> str:
+        calls["count"] += 1
+        raise RetryableError("fail")
+
+    with pytest.raises(BudgetExceeded):
+        with_budget_retry(guard, call, estimated_cost=0.02, max_attempts=3)
+
+    # The first attempt raised RetryableError, guard.check() then raised
+    # BudgetExceeded — call itself ran exactly once.
+    assert calls["count"] == 1
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        UnpriceableVoiceError("elevenlabs", "tts"),
+        HostedEnforcementError("network timeout"),
+        DeadlineExceeded(500.0, 300.0),
+    ],
+)
+def test_floe_guard_error_subclasses_are_not_retried(exc: FloeGuardError) -> None:
+    """Every FloeGuardError subclass must be treated as terminal."""
+    guard = BudgetGuard(limit_usd=1.00)
+    calls = {"count": 0}
+
+    def call() -> str:
+        calls["count"] += 1
+        raise exc
+
+    with pytest.raises(type(exc)):
+        with_budget_retry(guard, call, estimated_cost=0.01, max_attempts=3)
+
+    assert calls["count"] == 1

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -85,6 +85,28 @@ def test_step_usd_cap_hard_blocks() -> None:
     assert not isinstance(exc.value, TokenBudgetExceeded)
 
 
+def test_step_usd_diagnostics_report_step_ceiling() -> None:
+    """When a step USD ceiling is crossed the BudgetExceeded must report
+    the step's own committed spend and the step ceiling, NOT the aggregate
+    guard figures (which are much larger and misleading).
+    """
+    guard = BudgetGuard(limit_usd=10.0, on_block=lambda *_: None)  # aggregate = $10
+    with guard.step(max_usd=1.0) as g:
+        # Spend $0.80 inside the step before trying to reserve another $0.30.
+        g.record(MODEL, 100_000, 50_000)  # gpt-4o: ~$0.75 prompt + $0.50 completion
+        with pytest.raises(BudgetExceeded) as exc:
+            g.reserve(0.30)  # step ceiling = $1.00, already past it
+    err = exc.value
+    assert not isinstance(err, TokenBudgetExceeded)
+    # The limit must be the step ceiling, not the $10 aggregate.
+    assert err.limit_usd == pytest.approx(1.0)
+    # The spent value must reflect the step's committed (spent + reserved) spend.
+    # We reserved $0.00 before, so spent_usd == step.spent_usd after record().
+    assert err.spent_usd <= 1.0 + 1e-6  # committed <= step ceiling when blocking
+    # The error message must contain the step ceiling, not the $10 aggregate.
+    assert "1.000000" in str(err)
+
+
 def test_step_cap_frees_on_exit() -> None:
     guard = BudgetGuard(limit_usd=100.0, on_block=lambda *_: None)
     with guard.step(max_tokens=100) as g:

--- a/tests/test_token_step_budgets.py
+++ b/tests/test_token_step_budgets.py
@@ -92,10 +92,10 @@ def test_step_usd_diagnostics_report_step_ceiling() -> None:
     """
     guard = BudgetGuard(limit_usd=10.0, on_block=lambda *_: None)  # aggregate = $10
     with guard.step(max_usd=1.0) as g:
-        # Spend $0.80 inside the step before trying to reserve another $0.30.
-        g.record(MODEL, 100_000, 50_000)  # gpt-4o: ~$0.75 prompt + $0.50 completion
+        # Spend ~$0.75 inside the step before trying to reserve another $0.30.
+        g.record(MODEL, 100_000, 50_000)  # gpt-4o: $0.25 prompt + $0.50 completion
         with pytest.raises(BudgetExceeded) as exc:
-            g.reserve(0.30)  # step ceiling = $1.00, already past it
+            g.reserve(0.30)  # step ceiling = $1.00, 0.75 + 0.30 would cross it
     err = exc.value
     assert not isinstance(err, TokenBudgetExceeded)
     # The limit must be the step ceiling, not the $10 aggregate.


### PR DESCRIPTION

## Summary
This PR fixes two related bugs across both the Python and JavaScript packages: it makes the default retry helper treat all deterministic guard errors as terminal to prevent runaway spend, and it fixes the per-step USD budget diagnostics so `BudgetExceeded` correctly reports the step ceiling instead of the aggregate guard ceiling.

## Changes
- **Fix Retry Predicate:** Changed `_default_retry_if` (Python) and `defaultRetryIf` (JS) to block the entire `FloeGuardError` family (`not isinstance(exc, FloeGuardError)`). Previously, only `BudgetExceeded` was excluded, meaning deterministic errors like `UnpriceableModelError` or `DeadlineExceeded` would retry and multiply LLM spend.
- **Fix Step-USD Diagnostics:** Updated the blocking logic (`guard.py` and `guard.ts`) to capture and return the step's own committed spend and step ceiling. `BudgetExceeded` now accurately reports the step boundary instead of the misleading aggregate guard values.
- **Tests Added:** Added Python and JS tests verifying that `UnpriceableModelError`, `DeadlineExceeded`, etc., are terminal (call count = 1), while ordinary errors still retry. Added tests asserting that a step USD block reports the step ceiling correctly.
- **Versions Bumped:** Python bumped to `0.17.1`, JS bumped to `0.13.1` (including `package-lock.json`).

## Testing
How was this tested?
Tested locally in both the Python and JS environments. Added new unit tests covering all edge cases for both fixes.

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)

## Related issues
Closes #