### PR TITLE
fix(js): fail closed when stream ends without a usage-bearing finish part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,25 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.17.1
+## Unreleased — py 0.17.1 / js 0.13.2
+
+### Fixed (js)
+
+- **`wrapStream` now fails closed when a stream ends without a usage-bearing
+  finish part.** Previously, `flush()` silently released the reservation and
+  allowed the stream to complete as though no tokens were consumed (effective
+  $0 spend), violating the package's fail-closed philosophy. The new behavior
+  releases the reservation **and** throws a descriptive `Error` — consistent
+  with how `wrapGenerate` and `usageTokens()` handle missing token data — so
+  the stream is rejected rather than treated as free. Cancellation (`cancel()`)
+  behavior is unchanged.
+
+  **AI SDK contract note (verified against `ai@4.3.19` / `@ai-sdk/provider`):**
+  `LanguageModelV1StreamPart` defines the `finish` part as carrying `usage`
+  (`promptTokens`/`completionTokens`), but the `doStream` contract does **not**
+  guarantee that a stream *must* emit a finish part before closing. A stream
+  that ends without one is therefore a contract violation that the guard must
+  treat as unmeterable spend, not a free call.
 
 ### Fixed (py)
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -20,7 +20,9 @@
  * Reserving before the await is what makes parallel calls (`Promise.all` over
  * several generations) honour the ceiling: each holds its slice instead of all
  * reading the same stale total (issue #18). The reservation is released if the
- * call throws, or if a stream ends without reporting usage.
+ * call throws, is cancelled by the consumer, or if a stream completes without a
+ * usage-bearing finish part — in the last case the stream is also rejected with
+ * an error rather than treated as a free ($0) call (fail-closed).
  *
  * The model id used for pricing comes from `model.modelId`.
  */
@@ -170,10 +172,20 @@ export function budgetGuardMiddleware(guard: BudgetGuard): BudgetGuardMiddleware
             controller.enqueue(chunk);
           },
           flush() {
-            // Clean close with no finish/usage part — free the held budget.
+            // The stream closed cleanly but never emitted a usage-bearing
+            // finish part. Per the package's fail-closed philosophy (see
+            // usageTokens()), we cannot treat an unmetered LLM call as free:
+            // release the hold first (so the ceiling is not permanently
+            // depleted), then throw so the consumer learns the call was not
+            // settled. This mirrors how wrapGenerate() rejects missing usage.
             if (!handled) {
               handled = true;
               guard.release(reserved);
+              throw new Error(
+                `Model '${model.modelId}' stream completed without a token-usage ` +
+                  `finish part — the budget guard cannot meter spend it cannot see, ` +
+                  `so this call is rejected rather than treated as free.`,
+              );
             }
           },
           cancel() {

--- a/js/test/middleware.test.ts
+++ b/js/test/middleware.test.ts
@@ -202,6 +202,76 @@ describe("budgetGuardMiddleware — wrapStream (ai@5 usage shape)", () => {
   });
 });
 
+describe("budgetGuardMiddleware — wrapStream (no finish part / fail-closed)", () => {
+  it("rejects when the stream ends with no usage-bearing finish part", async () => {
+    // Verify: a stream that produces only text-delta chunks (no finish part) must
+    // reject — the guard cannot meter spend it cannot see, so treating the call as
+    // $0 / free would violate the package's fail-closed philosophy.
+    const guard = new BudgetGuard(1.0);
+    const mw = budgetGuardMiddleware(guard);
+    const initialRemaining = guard.remainingUsd;
+
+    const doStream = vi.fn(async () => ({
+      stream: readableOf([
+        { type: "text-delta", textDelta: "hello" },
+        { type: "text-delta", textDelta: " world" },
+        // No finish part — the stream closes cleanly without token usage.
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+    }));
+
+    const result = await mw.wrapStream!({
+      doGenerate: vi.fn() as never,
+      doStream: doStream as never,
+      params: fakeParams,
+      model: fakeModel("gpt-4o"),
+    });
+
+    // Consuming the stream must reject with the expected error.
+    await expect(drain((result as { stream: ReadableStream }).stream)).rejects.toThrow(
+      /stream completed without a token-usage finish part/,
+    );
+
+    // The call must NOT be metered as $0 / free.
+    expect(guard.spentUsd).toBe(0);
+
+    // The reservation must have been released — budget returns to pre-call level.
+    expect(guard.remainingUsd).toBeCloseTo(initialRemaining, 12);
+  });
+
+  it("the normal finish-with-usage path still settles successfully", async () => {
+    // Regression guard: ensure the fail-closed change does not break the happy path.
+    const guard = new BudgetGuard(1.0);
+    const mw = budgetGuardMiddleware(guard);
+
+    const doStream = vi.fn(async () => ({
+      stream: readableOf([
+        { type: "text-delta", textDelta: "hello" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          usage: { promptTokens: 500, completionTokens: 500 },
+        },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+    }));
+
+    const result = await mw.wrapStream!({
+      doGenerate: vi.fn() as never,
+      doStream: doStream as never,
+      params: fakeParams,
+      model: fakeModel("gpt-4o"),
+    });
+
+    // Must not throw.
+    await drain((result as { stream: ReadableStream }).stream);
+
+    const priced = pricing.resolvePrice("gpt-4o")!;
+    expect(guard.spentUsd).toBeCloseTo(pricing.priceTokens(priced, 500, 500), 12);
+    expect(guard.spentUsd).toBeGreaterThan(0);
+  });
+});
+
 describe("BudgetExceeded message parity with the Python guard", () => {
   it("formats the message exactly like floe_guard.errors.BudgetExceeded", () => {
     const err = new BudgetExceeded(5.00125, 5.0);


### PR DESCRIPTION
## Summary

`wrapStream` in the Vercel AI SDK middleware previously failed open when a stream closed without emitting a usage-bearing `finish` part: `flush()` silently released the reservation and let the stream complete as though zero tokens were consumed. An LLM call could run and record `$0` spend, bypassing the budget ceiling entirely.

This PR makes `wrapStream` fail closed - consistent with how `wrapGenerate` and `usageTokens()` already behave - by releasing the reservation **and** throwing a descriptive error when `flush()` fires with no `finish` part seen.

## Changes

- **`js/src/middleware.ts`** - `flush()` now releases the reservation then throws `"Model '…' stream completed without a token-usage finish part - … rejected rather than treated as free"` instead of silently releasing. Module docstring updated to reflect fail-closed behavior. Cancellation (`cancel()`) is unchanged.
- **`js/test/middleware.test.ts`** - new `wrapStream (no finish part / fail-closed)` describe block with two tests: one asserting the stream rejects with the expected error and `spentUsd === 0` / `remainingUsd` restored; one regression-guarding the normal finish-with-usage path still settles successfully.
- **`js/package.json` / `js/package-lock.json`** - version bump `0.13.1 → 0.13.2`.
- **`CHANGELOG.md`** - `### Fixed (js)` entry added under Unreleased, including the AI SDK contract verification note (`ai@4.3.19` / `@ai-sdk/provider`).

## Testing

Verified against `ai@4.3.19` (`@ai-sdk/provider`): `LanguageModelV1StreamPart` defines `finish` with `usage`, but `doStream`'s return type does **not** guarantee a stream must emit a finish part before closing - missing finish is therefore a contract violation that must be treated as unmeterable spend, not a free call.

Adapters inspected - none duplicate the pattern: LiveKit settles via `metrics_collected`; Vapi's `iterateStream` already throws `VapiUsageMissingError` on no usage; Retell uses explicit `settleTurn()`.

- [x] `pytest` passes (Python changes) - 397 passed, 3 skipped
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` - 222 passed, 16 test files
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)

## Related issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated JavaScript stream handling to release reserved capacity when streams are cancelled or completed.
  - Streams that finish without valid token-usage information now report an error instead of being treated as free.
  - Streams with valid usage data continue to settle and record spending correctly.

- **Documentation**
  - Updated release notes and middleware documentation to clarify stream completion, cancellation, and usage-reporting behavior.
  - Published JavaScript version 0.13.2 and Python version 0.17.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->