### PR TITLE
feat(cli): floe-guard demo — run the no-key demo from the installed package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.17.1
+## Unreleased — py 0.18.0
 
 ### Fixed (py)
 
@@ -44,6 +44,13 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   rationale recorded inline in `pyproject.toml`.
 
 ### Added (py)
+
+- **`floe-guard demo` — the no-key demo, runnable from the installed package.**
+  `pip install floe-guard && floe-guard demo` runs the runaway-loop demo (stub
+  LLM, no account, no network) straight from the wheel — no repository checkout
+  needed. The demo logic moved into the package (`floe_guard.demo.run_demo`);
+  `examples/runaway_loop.py` is now a thin wrapper around it, so there's one
+  source of truth. `--limit-usd` overrides the $0.10 ceiling.
 
 - **Opt-in ledger sync → Reconcile Mode / Coverage Score.** A new **explicit,
   off-by-default** way to push your local spend ledger to Floe so **Coverage

--- a/README.md
+++ b/README.md
@@ -95,17 +95,23 @@ BUDGET EXCEEDED — call blocked
 
 ![floe-guard hard-stopping a runaway loop before it crosses a $0.10 ceiling](docs/stop-the-loop.gif)
 
-_Run it yourself: `python examples/runaway_loop.py` — no API key, no account, no network._
+_Run it yourself, straight from the install: `pip install floe-guard && floe-guard demo` — no API key, no account, no network._
 
 ## See it stop a loop (no API key needed)
 
+Straight from the install — no repository checkout needed:
+
 ```bash
-python examples/runaway_loop.py
+pip install floe-guard
+floe-guard demo
 ```
 
 This rigs a loop against a **stub LLM** — no real API key, no account, no network.
 It prices each fake `gpt-4o` call offline and the guard halts the loop after a few
-iterations. This is the reproducible "stop the loop" demo.
+iterations, before it can cross the $0.10 ceiling. This is the reproducible "stop
+the loop" demo. Cloned the repo? The same demo is
+[`examples/runaway_loop.py`](examples/runaway_loop.py) (a thin wrapper around
+`floe_guard.demo.run_demo`).
 
 ## What did that call cost?
 

--- a/examples/runaway_loop.py
+++ b/examples/runaway_loop.py
@@ -22,5 +22,11 @@ from __future__ import annotations
 
 from floe_guard.demo import run_demo
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Run the packaged demo. Kept as a stable entry point for callers/tests."""
     run_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/runaway_loop.py
+++ b/examples/runaway_loop.py
@@ -8,54 +8,19 @@ Run it::
 
     python examples/runaway_loop.py
 
-The "LLM" here is a stub that returns fixed token usage — no network, no key, no
-crewai/litellm needed. The cost is computed offline from the bundled cost map,
-exactly as it would be for a real ``gpt-4o`` call.
+Or, straight from the installed package (no repository checkout needed)::
+
+    floe-guard demo
+
+The "LLM" here is a stub that returns fixed token usage — no network, no key. The
+cost is priced offline from the bundled cost map, exactly as for a real ``gpt-4o``
+call. The demo itself lives in the package (:func:`floe_guard.demo.run_demo`); this
+file is a thin wrapper so a repo checkout keeps working.
 """
 
 from __future__ import annotations
 
-from floe_guard import BudgetExceeded, BudgetGuard
-
-MODEL = "gpt-4o"
-
-
-def stub_llm(prompt: str) -> dict[str, object]:
-    """A fake LLM call. No network, no API key — returns fixed token usage."""
-    return {
-        "model": MODEL,
-        "text": "...thinking... let me call myself again...",
-        "prompt_tokens": 1_000,
-        "completion_tokens": 1_000,
-    }
-
-
-def main() -> None:
-    # $0.10 ceiling. gpt-4o at 1k in + 1k out ~= $0.0125/call, so the guard should
-    # stop the loop after a handful of iterations — well before any real damage.
-    guard = BudgetGuard(limit_usd=0.10)
-
-    print(f"Starting a runaway loop with a ${guard.limit_usd:.2f} budget...\n", flush=True)
-    call = 0
-    while True:  # a real runaway loop never decides to stop on its own
-        call += 1
-        try:
-            guard.check()  # <-- the kill-switch: raises before the crossing call
-        except BudgetExceeded:
-            print(
-                f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.",
-                flush=True,
-            )
-            break
-
-        response = stub_llm("keep going")
-        cost = guard.record(
-            str(response["model"]),
-            int(response["prompt_tokens"]),  # type: ignore[arg-type]
-            int(response["completion_tokens"]),  # type: ignore[arg-type]
-        )
-        print(f"  call #{call}: +${cost:.4f}  (running total ${guard.spent_usd:.4f})", flush=True)
-
+from floe_guard.demo import run_demo
 
 if __name__ == "__main__":
-    main()
+    run_demo()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.17.1"
+version = "0.18.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -14,6 +14,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 
+from .demo import run_demo
 from .errors import LedgerSyncError
 from .sync import push_ledger
 
@@ -48,7 +49,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="API base URL. Defaults to $FLOE_API_BASE_URL, else the production host.",
     )
 
+    demo = sub.add_parser(
+        "demo",
+        help="Run the no-key 'stop a loop' demo (no account, no network).",
+        description=(
+            "Run the runaway-loop demo: a naive agent loop that floe-guard hard-stops "
+            "before it crosses a $0.10 ceiling. Stub LLM — no API key, no account, no "
+            "network. The same demo as examples/runaway_loop.py, runnable straight from "
+            "the installed package."
+        ),
+    )
+    demo.add_argument(
+        "--limit-usd",
+        type=float,
+        default=0.10,
+        help="Spend ceiling for the demo, in USD (default: 0.10).",
+    )
+
     args = parser.parse_args(argv)
+
+    if args.command == "demo":
+        run_demo(limit_usd=args.limit_usd)
+        return 0
 
     if args.command == "push":
         try:

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -1,11 +1,17 @@
 """floe-guard CLI.
 
-One command today: ``floe-guard push`` — the **opt-in** ledger sync. It reads an
-:meth:`~floe_guard.BudgetGuard.export_log` JSONL ledger (from a file or stdin) and
-POSTs it to Floe's Reconcile Mode so your **Coverage Score** can count spend the
-gateway never routed (BYOK / self-hosted / off-path). Nothing runs on import or in
-the background — ``push`` is a one-shot send you invoke, with your key. Zero
-telemetry otherwise.
+Two commands:
+
+- ``floe-guard demo`` — run the no-key "stop a loop" demo (stub LLM, no account,
+  no network) straight from the installed package. ``--limit-usd`` sets the
+  ceiling (default $0.10).
+- ``floe-guard push`` — the **opt-in** ledger sync. It reads an
+  :meth:`~floe_guard.BudgetGuard.export_log` JSONL ledger (from a file or stdin)
+  and POSTs it to Floe's Reconcile Mode so your **Coverage Score** can count spend
+  the gateway never routed (BYOK / self-hosted / off-path).
+
+Nothing runs on import or in the background — every command is invoked explicitly,
+and only ``push`` touches the network (with your key). Zero telemetry otherwise.
 """
 
 from __future__ import annotations
@@ -69,7 +75,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "demo":
-        run_demo(limit_usd=args.limit_usd)
+        try:
+            run_demo(limit_usd=args.limit_usd)
+        except ValueError as exc:
+            # e.g. a negative/non-finite --limit-usd; surface a clean CLI error
+            # (exit 2) instead of a Python traceback.
+            parser.error(str(exc))
         return 0
 
     if args.command == "push":

--- a/src/floe_guard/demo.py
+++ b/src/floe_guard/demo.py
@@ -1,0 +1,55 @@
+"""The no-key "stop a loop" demo, runnable straight from the installed package.
+
+``floe-guard demo`` (or ``from floe_guard.demo import run_demo``) runs a naive
+agent loop against a **stub LLM** — no API key, no account, no network. The guard
+hard-stops the loop before the call that would cross a ``$0.10`` ceiling; cost is
+priced offline from the bundled cost map, exactly as it would be for a real
+``gpt-4o`` call.
+
+This is the same demo as ``examples/runaway_loop.py`` (which is a thin wrapper
+around :func:`run_demo`), but it ships inside the wheel — so ``pip install
+floe-guard`` is enough to see the guard work, no repository checkout needed.
+"""
+
+from __future__ import annotations
+
+from .errors import BudgetExceeded
+from .guard import BudgetGuard
+
+MODEL = "gpt-4o"
+
+
+def _stub_llm() -> dict[str, object]:
+    """A fake LLM call — no network, no API key. Returns fixed token usage."""
+    return {"model": MODEL, "prompt_tokens": 1_000, "completion_tokens": 1_000}
+
+
+def run_demo(limit_usd: float = 0.10) -> None:
+    """Run the runaway-loop demo: a loop a ``limit_usd`` guard hard-stops.
+
+    A naive agent loop calls a stub LLM forever; ``floe-guard`` stops it before
+    the call that would cross ``limit_usd``. Prints one line per call plus the
+    stop line — identical to ``examples/runaway_loop.py``.
+    """
+    guard = BudgetGuard(limit_usd=limit_usd)
+
+    print(f"Starting a runaway loop with a ${guard.limit_usd:.2f} budget...\n", flush=True)
+    call = 0
+    while True:  # a real runaway loop never decides to stop on its own
+        call += 1
+        try:
+            guard.check()  # the kill-switch: raises before the crossing call
+        except BudgetExceeded:
+            print(
+                f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.",
+                flush=True,
+            )
+            break
+
+        response = _stub_llm()
+        cost = guard.record(
+            str(response["model"]),
+            int(response["prompt_tokens"]),  # type: ignore[arg-type]
+            int(response["completion_tokens"]),  # type: ignore[arg-type]
+        )
+        print(f"  call #{call}: +${cost:.4f}  (running total ${guard.spent_usd:.4f})", flush=True)

--- a/src/floe_guard/demo.py
+++ b/src/floe_guard/demo.py
@@ -38,7 +38,12 @@ def run_demo(limit_usd: float = 0.10) -> None:
     while True:  # a real runaway loop never decides to stop on its own
         call += 1
         try:
-            guard.check()  # the kill-switch: raises before the crossing call
+            # Size the check to the KNOWN request so the guard hard-stops before
+            # the crossing call even on call #1 — a bare check() is blind until the
+            # first record() (it estimates from the last call's cost, which is $0
+            # up front). estimate_call() prices the stub payload we're about to send.
+            est = guard.estimate_call(MODEL, 1_000, max_completion_tokens=1_000)
+            guard.check(estimated_next_cost=est)  # the kill-switch: raises before the crossing call
         except BudgetExceeded:
             print(
                 f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.",

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,37 @@
+"""Tests for the packaged demo (``floe-guard demo`` / ``floe_guard.demo.run_demo``).
+
+The stub call costs ~$0.0125 (gpt-4o, 1k in + 1k out). These guard the request-sized
+``check()`` so the demo hard-stops *before* the crossing call at an arbitrary
+``--limit-usd``, not just at exact multiples of the per-call cost.
+"""
+
+from __future__ import annotations
+
+import re
+
+from floe_guard.demo import run_demo
+
+_STUB_CALL_COST = 0.0125  # gpt-4o: 1000 * $2.5e-6 + 1000 * $1e-5
+
+
+def test_demo_blocks_the_first_call_when_ceiling_is_below_one_call(capsys):
+    """A ceiling below a single stub call must stop at call #1 — the request-sized
+    check() blocks it before it runs, so nothing is ever recorded (regression: a
+    bare check() would let call #1 through and record spend above the ceiling)."""
+    run_demo(limit_usd=_STUB_CALL_COST / 4)  # ~$0.003 — smaller than one call
+    out = capsys.readouterr().out
+    assert "Loop stopped at call #1" in out
+    # The crossing call must NOT have run — no "call #1: +$…" record line.
+    assert not re.search(r"call #1: \+\$", out)
+
+
+def test_demo_never_records_spend_above_the_ceiling(capsys):
+    """For a ceiling that is NOT an exact multiple of the per-call cost, the last
+    recorded running total must stay at or below the ceiling."""
+    limit = 0.033  # between 2 and 3 calls (~$0.025 and ~$0.0375)
+    run_demo(limit_usd=limit)
+    out = capsys.readouterr().out
+    totals = [float(m) for m in re.findall(r"running total \$([0-9.]+)", out)]
+    assert totals, "expected at least one recorded call"
+    assert max(totals) <= limit + 1e-9, f"recorded spend {max(totals)} exceeded ceiling {limit}"
+    assert "Loop stopped at call" in out

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -136,3 +136,19 @@ def test_anthropic_adapter() -> None:
     assert result.returncode == 0, result.stderr
     combined = result.stdout + result.stderr
     assert "cache" in combined.lower()
+
+
+def test_cli_demo() -> None:
+    """`floe-guard demo` (python -m floe_guard demo) runs from the installed package."""
+    env = {k: v for k, v in os.environ.items() if k not in {"FLOE_API_KEY", "OPENAI_API_KEY"}}
+    result = subprocess.run(
+        [sys.executable, "-m", "floe_guard", "demo"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=TIMEOUT,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "Loop stopped at call" in combined

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -143,8 +143,7 @@ def test_cli_demo() -> None:
     env = {k: v for k, v in os.environ.items() if k not in {"FLOE_API_KEY", "OPENAI_API_KEY"}}
     result = subprocess.run(
         [sys.executable, "-m", "floe_guard", "demo"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         text=True,
         timeout=TIMEOUT,
         env=env,


### PR DESCRIPTION
Closes the activation break a reviewer hit: the README leads with `pip install floe-guard`, but the aha-moment demo (`examples/runaway_loop.py`) needs a **repo checkout** — the wheel ships only `cost_map.json`, not `examples/`. So `pip install` → `python examples/runaway_loop.py` fails.

## Change
- **`floe-guard demo`** (`python -m floe_guard demo`) runs the runaway-loop demo straight from the wheel — stub LLM, no key, no account, no network. `--limit-usd` overrides the $0.10 ceiling.
- Demo logic moved into the package (`floe_guard.demo.run_demo`); `examples/runaway_loop.py` is now a thin wrapper → one source of truth, no drift.
- README "See it stop a loop" leads with `pip install floe-guard && floe-guard demo`.
- `test_cli_demo` covers the CLI path.

## Verified
`floe-guard demo` stops the loop at call #9 (matches the reviewer's run); `--limit-usd 0.05` stops at #5; example wrapper still works; **12 smoke tests + the new CLI test pass**; ruff clean. Version `0.17.1 → 0.18.0` (feature).

Part 1 of 3 from the activation feedback (companions: activation-funnel README, cost-map freshness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a no-key `floe-guard demo` command that demonstrates budget protection offline.
  * Added a configurable spending limit, defaulting to $0.10.
  * The demo stops safely before exceeding the configured limit and reports the result.

* **Documentation**
  * Updated installation and usage guidance for running the demo directly after package installation.
  * Clarified offline stub behavior and provided guidance for repository-based usage.

* **Chores**
  * Updated the release version to 0.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->