### PR TITLE
feat(pricing): surface bundled cost-map freshness (verified date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.17.1
+## Unreleased — py 0.18.0
 
 ### Fixed (py)
 
@@ -44,6 +44,13 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   rationale recorded inline in `pyproject.toml`.
 
 ### Added (py)
+
+- **Bundled-pricing freshness.** `cost_map_generated_at()` returns the
+  `YYYY-MM-DD` the bundled cost map was last generated/verified (from a reserved
+  `__meta__` key), so you can display or gate on how fresh the drift-prone public
+  list rates are. `scripts/update-cost-map.mjs` stamps it on every refresh; the
+  token resolver excludes `__meta__` the same way it excludes `__voice__`. TS
+  parity: `costMapGeneratedAt()`.
 
 - **Opt-in ledger sync → Reconcile Mode / Coverage Score.** A new **explicit,
   off-by-default** way to push your local spend ledger to Floe so **Coverage
@@ -128,7 +135,14 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   stdout and stderr and asserts that "Starting a runaway loop" precedes the
   "BUDGET EXCEEDED" banner.
 
-## Unreleased — js 0.13.1
+## Unreleased — js 0.14.0
+
+### Added (js)
+
+- **`costMapGeneratedAt()`** — parity with the Python `cost_map_generated_at()`:
+  returns the `YYYY-MM-DD` the bundled cost map was last generated/verified (from
+  the reserved `__meta__` key), or `undefined` on a pre-metadata map. Surfaces how
+  fresh the drift-prone bundled list rates are.
 
 ### Fixed (js)
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ guard = BudgetGuard(
 
 ### What the bundled map prices
 
+The bundled prices are a **dated snapshot** of public list rates — vendors change
+them, so treat freshness as a signal, not a guarantee. The snapshot date is
+exposed: `floe_guard.cost_map_generated_at()` (Python) / `costMapGeneratedAt()`
+(TypeScript) returns the `YYYY-MM-DD` it was last generated/verified, so you can
+display it or gate on it.
+
 The vendored map deliberately covers **OpenAI, Anthropic, Google Gemini (AI
 Studio), and a curated set of Groq models** (the rules live in
 [`scripts/update-cost-map.mjs`](scripts/update-cost-map.mjs)) — not all of

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -1,4 +1,8 @@
 {
+  "__meta__": {
+    "generated_at": "2026-08-17",
+    "source": "LiteLLM public model prices (bundled snapshot); voice rates verified from vendor list pages"
+  },
   "chatgpt-4o-latest": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000015,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -38,6 +38,7 @@ export {
   type PricedModel,
   resolvePrice,
   priceTokens,
+  costMapGeneratedAt,
 } from "./pricing.js";
 export {
   withBudgetRetry,

--- a/js/src/pricing.ts
+++ b/js/src/pricing.ts
@@ -33,6 +33,19 @@ interface CostMapEntry {
 const COST_MAP = costMapJson as Record<string, CostMapEntry>;
 
 /**
+ * Date the bundled pricing snapshot was last generated/verified (ISO
+ * `YYYY-MM-DD`), or `undefined` if the bundled map predates the metadata.
+ * Pricing is a drift-prone snapshot of public list rates; this surfaces *how
+ * fresh* it is — a trust signal you can display or gate on. Parity with the
+ * Python `cost_map_generated_at()`.
+ */
+export function costMapGeneratedAt(): string | undefined {
+  const meta = (costMapJson as Record<string, unknown>).__meta__;
+  const value = (meta as Record<string, unknown> | undefined)?.generated_at;
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
  * The one `<provider>/` prefix that is safe to strip: the remainder of a
  * `groq/…` id is the ChatGroq id the map vendors (e.g. `groq/qwen/qwen3-32b` →
  * `qwen/qwen3-32b`). `openai/` and `anthropic/` are deliberately excluded:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.17.1"
+version = "0.18.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -308,6 +308,14 @@ for (const [k, v] of Object.entries(raw)) {
 // null-prototype: model keys come from remote JSON, so a "__proto__" (or similar)
 // key is stored as plain data instead of mutating the object's prototype.
 const out = Object.create(null);
+// Provenance/freshness of this snapshot. pricing.py / pricing.ts split this
+// reserved key back out (like __voice__), so it never reaches the token resolver;
+// it's surfaced via cost_map_generated_at() / costMapGeneratedAt().
+out.__meta__ = {
+  generated_at: new Date().toISOString().slice(0, 10),
+  source:
+    "LiteLLM public model prices (bundled snapshot); voice rates verified from vendor list pages",
+};
 for (const [k, v] of entries) {
   const entry = {
     input_cost_per_token: v.input_cost_per_token,

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -39,7 +39,13 @@ from .guard import (
 )
 from .hosted import hosted_enforcement_available, hosted_remaining_usd
 from .latency import LatencyAdvisory, LatencyBudget
-from .pricing import ManualPrice, PricedModel, price_tokens, resolve_price
+from .pricing import (
+    ManualPrice,
+    PricedModel,
+    cost_map_generated_at,
+    price_tokens,
+    resolve_price,
+)
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
@@ -85,6 +91,7 @@ __all__ = [
     "UnpriceableVoiceError",
     "ManualPrice",
     "PricedModel",
+    "cost_map_generated_at",
     "price_tokens",
     "resolve_price",
     "VoiceRate",

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -1,4 +1,8 @@
 {
+  "__meta__": {
+    "generated_at": "2026-08-17",
+    "source": "LiteLLM public model prices (bundled snapshot); voice rates verified from vendor list pages"
+  },
   "chatgpt-4o-latest": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000015,

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -47,9 +47,30 @@ def _load_cost_map() -> dict[str, Any]:
 # per-token prices), so keeping them out of _COST_MAP means the token resolver
 # and its whole-map invariants never see them. See voice_pricing.py.
 _VOICE_MAP_KEY = "__voice__"
+# Reserved metadata key: provenance/freshness of the bundled snapshot, e.g.
+# {"generated_at": "2026-08-17"}. Like __voice__ it is NOT a model, so it stays
+# out of _COST_MAP; surfaced via cost_map_generated_at().
+_META_KEY = "__meta__"
 _RAW_COST_MAP: dict[str, Any] = _load_cost_map()
 _VOICE_MAP: dict[str, Any] = _RAW_COST_MAP.get(_VOICE_MAP_KEY, {})
-_COST_MAP: dict[str, Any] = {k: v for k, v in _RAW_COST_MAP.items() if k != _VOICE_MAP_KEY}
+_META: dict[str, Any] = _RAW_COST_MAP.get(_META_KEY, {})
+# Exclude every reserved dunder key (__voice__, __meta__, …) so the token
+# resolver only ever sees real model ids.
+_COST_MAP: dict[str, Any] = {
+    k: v for k, v in _RAW_COST_MAP.items() if not (k.startswith("__") and k.endswith("__"))
+}
+
+
+def cost_map_generated_at() -> str | None:
+    """Date the bundled pricing snapshot was last generated/verified.
+
+    Returns the ISO ``YYYY-MM-DD`` string from the cost map's ``__meta__`` block,
+    or ``None`` if the bundled map predates the metadata. Pricing is a
+    drift-prone snapshot of public list rates; this surfaces *how fresh* it is (a
+    trust signal you can display or gate on).
+    """
+    value = _META.get("generated_at")
+    return value if isinstance(value, str) else None
 
 
 # The one "<provider>/" prefix that is safe to strip: the remainder of a

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -251,3 +251,23 @@ def test_price_tokens_caching_constants() -> None:
     assert _CACHE_CREATION_1H_MULTIPLIER == 2.00
     assert _CACHE_READ_MULTIPLIER == 0.10
 
+
+
+def test_cost_map_generated_at_is_iso_date():
+    """The bundled snapshot exposes a YYYY-MM-DD freshness date."""
+    import re
+
+    from floe_guard import cost_map_generated_at
+
+    date = cost_map_generated_at()
+    assert date is not None
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", date), date
+
+
+def test_reserved_meta_keys_are_not_priceable_models():
+    """__meta__ / __voice__ are reserved keys, never resolved as models."""
+    from floe_guard.pricing import _COST_MAP
+
+    assert "__meta__" not in _COST_MAP
+    assert "__voice__" not in _COST_MAP
+    assert "gpt-4o" in _COST_MAP  # real models are still present


### PR DESCRIPTION
From the activation feedback: Floe makes spend decisions from a **bundled snapshot** of drift-prone public list rates, but there was no way to see *how fresh* it is. This turns that necessary caveat into a trust signal.

## Change
- **`cost_map_generated_at()`** (Python, exported) → the `YYYY-MM-DD` the bundled cost map was last generated/verified, from a reserved `__meta__` key. **`costMapGeneratedAt()`** in TS (parity).
- The token resolver now excludes every reserved dunder key (`__voice__`, **`__meta__`**) from model lookups — `__meta__` is never priceable.
- `scripts/update-cost-map.mjs` stamps `__meta__.generated_at` on every refresh, into **both** the Python and JS cost maps.
- README documents it as a freshness/trust signal.

## Verified
- `cost_map_generated_at()` → `2026-08-17`; `__meta__`/`__voice__` excluded from models, real models still priceable.
- Python: 25 pricing tests pass (incl. 2 new), ruff clean. JS: typecheck + build pass with `__meta__` in the map + the new accessor.

## Merge note
Bumps py `0.17.1 → 0.18.0` — the **same 0.18.0 target as #89 (`floe-guard demo`)**, since both are features in this unreleased cycle. Expect a trivial version-line + CHANGELOG merge with #89 (rebase whichever lands second). JS `0.13.1 → 0.14.0` (only this PR touches JS).

Part 3 of 3 from the activation feedback (companions: #89 `floe-guard demo`; activation-funnel README next).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessors in Python and JavaScript to retrieve the bundled pricing snapshot date.
  * Added pricing metadata, including generation date and source details.
  * Added documentation explaining pricing snapshot freshness and verification.

* **Bug Fixes**
  * Prevented metadata entries from being treated as priceable models.

* **Chores**
  * Updated Python to version 0.18.0 and JavaScript to version 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->