### PR TITLE
docs: add 'guard your first real workflow' step to the activation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ misses the rest of the bill. Rates are a snapshot of public US list prices and
 drift — details, caveats, and the Pipecat version in
 [Voice adapters](#voice-adapters-stt--llm--tts).
 
+## Guard your first real workflow
+
+You've watched it stop a *stub* loop — the real payoff is protecting a *real* one,
+where the local ceiling earns its keep. Pick your stack; each is a drop-in adapter,
+a few lines, no rearchitecting:
+
+- **OpenAI / Anthropic / Gemini** — [`guarded_completion`](#openai) wraps the client call.
+- **LangChain / LangGraph** — a [callback handler](#langchain) / [`guarded_node`](#langgraph) per fan-out branch.
+- **CrewAI / LiteLLM** — [`budget_guarded_llm`](#crewai) / [`guarded_completion`](#litellm).
+- **Voice (Pipecat · LiveKit · Vapi · Retell)** — [per-turn voice adapters](#voice-adapters-stt--llm--tts).
+
+See the [adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
+Only once one real workflow is protected does hosted Floe really make sense — and
+that's exactly what comes next.
+
 ## One line to hosted
 
 Already on hosted Floe? Keep every line of your code — swap the constructor.


### PR DESCRIPTION
Part 2 of 3 from the activation feedback (companions: #89 `floe-guard demo`, #90 cost-map freshness).

The reviewer's point: after the aha-moment demo, the README moved straight to **hosted Floe**, skipping the step where the local guard actually earns its keep — protecting a **real** workflow. Their hypothesis (well-reasoned): someone who has guarded one real workflow understands why they'd eventually want hosted far better than someone who only watched a simulated loop stop.

## Change (README-only)
Adds a **"Guard your first real workflow"** section between the demos and "One line to hosted", routing to the existing adapters (OpenAI/Anthropic/Gemini, LangChain/LangGraph, CrewAI/LiteLLM, voice). The path now reads: **install → demo → guard one real workflow → hosted**.

No new APIs — the adapters already exist; this fixes the *sequencing* so the integration step isn't skipped. All links resolve (the anchor link-check test passes). No version bump (docs only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for protecting real AI and voice workflows using existing adapters.
  * Linked to the adapter matrix and hosted platform guidance for additional setup information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->