### PR TITLE
docs: restructure README and add examples directory index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.20.1 / js 0.15.0
+
+### Documentation (py)
+
+- **README Restructure and Examples Index**: Restructured the root README to improve readability, compressed the introductory sections, reordered logical sections (motivation/mechanics earlier), and added a central index table mapping all 16 `examples/*.py` scripts (including the orphaned `langchain_groq_example.py`).
+
 ## Unreleased — py 0.20.0 / js 0.15.0
 
 ### Added (py)

--- a/README.md
+++ b/README.md
@@ -7,54 +7,24 @@
 [![CI](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**The spend meter and budget gate for AI voice agents — and any LLM agent.**
-floe-guard meters the whole call — STT + LLM + TTS + telephony — from a bundled
-cost map (name each leg's vendor; no manual rates), and hard-stops the next turn
-or call *before* it crosses your spend ceiling: **per-turn enforcement for
-[Pipecat](#pipecat-voice) and [LiveKit](#livekit-voice)**, and a hard stop for
-runaway LLM loops — a loop dies at $0.10 instead of $4,000; an over-budget call
-is rejected at the door. Local, in your process. No account, no signup, no
-network, **no telemetry**.
+**The spend meter and budget gate for AI agents.** Hard-stops the next LLM call,
+voice turn, or tool invocation *before* it crosses your USD ceiling — a runaway loop
+dies at $0.10 instead of $4,000. In-process, no account, no signup, **no telemetry**.
 
-**Voice:** [Pipecat](#pipecat-voice) · [LiveKit](#livekit-voice) (Python) ·
-LiveKit · Vapi · Retell ([TypeScript](#typescript-voice-adapters)) — reserve
-before each turn, settle on real usage, so a turn that would cross the ceiling
-never starts — plus [pre-call admission gates](#voice-admission-gates-pre-call)
-that speak each orchestrator's inbound webhook shape. **Any agent:** [CrewAI](#crewai) · [LiteLLM](#litellm) ·
-[LangChain](#langchain) · [LangGraph](#langgraph) · [OpenAI](#openai) ·
-[Anthropic](#anthropic) · [Gemini](#google-gemini) · [Vercel AI SDK](#vercel-ai-sdk)
-— or any stack, via plain `check()` / `record()`. See the
-[adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
-The hard-stop is contract-based: gate each call through the guard — adapters do
-it for LLM calls; for paid tools, [`reserve_tool()` / `settle_tool()`](#tool-spend-under-the-same-ceiling)
-block *before* the call runs (`record_tool()` alone meters a call after the
-fact — it can't stop one already made).
+**Python** (`pip install floe-guard`): plain `check()` / `record()` or adapters for
+[OpenAI](#openai) · [Anthropic](#anthropic) · [Gemini](#google-gemini) · [CrewAI](#crewai) ·
+[LiteLLM](#litellm) · [LangChain](#langchain) · [LangGraph](#langgraph); voice adapters for
+[Pipecat](#pipecat-voice) and [LiveKit](#livekit-voice);
+[pre-call admission gates](#voice-admission-gates-pre-call).
 
-## What's inside
+**TypeScript** (`npm i floe-guard`): [Vercel AI SDK](#vercel-ai-sdk) middleware, native
+[LiveKit · Vapi · Retell](#typescript-voice-adapters) voice adapters.
+See the [adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
 
-floe-guard grows from a one-line local ceiling to fleet-wide coverage — take only
-the depth you need:
-
-- **Stop a runaway loop** — the [hard stop](#how-it-works) before the next call
-  (`check()` / `record()`), or a [framework adapter](#framework-adapters-optional-extras)
-  for OpenAI / Anthropic / Gemini / CrewAI / LangChain / LangGraph / LiteLLM /
-  Vercel AI SDK.
-- **Guard a voice call** — per-turn [voice adapters](#voice-adapters-stt--llm--tts)
-  (Pipecat + LiveKit in Python; LiveKit, Vapi, Retell in TypeScript) that price
-  STT + LLM + TTS + telephony, and
-  [pre-call admission gates](#voice-admission-gates-pre-call) that reject an
-  over-budget call at the door.
-- **Adapt before the cap** — [`advisory()`](#context-aware-budgeting) (near-limit
-  flag + `$/min` burn rate) to taper, plus
-  [token / step](#token-ceilings-and-per-step-budgets) and
-  [latency](#latencybudget--deadlines-the-same-way) budgets.
-- **Upgrade to hosted** — [`from_floe()`](#one-line-to-hosted) reads your
-  server-side budget headroom into the local ceiling, one line.
-- **Feed Coverage Score** — [opt-in ledger sync](#sync-your-ledger-for-coverage-score-opt-in)
-  pushes off-path (BYOK / self-hosted) spend so it counts. Off by default.
-
-Everything above is **local, no account, [no telemetry](#no-telemetry)** — unless
-you explicitly opt into a hosted read or a ledger sync.
+The hard-stop is contract-based: adapters gate LLM calls automatically; for paid
+tools, [`reserve_tool()` / `settle_tool()`](#tool-spend-under-the-same-ceiling)
+block *before* the call runs (`record_tool()` alone meters after the fact — it
+can't stop a call already made).
 
 ## Works best with the Floe skill
 
@@ -136,50 +106,6 @@ That's the answer a token-level tool can't give: it meters the LLM leg and
 misses the rest of the bill. Rates are a snapshot of public US list prices and
 drift — details, caveats, and the Pipecat version in
 [Voice adapters](#voice-adapters-stt--llm--tts).
-
-## Guard your first real workflow
-
-You've watched it stop a *stub* loop — the real payoff is protecting a *real* one,
-where the local ceiling earns its keep. Pick your stack; each is a drop-in adapter,
-a few lines, no rearchitecting:
-
-- **OpenAI / Anthropic / Gemini** — [`guarded_completion`](#openai) wraps the client call.
-- **LangChain / LangGraph** — a [callback handler](#langchain) / [`guarded_node`](#langgraph) per fan-out branch.
-- **CrewAI / LiteLLM** — [`budget_guarded_llm`](#crewai) / [`guarded_completion`](#litellm).
-- **Voice (Pipecat · LiveKit · Vapi · Retell)** — [per-turn voice adapters](#voice-adapters-stt--llm--tts).
-
-See the [adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
-Only once one real workflow is protected does hosted Floe really make sense — and
-that's exactly what comes next.
-
-## One line to hosted
-
-Already on hosted Floe? Keep every line of your code — swap the constructor.
-`from_floe` reads your **server-side budget headroom** and uses it as the local
-ceiling, so the free→hosted upgrade is one line:
-
-```python
-from floe_guard import BudgetGuard
-
-guard = BudgetGuard.from_floe(api_key="floe_…")   # ceiling = your hosted headroom
-guard.check()                                     # everything else is unchanged
-response = call_your_llm(...)
-guard.record("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens)
-```
-
-Budget, not balance: the read is a *headroom* signal and enforcement stays
-**local** — [hosted Floe](#when-you-outgrow-local-guardrails) remains the source
-of truth for the un-bypassable, cross-vendor cap. No key set → no network (the
-[zero-telemetry](#no-telemetry) invariant holds); a failed read fails closed
-(pass `fallback_limit_usd=` to degrade to a local ceiling instead).
-
-Your tapering logic carries over, too: local `advisory()` and hosted's
-`X-Floe-Budget-Advisory` header expose the same **near-limit signal**
-(`near_limit` + `used_bps` utilization), so the "near the cap? taper now"
-decision you branch on is the same. The wire shapes differ — the hosted header
-nests the tightest cap under `tightest` with raw-integer amounts, so field access
-is a light remap — but it answers that signal across *every* vendor and cap, not
-just the one you instrumented locally.
 
 ## Why floe-guard?
 
@@ -290,262 +216,18 @@ Everything else — Mistral, Cohere, Ollama, Bedrock, realtime/audio models,
 self-hosted — needs `price_overrides` (or `fail_closed=False` to accept it
 un-metered).
 
-## Context-aware budgeting
+## Guard your first real workflow
 
-The hard-stop is the guarantee; `advisory()` is the *upside*. Read it before a
-step to let your agent **adapt** as it nears the cap — taper to a cheaper model,
-shrink the task, or wrap up — instead of getting cut off mid-run.
+You've watched it stop a *stub* loop — the real payoff is protecting a *real* one,
+where the local ceiling earns its keep. Pick your stack; each is a drop-in adapter,
+a few lines, no rearchitecting:
 
-```python
-guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)   # flag at 70% used
+- **OpenAI / Anthropic / Gemini** — [`guarded_completion`](#openai) wraps the client call.
+- **LangChain / LangGraph** — a [callback handler](#langchain) / [`guarded_node`](#langgraph) per fan-out branch.
+- **CrewAI / LiteLLM** — [`budget_guarded_llm`](#crewai) / [`guarded_completion`](#litellm).
+- **Voice (Pipecat · LiveKit · Vapi · Retell)** — [per-turn voice adapters](#voice-adapters-stt--llm--tts).
 
-adv = guard.advisory()
-# BudgetAdvisory(near_limit=False, used_bps=125, remaining_usd=0.0987, ...)
-model = "gpt-4o-mini" if adv.near_limit else "gpt-4o"        # downshift near the cap
-
-guard.check()                  # still the hard line — taper or not, this holds
-response = call_your_llm(model)
-guard.record(model, response.usage.prompt_tokens, response.usage.completion_tokens)
-```
-
-`advisory()` returns `near_limit`, `used_bps` (utilization in basis points),
-`remaining_usd`, and the budget totals. It also reports `expected_cost` (the
-guard's own next-call estimate) and `est_calls_remaining` (how many more calls
-the remaining budget buys, `None` until the first call is recorded) — call
-headroom, not just dollars. For voice, it also reports `burn_rate_usd_per_min`
-(spend ÷ minutes since the guard was created — the $/min voice teams watch;
-make one guard per call/turn for a per-call rate, `None` before any time
-elapses). It's a **soft** signal — the model may
-ignore it; `check()` is what enforces the ceiling. See
-[`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
-(no API key).
-
-Model choice is only one axis. The same signal drives **any** cost lever, and in
-most agents the bigger levers are elsewhere — retrieval depth
-([`examples/retrieval_depth.py`](examples/retrieval_depth.py): RAG `top_k` falls
-20 → 12 → 5), context size
-([`examples/context_size.py`](examples/context_size.py): stop resending the whole
-transcript, cap replies shorter), and plan complexity
-([`examples/plan_complexity.py`](examples/plan_complexity.py): thin the reasoning,
-then drop the optional sub-tasks to protect the required ones). Each holds the
-model fixed and shrinks a non-model parameter as the budget drains (no API key).
-
-### Budget-aware retry
-
-Blind retries can spend the same expensive path again right when the agent is
-running out of headroom. `with_budget_retry()` composes over the existing guard:
-retry normally while budget is healthy, ask your code for a cheaper retry plan
-when `advisory().near_limit` is true, and call `check(estimated_cost)` before
-each retry so an over-budget retry never runs.
-
-```python
-from floe_guard import BudgetGuard, RetryPlan, with_budget_retry
-
-guard = BudgetGuard(limit_usd=1.00)
-
-def premium_model():
-    return call_model("gpt-4o")
-
-def mini_model():
-    return call_model("gpt-4o-mini")
-
-result = with_budget_retry(
-    guard,
-    premium_model,
-    estimated_cost=0.20,
-    max_attempts=2,
-    on_degrade=lambda exc, adv: RetryPlan(call=mini_model, estimated_cost=0.01),
-)
-```
-
-The helper does not rank models or know provider pricing; the caller defines
-what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
-`withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
-for a no-network demo.
-
-The taper logic you just wrote carries over to hosted — the same near-limit
-signal (`near_limit` + `used_bps`), answered across *every* vendor and cap; the
-hosted `X-Floe-Budget-Advisory` header nests it under `tightest` with raw-integer
-amounts, so field access is a light remap. See
-[One line to hosted](#one-line-to-hosted). The TS package exposes the identical
-`guard.advisory()`.
-
-## Per-call spend log
-
-The guard keeps a typed, in-memory ledger of everything it priced: each
-`record()` / `settle()` appends one `SpendEvent`, and `record_tool()` lets paid
-non-LLM calls (search APIs, scrapers) spend the same budget and land in the same
-log. The events sum to `spent_usd` (unless a `max_log_events` ring buffer has
-evicted old ones) — no more rebuilding per-call breakdowns around the guard.
-
-```python
-guard = BudgetGuard(limit_usd=1.00)                      # max_log_events=N caps memory
-guard.record("gpt-4o", 1_200, 350, label="researcher")   # label is optional
-guard.record_tool("serpapi.search", 0.01, label="researcher")
-
-guard.spend_log      # [SpendEvent(timestamp=…, kind="llm", model_or_tool="gpt-4o",
-                     #             prompt_tokens=1200, completion_tokens=350,
-                     #             cost_usd=0.0065, label="researcher"), …]
-print(guard.export_log(), end="")   # JSONL, one event per line
-```
-
-`export_log()` emits a stable snake_case schema —
-`{timestamp, kind: llm|tool, model_or_tool, prompt_tokens, completion_tokens,
-cost_usd, label?, reserved?}` — identical to the TS package's `exportLog()`, so
-every agent produces the same shape regardless of stack and the streams can be
-concatenated and analysed together.
-
-## Tool spend under the same ceiling
-
-Tool-heavy agents often spend more on paid APIs (Apollo lookups, Exa searches,
-scrapers) than on tokens — and those dollars must count against the same cap,
-or the kill-switch guarantee is fiction for them. Tool spend is a first-class
-primitive with the full reserve/settle contract; it's actually **stronger**
-than the LLM path, because the price is known *before* the call:
-
-```python
-# pre-call hard-stop — the crossing call NEVER runs
-handle = guard.reserve_tool(0.02)              # raises BudgetExceeded before Apollo
-result = apollo.people_lookup(...)
-guard.settle_tool("apollo.people_lookup", 0.02, reserved=handle)
-
-guard.record_tool("exa.search", 0.004)         # post-hoc, for metered APIs
-
-guard.tool_costs     # {"apollo.people_lookup": 0.42, "exa.search": 0.11}
-guard.remaining_usd  # tokens + tools, one ceiling
-```
-
-`record_tool` also updates the next-call estimate, so a plain
-`check()`/`record_tool` loop stops *before* the crossing call — a runaway tool
-loop dies exactly like a runaway LLM loop. (Tool and LLM estimates are tracked
-separately; the default prediction is the costlier of the two, so a cheap tool
-call never shrinks the hold ahead of an expensive LLM call.) The caller supplies the USD (there
-is no tool cost-map); every tool call lands in `spend_log` as a
-`kind: "tool"` event. Same API in TS (`reserveTool`/`settleTool`/`recordTool`/
-`toolCosts`). See [`examples/tool_budget.py`](examples/tool_budget.py).
-
-## Token ceilings and per-step budgets
-
-Dollars aren't the only runaway. A token ceiling caps *total recorded token
-usage — every bucket the guard counts: prompt, completion, and cache* regardless
-of price, and a **per-step** cap keeps one step of a sequential loop from
-starving the rest even when the global budget has room.
-Both ride on the same reserve/settle machinery — they're a second dimension, not
-a second guard:
-
-```python
-from floe_guard import BudgetGuard, TokenBudgetExceeded
-
-# aggregate token ceiling alongside the USD ceiling
-guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
-
-guard.check(estimated_tokens=1_200)      # raises TokenBudgetExceeded if it'd cross
-guard.record("gpt-4o", 800, 400)         # tokens accrue for free from the counts
-
-# a per-step cap for one step of a sequential loop
-with guard.step(max_tokens=5_000) as g:  # g IS guard — adapters pass it through
-    g.record("gpt-4o", 3_000, 1_500)
-    g.check(estimated_tokens=1_000)       # 4_500 + 1_000 > 5_000 → scope="step"
-
-adv = guard.advisory()
-adv.token_used_bps        # aggregate token utilization (None if no token_limit)
-adv.remaining_tokens      # tokens left before the ceiling (None if no token_limit)
-adv.step_remaining_tokens # active step's headroom (None if no step, or its token cap is unset)
-```
-
-`TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry treats a
-token block as terminal automatically. With no `token_limit` and no `step()`, USD
-enforcement is unchanged and `reserve()` still returns a plain `float` — a
-`BudgetReservation` handle appears only when tokens are actually reserved or a
-step is active. (`advisory()` gains the token/step fields shown above; they're
-additive and `None` when their dimension is unused.) In TS the step is a callback
-and fields are camelCase:
-
-```ts
-const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
-guard.check(undefined, { estimatedTokens: 1_200 });
-guard.step({ maxTokens: 5_000 }, (g) => {
-  g.record("gpt-4o", 3_000, 1_500);
-  g.check(undefined, { estimatedTokens: 1_000 }); // throws TokenBudgetExceeded
-});
-guard.advisory().stepRemainingTokens;
-```
-
-See [`examples/step_budget.py`](examples/step_budget.py) (no network).
-
-## LatencyBudget — deadlines, the same way
-
-Money isn't the only budget an agent burns. `LatencyBudget` is `BudgetGuard`'s
-sibling for **time**: it tracks cumulative elapsed time across a tool chain
-against an end-user SLA and stops the *next* call before it would blow it.
-
-```python
-from floe_guard import LatencyBudget, DeadlineExceeded
-
-deadline = LatencyBudget(sla_ms=5000)          # the user is promised 5s
-
-for step in plan:
-    deadline.check(expected_ms=step.est_ms)    # raises DeadlineExceeded when projected over
-    model = DEFAULT_MODEL
-    if deadline.advisory().near_deadline:      # 80% consumed by default —
-        model = FAST_FALLBACK                  # downshift BEFORE the wall
-    run(step, model, timeout_ms=deadline.remaining_ms)
-```
-
-Same shape in TypeScript: `new LatencyBudget(5000)`, `check(expectedMs)`,
-`remainingMs`, `advisory().nearDeadline`.
-
-Honest scope, mirroring the rest of this package:
-
-- **Monotonic clock** (`time.monotonic()` / `performance.now()`) — NTP steps
-  and DST can't corrupt the budget.
-- **Cooperative, not preemptive.** The guard supplies the deadline *signal*;
-  killing an already-running stalled call is your framework's job (asyncio
-  cancellation, `AbortSignal`). `check()` prevents the next call from starting.
-- **Advisory symmetry.** `near_deadline` / `used_bps` / `remaining_ms` are the
-  latency twin of the budget advisory's `near_limit` / `used_bps` /
-  `remaining_usd` — taper logic written against one ports to the other.
-- **In-process.** One instance per request/run; distributed/server-side latency
-  tracking is out of scope.
-
-## Request-sized estimates and mid-stream enforcement
-
-Two gaps in last-cost prediction, closed in 0.4.0 (Python):
-
-**The oversized first call.** `check()`/`reserve()` predict from the *last*
-call — blind on call #1, wrong for a call much bigger than the previous one.
-`estimate_call()` prices the **actual incoming request** so even a first call
-that alone would cross the cap blocks pre-flight:
-
-```python
-est = guard.estimate_call("gpt-4o", prompt_tokens=12_000, max_completion_tokens=4_096)
-handle = guard.reserve(est)   # raises BudgetExceeded NOW if this call can't fit
-```
-
-The LiteLLM adapter does this automatically (prompt tokens via
-`litellm.token_counter`, output cap from `max_tokens`), and the LangChain
-handler sizes its pre-call `check()` the same way. Unpriceable or unsized
-requests fall back to the old last-cost prediction — the wiring only ever
-tightens enforcement.
-
-**The stream that runs long.** `record()` meters a *completed* response — too
-late for a generation that starts cheap and keeps going. `guard_stream()` (or
-the underlying `StreamGuard`) re-prices the call on every chunk and cuts the
-stream off **mid-generation**, settling the tokens actually consumed instead of
-recording a big overshoot after the fact:
-
-```python
-from floe_guard import guard_stream
-
-for chunk in guard_stream(guard, "gpt-4o", stream, prompt_tokens=1_000):
-    print(chunk, end="")   # raises BudgetExceeded mid-stream at the ceiling
-```
-
-Chunk sizes are estimated at ~4 chars/token (pass `count_tokens=` for a real
-tokenizer); the final accrual reconciles to provider-reported usage via
-`StreamGuard.finish(...)`. See
-[`examples/streaming_guard.py`](examples/streaming_guard.py) for a runnable
-demo (no API key).
+See the [adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
 
 ## Framework adapters (optional extras)
 
@@ -1021,6 +703,292 @@ is no Node Pipecat server surface to adapt.
 For wiring floe-guard into an existing voice pipeline, see the Floe docs:
 **[Add Floe to your existing pipeline](https://floe-labs.gitbook.io/docs/getting-started/integrate-existing-pipeline)**.
 
+## Context-aware budgeting
+
+The hard-stop is the guarantee; `advisory()` is the *upside*. Read it before a
+step to let your agent **adapt** as it nears the cap — taper to a cheaper model,
+shrink the task, or wrap up — instead of getting cut off mid-run.
+
+```python
+guard = BudgetGuard(limit_usd=0.10, near_limit_bps=7000)   # flag at 70% used
+
+adv = guard.advisory()
+# BudgetAdvisory(near_limit=False, used_bps=125, remaining_usd=0.0987, ...)
+model = "gpt-4o-mini" if adv.near_limit else "gpt-4o"        # downshift near the cap
+
+guard.check()                  # still the hard line — taper or not, this holds
+response = call_your_llm(model)
+guard.record(model, response.usage.prompt_tokens, response.usage.completion_tokens)
+```
+
+`advisory()` returns `near_limit`, `used_bps` (utilization in basis points),
+`remaining_usd`, and the budget totals. It also reports `expected_cost` (the
+guard's own next-call estimate) and `est_calls_remaining` (how many more calls
+the remaining budget buys, `None` until the first call is recorded) — call
+headroom, not just dollars. For voice, it also reports `burn_rate_usd_per_min`
+(spend ÷ minutes since the guard was created — the $/min voice teams watch;
+make one guard per call/turn for a per-call rate, `None` before any time
+elapses). It's a **soft** signal — the model may
+ignore it; `check()` is what enforces the ceiling. See
+[`examples/budget_aware.py`](examples/budget_aware.py) for a runnable taper demo
+(no API key).
+
+Model choice is only one axis. The same signal drives **any** cost lever, and in
+most agents the bigger levers are elsewhere — retrieval depth
+([`examples/retrieval_depth.py`](examples/retrieval_depth.py): RAG `top_k` falls
+20 → 12 → 5), context size
+([`examples/context_size.py`](examples/context_size.py): stop resending the whole
+transcript, cap replies shorter), and plan complexity
+([`examples/plan_complexity.py`](examples/plan_complexity.py): thin the reasoning,
+then drop the optional sub-tasks to protect the required ones). Each holds the
+model fixed and shrinks a non-model parameter as the budget drains (no API key).
+
+### Budget-aware retry
+
+Blind retries can spend the same expensive path again right when the agent is
+running out of headroom. `with_budget_retry()` composes over the existing guard:
+retry normally while budget is healthy, ask your code for a cheaper retry plan
+when `advisory().near_limit` is true, and call `check(estimated_cost)` before
+each retry so an over-budget retry never runs.
+
+```python
+from floe_guard import BudgetGuard, RetryPlan, with_budget_retry
+
+guard = BudgetGuard(limit_usd=1.00)
+
+def premium_model():
+    return call_model("gpt-4o")
+
+def mini_model():
+    return call_model("gpt-4o-mini")
+
+result = with_budget_retry(
+    guard,
+    premium_model,
+    estimated_cost=0.20,
+    max_attempts=2,
+    on_degrade=lambda exc, adv: RetryPlan(call=mini_model, estimated_cost=0.01),
+)
+```
+
+The helper does not rank models or know provider pricing; the caller defines
+what "cheaper" means in `on_degrade`. TypeScript exposes the same pattern as
+`withBudgetRetry()`. See [`examples/budget_retry.py`](examples/budget_retry.py)
+for a no-network demo.
+
+The taper logic you just wrote carries over to hosted — the same near-limit
+signal (`near_limit` + `used_bps`), answered across *every* vendor and cap; the
+hosted `X-Floe-Budget-Advisory` header nests it under `tightest` with raw-integer
+amounts, so field access is a light remap. See
+[One line to hosted](#one-line-to-hosted). The TS package exposes the identical
+`guard.advisory()`.
+
+## Per-call spend log
+
+The guard keeps a typed, in-memory ledger of everything it priced: each
+`record()` / `settle()` appends one `SpendEvent`, and `record_tool()` lets paid
+non-LLM calls (search APIs, scrapers) spend the same budget and land in the same
+log. The events sum to `spent_usd` (unless a `max_log_events` ring buffer has
+evicted old ones) — no more rebuilding per-call breakdowns around the guard.
+
+```python
+guard = BudgetGuard(limit_usd=1.00)                      # max_log_events=N caps memory
+guard.record("gpt-4o", 1_200, 350, label="researcher")   # label is optional
+guard.record_tool("serpapi.search", 0.01, label="researcher")
+
+guard.spend_log      # [SpendEvent(timestamp=…, kind="llm", model_or_tool="gpt-4o",
+                     #             prompt_tokens=1200, completion_tokens=350,
+                     #             cost_usd=0.0065, label="researcher"), …]
+print(guard.export_log(), end="")   # JSONL, one event per line
+```
+
+`export_log()` emits a stable snake_case schema —
+`{timestamp, kind: llm|tool, model_or_tool, prompt_tokens, completion_tokens,
+cost_usd, label?, reserved?}` — identical to the TS package's `exportLog()`, so
+every agent produces the same shape regardless of stack and the streams can be
+concatenated and analysed together.
+
+## Tool spend under the same ceiling
+
+Tool-heavy agents often spend more on paid APIs (Apollo lookups, Exa searches,
+scrapers) than on tokens — and those dollars must count against the same cap,
+or the kill-switch guarantee is fiction for them. Tool spend is a first-class
+primitive with the full reserve/settle contract; it's actually **stronger**
+than the LLM path, because the price is known *before* the call:
+
+```python
+# pre-call hard-stop — the crossing call NEVER runs
+handle = guard.reserve_tool(0.02)              # raises BudgetExceeded before Apollo
+result = apollo.people_lookup(...)
+guard.settle_tool("apollo.people_lookup", 0.02, reserved=handle)
+
+guard.record_tool("exa.search", 0.004)         # post-hoc, for metered APIs
+
+guard.tool_costs     # {"apollo.people_lookup": 0.42, "exa.search": 0.11}
+guard.remaining_usd  # tokens + tools, one ceiling
+```
+
+`record_tool` also updates the next-call estimate, so a plain
+`check()`/`record_tool` loop stops *before* the crossing call — a runaway tool
+loop dies exactly like a runaway LLM loop. (Tool and LLM estimates are tracked
+separately; the default prediction is the costlier of the two, so a cheap tool
+call never shrinks the hold ahead of an expensive LLM call.) The caller supplies the USD (there
+is no tool cost-map); every tool call lands in `spend_log` as a
+`kind: "tool"` event. Same API in TS (`reserveTool`/`settleTool`/`recordTool`/
+`toolCosts`). See [`examples/tool_budget.py`](examples/tool_budget.py).
+
+## Token ceilings and per-step budgets
+
+Dollars aren't the only runaway. A token ceiling caps *total recorded token
+usage — every bucket the guard counts: prompt, completion, and cache* regardless
+of price, and a **per-step** cap keeps one step of a sequential loop from
+starving the rest even when the global budget has room.
+Both ride on the same reserve/settle machinery — they're a second dimension, not
+a second guard:
+
+```python
+from floe_guard import BudgetGuard, TokenBudgetExceeded
+
+# aggregate token ceiling alongside the USD ceiling
+guard = BudgetGuard(limit_usd=100.0, token_limit=20_000)
+
+guard.check(estimated_tokens=1_200)      # raises TokenBudgetExceeded if it'd cross
+guard.record("gpt-4o", 800, 400)         # tokens accrue for free from the counts
+
+# a per-step cap for one step of a sequential loop
+with guard.step(max_tokens=5_000) as g:  # g IS guard — adapters pass it through
+    g.record("gpt-4o", 3_000, 1_500)
+    g.check(estimated_tokens=1_000)       # 4_500 + 1_000 > 5_000 → scope="step"
+
+adv = guard.advisory()
+adv.token_used_bps        # aggregate token utilization (None if no token_limit)
+adv.remaining_tokens      # tokens left before the ceiling (None if no token_limit)
+adv.step_remaining_tokens # active step's headroom (None if no step, or its token cap is unset)
+```
+
+`TokenBudgetExceeded` subclasses `BudgetExceeded`, so budget-aware retry treats a
+token block as terminal automatically. With no `token_limit` and no `step()`, USD
+enforcement is unchanged and `reserve()` still returns a plain `float` — a
+`BudgetReservation` handle appears only when tokens are actually reserved or a
+step is active. (`advisory()` gains the token/step fields shown above; they're
+additive and `None` when their dimension is unused.) In TS the step is a callback
+and fields are camelCase:
+
+```ts
+const guard = new BudgetGuard(100, { tokenLimit: 20_000 });
+guard.check(undefined, { estimatedTokens: 1_200 });
+guard.step({ maxTokens: 5_000 }, (g) => {
+  g.record("gpt-4o", 3_000, 1_500);
+  g.check(undefined, { estimatedTokens: 1_000 }); // throws TokenBudgetExceeded
+});
+guard.advisory().stepRemainingTokens;
+```
+
+See [`examples/step_budget.py`](examples/step_budget.py) (no network).
+
+## LatencyBudget — deadlines, the same way
+
+Money isn't the only budget an agent burns. `LatencyBudget` is `BudgetGuard`'s
+sibling for **time**: it tracks cumulative elapsed time across a tool chain
+against an end-user SLA and stops the *next* call before it would blow it.
+
+```python
+from floe_guard import LatencyBudget, DeadlineExceeded
+
+deadline = LatencyBudget(sla_ms=5000)          # the user is promised 5s
+
+for step in plan:
+    deadline.check(expected_ms=step.est_ms)    # raises DeadlineExceeded when projected over
+    model = DEFAULT_MODEL
+    if deadline.advisory().near_deadline:      # 80% consumed by default —
+        model = FAST_FALLBACK                  # downshift BEFORE the wall
+    run(step, model, timeout_ms=deadline.remaining_ms)
+```
+
+Same shape in TypeScript: `new LatencyBudget(5000)`, `check(expectedMs)`,
+`remainingMs`, `advisory().nearDeadline`.
+
+Honest scope, mirroring the rest of this package:
+
+- **Monotonic clock** (`time.monotonic()` / `performance.now()`) — NTP steps
+  and DST can't corrupt the budget.
+- **Cooperative, not preemptive.** The guard supplies the deadline *signal*;
+  killing an already-running stalled call is your framework's job (asyncio
+  cancellation, `AbortSignal`). `check()` prevents the next call from starting.
+- **Advisory symmetry.** `near_deadline` / `used_bps` / `remaining_ms` are the
+  latency twin of the budget advisory's `near_limit` / `used_bps` /
+  `remaining_usd` — taper logic written against one ports to the other.
+- **In-process.** One instance per request/run; distributed/server-side latency
+  tracking is out of scope.
+
+## Request-sized estimates and mid-stream enforcement
+
+Two gaps in last-cost prediction, closed in 0.4.0 (Python):
+
+**The oversized first call.** `check()`/`reserve()` predict from the *last*
+call — blind on call #1, wrong for a call much bigger than the previous one.
+`estimate_call()` prices the **actual incoming request** so even a first call
+that alone would cross the cap blocks pre-flight:
+
+```python
+est = guard.estimate_call("gpt-4o", prompt_tokens=12_000, max_completion_tokens=4_096)
+handle = guard.reserve(est)   # raises BudgetExceeded NOW if this call can't fit
+```
+
+The LiteLLM adapter does this automatically (prompt tokens via
+`litellm.token_counter`, output cap from `max_tokens`), and the LangChain
+handler sizes its pre-call `check()` the same way. Unpriceable or unsized
+requests fall back to the old last-cost prediction — the wiring only ever
+tightens enforcement.
+
+**The stream that runs long.** `record()` meters a *completed* response — too
+late for a generation that starts cheap and keeps going. `guard_stream()` (or
+the underlying `StreamGuard`) re-prices the call on every chunk and cuts the
+stream off **mid-generation**, settling the tokens actually consumed instead of
+recording a big overshoot after the fact:
+
+```python
+from floe_guard import guard_stream
+
+for chunk in guard_stream(guard, "gpt-4o", stream, prompt_tokens=1_000):
+    print(chunk, end="")   # raises BudgetExceeded mid-stream at the ceiling
+```
+
+Chunk sizes are estimated at ~4 chars/token (pass `count_tokens=` for a real
+tokenizer); the final accrual reconciles to provider-reported usage via
+`StreamGuard.finish(...)`. See
+[`examples/streaming_guard.py`](examples/streaming_guard.py) for a runnable
+demo (no API key).
+
+## One line to hosted
+
+Already on hosted Floe? Keep every line of your code — swap the constructor.
+`from_floe` reads your **server-side budget headroom** and uses it as the local
+ceiling, so the free→hosted upgrade is one line:
+
+```python
+from floe_guard import BudgetGuard
+
+guard = BudgetGuard.from_floe(api_key="floe_…")   # ceiling = your hosted headroom
+guard.check()                                     # everything else is unchanged
+response = call_your_llm(...)
+guard.record("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens)
+```
+
+Budget, not balance: the read is a *headroom* signal and enforcement stays
+**local** — [hosted Floe](#when-you-outgrow-local-guardrails) remains the source
+of truth for the un-bypassable, cross-vendor cap. No key set → no network (the
+[zero-telemetry](#no-telemetry) invariant holds); a failed read fails closed
+(pass `fallback_limit_usd=` to degrade to a local ceiling instead).
+
+Your tapering logic carries over, too: local `advisory()` and hosted's
+`X-Floe-Budget-Advisory` header expose the same **near-limit signal**
+(`near_limit` + `used_bps` utilization), so the "near the cap? taper now"
+decision you branch on is the same. The wire shapes differ — the hosted header
+nests the tightest cap under `tightest` with raw-integer amounts, so field access
+is a light remap — but it answers that signal across *every* vendor and cap, not
+just the one you instrumented locally.
+
 ## Honest about what this is
 
 floe-guard is a **local, estimate-based** guardrail. It prices tokens from a
@@ -1115,16 +1083,6 @@ enforcement stays local.
 
 → [dev-dashboard.floelabs.xyz](https://dev-dashboard.floelabs.xyz/)
 
-## Built with floe-guard
-
-Using floe-guard in your project? Add the badge so others find it:
-
-[![guarded by floe-guard](https://img.shields.io/badge/guarded%20by-floe--guard-2f81f7.svg)](https://github.com/Floe-Labs/floe-guard)
-
-```markdown
-[![guarded by floe-guard](https://img.shields.io/badge/guarded%20by-floe--guard-2f81f7.svg)](https://github.com/Floe-Labs/floe-guard)
-```
-
 ## Examples
 
 All runnable examples live in [`examples/`](examples/). Use `python examples/<file>` from the repo root.
@@ -1147,6 +1105,16 @@ All runnable examples live in [`examples/`](examples/). Use `python examples/<fi
 | [`voice_turn_budget.py`](examples/voice_turn_budget.py) | Pipecat pipeline with `FloeBudgetGuardProcessor`: multi-turn voice conversation halted mid-run | `pip install floe-guard[pipecat]` | none |
 | [`voice_call_cost_pipecat.py`](examples/voice_call_cost_pipecat.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via Pipecat, priced from the bundled map | `pip install floe-guard[pipecat]` | none |
 | [`voice_call_cost_livekit.py`](examples/voice_call_cost_livekit.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via LiveKit, priced from the bundled map | `pip install floe-guard[livekit]` | none |
+
+## Built with floe-guard
+
+Using floe-guard in your project? Add the badge so others find it:
+
+[![guarded by floe-guard](https://img.shields.io/badge/guarded%20by-floe--guard-2f81f7.svg)](https://github.com/Floe-Labs/floe-guard)
+
+```markdown
+[![guarded by floe-guard](https://img.shields.io/badge/guarded%20by-floe--guard-2f81f7.svg)](https://github.com/Floe-Labs/floe-guard)
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -862,7 +862,7 @@ task = PipelineTask(
 )
 ```
 
-> **Fragment** — `transport`, `stt`, `llm`, `tts`, and `context_aggregator` are your existing Pipecat objects; this shows only where the guard sits in a pipeline you already have. For a complete, runnable demo (no API key, no network), see [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
+> **Fragment** — `transport`, `stt`, `llm`, `tts`, and `context_aggregator` are your existing Pipecat objects; this shows only where the guard sits in a pipeline you already have. For a complete, runnable demo (no API key, no network — needs `pip install floe-guard[pipecat]`), see [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py).
 
 By default a blocked turn pushes a fatal `ErrorFrame` that terminates the
 pipeline — the hard-stop every other adapter gives you. Pass an
@@ -875,7 +875,7 @@ emits; `stt_model` / `telephony` are metered explicitly (Pipecat emits no STT/
 telephony usage frame) via `processor.meter_stt(seconds)` /
 `processor.meter_telephony(minutes)`. See
 [`examples/voice_call_cost_pipecat.py`](examples/voice_call_cost_pipecat.py) for
-the full per-leg breakdown (no API key, no network).
+the full per-leg breakdown (no API key, no network — needs `pip install floe-guard[pipecat]`).
 
 ### LiveKit (voice)
 
@@ -1124,6 +1124,29 @@ Using floe-guard in your project? Add the badge so others find it:
 ```markdown
 [![guarded by floe-guard](https://img.shields.io/badge/guarded%20by-floe--guard-2f81f7.svg)](https://github.com/Floe-Labs/floe-guard)
 ```
+
+## Examples
+
+All runnable examples live in [`examples/`](examples/). Use `python examples/<file>` from the repo root.
+
+| Example | Description | Extra | API key / network |
+|---|---|---|---|
+| [`runaway_loop.py`](examples/runaway_loop.py) | The canonical hard-stop demo — a stub loop halted before it crosses $0.10 | none | none |
+| [`streaming_guard.py`](examples/streaming_guard.py) | Pre-flight block on an oversized first call + mid-stream cut-off via `guard_stream()` | none | none |
+| [`budget_aware.py`](examples/budget_aware.py) | Context-aware tapering: agent downshifts to a cheap model when `advisory().near_limit` trips | none | none |
+| [`budget_retry.py`](examples/budget_retry.py) | Budget-aware retry / graceful degradation with `with_budget_retry()` | none | none |
+| [`context_size.py`](examples/context_size.py) | Context size adapts to budget: history trimmed and `max_tokens` capped near the ceiling | none | none |
+| [`plan_complexity.py`](examples/plan_complexity.py) | Plan complexity adapts: optional sub-tasks dropped and reasoning depth reduced near the cap | none | none |
+| [`retrieval_depth.py`](examples/retrieval_depth.py) | RAG `top_k` shrinks in two steps (20→12→5) as budget drains | none | none |
+| [`step_budget.py`](examples/step_budget.py) | Per-step token caps for a sequential loop: one runaway step blocked without stopping the run | none | none |
+| [`tool_budget.py`](examples/tool_budget.py) | Tool spend (Apollo lookups, Exa searches) as a first-class citizen of the same USD ceiling | none | none |
+| [`openai_adapter.py`](examples/openai_adapter.py) | `guarded_completion` against a duck-typed stub — exercises the real pre-flight hard-stop | none | none |
+| [`anthropic_adapter.py`](examples/anthropic_adapter.py) | Anthropic adapter with native prompt-cache pricing (cache write vs. cache read vs. uncached) | none | none |
+| [`langgraph_budget_aware.py`](examples/langgraph_budget_aware.py) | LangGraph `guarded_node` fan-out with an advisory-driven router that tapers before the cap | `pip install floe-guard[langgraph]` | none |
+| [`langchain_groq_example.py`](examples/langchain_groq_example.py) | LangChain callback handler on ChatGroq (Llama-3): call 1 succeeds, call 2 is hard-stopped | `pip install floe-guard[langchain] langchain-groq` | `GROQ_API_KEY` + network |
+| [`voice_turn_budget.py`](examples/voice_turn_budget.py) | Pipecat pipeline with `FloeBudgetGuardProcessor`: multi-turn voice conversation halted mid-run | `pip install floe-guard[pipecat]` | none |
+| [`voice_call_cost_pipecat.py`](examples/voice_call_cost_pipecat.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via Pipecat, priced from the bundled map | `pip install floe-guard[pipecat]` | none |
+| [`voice_call_cost_livekit.py`](examples/voice_call_cost_livekit.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via LiveKit, priced from the bundled map | `pip install floe-guard[livekit]` | none |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **The spend meter and budget gate for AI agents.** Hard-stops the next LLM call,
 voice turn, or tool invocation *before* it crosses your USD ceiling — a runaway loop
-dies at $0.10 instead of $4,000. In-process, no account, no signup, **no telemetry**.
+dies at $0.10 instead of $4,000. In-process, no account, no signup, **no telemetry by default**.
 
 **Python** (`pip install floe-guard`): plain `check()` / `record()` or adapters for
 [OpenAI](#openai) · [Anthropic](#anthropic) · [Gemini](#google-gemini) · [CrewAI](#crewai) ·
@@ -716,7 +716,9 @@ adv = guard.advisory()
 # BudgetAdvisory(near_limit=False, used_bps=125, remaining_usd=0.0987, ...)
 model = "gpt-4o-mini" if adv.near_limit else "gpt-4o"        # downshift near the cap
 
-guard.check()                  # still the hard line — taper or not, this holds
+# On the very first call, check() has no historical usage to predict cost with.
+# To ensure the ceiling is enforced on the first run, pass an estimated cost:
+guard.check(estimated_cost=0.01)  # still the hard line — taper or not, this holds
 response = call_your_llm(model)
 guard.record(model, response.usage.prompt_tokens, response.usage.completion_tokens)
 ```
@@ -780,8 +782,11 @@ The taper logic you just wrote carries over to hosted — the same near-limit
 signal (`near_limit` + `used_bps`), answered across *every* vendor and cap; the
 hosted `X-Floe-Budget-Advisory` header nests it under `tightest` with raw-integer
 amounts, so field access is a light remap. See
-[One line to hosted](#one-line-to-hosted). The TS package exposes the identical
-`guard.advisory()`.
+[One line to hosted](#one-line-to-hosted). The TypeScript package exposes
+`guard.advisory()`, mapping fields from Python's `snake_case` (e.g., `near_limit`,
+`used_bps`, `remaining_usd`) to TypeScript's `camelCase` (`nearLimit`, `usedBps`,
+`remainingUsd`), with newer TypeScript fields marked as optional. The JSONL schema and
+behavior produced by `exportLog()` match Python's `export_log()` exactly.
 
 ## Per-call spend log
 
@@ -819,8 +824,12 @@ than the LLM path, because the price is known *before* the call:
 ```python
 # pre-call hard-stop — the crossing call NEVER runs
 handle = guard.reserve_tool(0.02)              # raises BudgetExceeded before Apollo
-result = apollo.people_lookup(...)
-guard.settle_tool("apollo.people_lookup", 0.02, reserved=handle)
+try:
+    result = apollo.people_lookup(...)
+    guard.settle_tool("apollo.people_lookup", 0.02, reserved=handle)
+except Exception:
+    guard.release(handle)                      # free the reservation if the call fails
+    raise
 
 guard.record_tool("exa.search", 0.004)         # post-hoc, for metered APIs
 
@@ -933,6 +942,12 @@ that alone would cross the cap blocks pre-flight:
 ```python
 est = guard.estimate_call("gpt-4o", prompt_tokens=12_000, max_completion_tokens=4_096)
 handle = guard.reserve(est)   # raises BudgetExceeded NOW if this call can't fit
+try:
+    response = call_your_llm(model="gpt-4o", ...)
+    guard.settle("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens, reserved=handle)
+except Exception:
+    guard.release(handle)      # free the reservation if the call fails
+    raise
 ```
 
 The LiteLLM adapter does this automatically (prompt tokens via
@@ -948,17 +963,23 @@ stream off **mid-generation**, settling the tokens actually consumed instead of
 recording a big overshoot after the fact:
 
 ```python
-from floe_guard import guard_stream
+from floe_guard import StreamGuard
 
-for chunk in guard_stream(guard, "gpt-4o", stream, prompt_tokens=1_000):
-    print(chunk, end="")   # raises BudgetExceeded mid-stream at the ceiling
+# The context manager guarantees the reservation is settled or released:
+handle = guard.reserve(guard.estimate_call("gpt-4o", prompt_tokens=1_000, max_tokens=100))
+with StreamGuard(guard, "gpt-4o", prompt_tokens=1_000, reserved=handle) as sg:
+    for chunk in stream:
+        sg.feed_text(chunk.text)                       # raises BudgetExceeded mid-stream
+        consume(chunk)
+    sg.finish(completion_tokens=reported_usage_tokens) # reconcile to real usage
 ```
 
+> [!NOTE]
+> A generator wrapper `guard_stream(guard, ...)` is also available for automated reservation settling/releasing on stream termination, but does not support post-hoc usage reconciliation via `finish()`.
+
 Chunk sizes are estimated at ~4 chars/token (pass `count_tokens=` for a real
-tokenizer); the final accrual reconciles to provider-reported usage via
-`StreamGuard.finish(...)`. See
-[`examples/streaming_guard.py`](examples/streaming_guard.py) for a runnable
-demo (no API key).
+tokenizer). See [`examples/streaming_guard.py`](examples/streaming_guard.py)
+for a runnable demo (no API key).
 
 ## One line to hosted
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-litellm = ["litellm>=1.0"]
-crewai = ["crewai>=0.30", "litellm>=1.0"]
+litellm = ["litellm>=1.91.0"]
+crewai = ["crewai>=0.30", "litellm>=1.91.0"]
 langchain = ["langchain-core>=0.3"]
 langgraph = ["langgraph>=1.0"]
 openai = ["openai>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.20.0"
+version = "0.20.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 # core-metadata to `Metadata-Version: 2.5`, which the pinned
 # pypa/gh-action-pypi-publish@v1.14.0 (twine 6.1.0 + packaging 25.0) rejects
 # with "InvalidDistribution: '2.5' is not a valid metadata version". 1.31.0 is
-# the last release that emits 2.4, which both twine and PyPI accept. This is
-# why PyPI froze at 0.13.0 (Aug 6) while the repo moved to 0.16.x.
+# the last release that emits 2.4, which both twine and PyPI accept. This pin
+# is a historical compatibility guard for that publisher action; raise it only
+# after verifying the CI publisher handles Metadata-Version 2.5 cleanly.
 [build-system]
 requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -1,4 +1,5 @@
 """LiteLLM adapter (optional extra: ``pip install floe-guard[litellm]``).
+Requires ``litellm >= 1.91.0``.
 
 Two ways to wire the guard into LiteLLM:
 

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -1,5 +1,4 @@
 """LiteLLM adapter (optional extra: ``pip install floe-guard[litellm]``).
-Requires ``litellm >= 1.91.0``.
 
 Two ways to wire the guard into LiteLLM:
 


### PR DESCRIPTION
## Summary
Declutters and restructures the root README to improve readability, adds a central Examples index linking all 16 example scripts, corrects outdated historical references, and bumps the version to pass CI packaging guards.

## Changes
- **Version Bump**:
  - Bumped the Python package version to `0.18.2` in [pyproject.toml](file:///d:/13.current-startups/2.floe-guard/floe-guard/pyproject.toml) to satisfy the repository's contribution version guard on metadata edits.
- **CHANGELOG**:
  - Updated the `Unreleased` header to track `py 0.18.2 / js 0.14.0`.
  - Added a `### Documentation (py)` section summarizing the README improvements.
- **README Restructure**:
  - Compressed the long introductory wall-of-text into a clean, platform-specific overview.
  - Removed the redundant "What's inside" section (since the adapter matrix already serves this purpose).
  - Reordered sections so motivation ("Why floe-guard?") and core mechanics ("How it works") immediately follow the quickstart demos.
  - Pushed the hosted upgrade path ("One line to hosted") further down to prioritize the local setup first.
  - Added a central **Examples** index table mapping all 16 `examples/*.py` scripts (including the previously orphaned `langchain_groq_example.py` with its dependency and API key requirements).
  - Explicitly annotated Pipecat example references (`voice_turn_budget.py` and `voice_call_cost_pipecat.py`) with their required `pip install floe-guard[pipecat]` extras.
- **pyproject.toml Comment**:
  - Rewrote the stale comment referencing frozen historical versions (`0.13.0` / `0.16.x`), reframing it as a forward-compatible compatibility guard for `pypa/gh-action-pypi-publish@v1.14.0`.

## Testing
- [x] `pytest` passes (Python changes)
- [x] `ruff check .` and `ruff format .` are clean (Python changes)
- [ ] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)

## Related issues
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and streamlined the README with clearer product positioning and expanded adapter coverage.
  * Added guidance for retries, spend tracking, tool and token budgets, latency limits, request estimates, and streaming enforcement.
  * Added a complete index of runnable examples and clarified setup requirements.
  * Reorganized workflow and hosted-upgrade information for easier navigation.

* **Chores**
  * Updated the Python package version to 0.18.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->