### PR TITLE
feat: FloeCost — the per-turn receipt contract (py 0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 - **`FloeCost` — the per-turn receipt contract, plus `turn_cost()`.** One shape
   for cost whether it's a local estimate (`source="estimate"`, priced from the
   bundled cost map — free, offline, no account) or hosted server-truth
-  (`source="hosted"`), with an optional `remaining_usd` filled from
-  `hosted_remaining_usd()` when a Floe key is present. `turn_cost(model,
-  prompt_tokens, completion_tokens)` returns a `FloeCost` (or `None`, fail-closed,
-  for an unpriceable model); `FloeCost.format()` renders a one-line receipt.
-  Adapters emit it once per turn so a developer sees what a call cost with no
-  extra config — and graduating to hosted is a key swap, not a re-integration
-  (identical shape). TS parity pending.
+  (`source="hosted"`); `source` is validated to one of those two. `turn_cost(model,
+  prompt_tokens, completion_tokens, remaining_usd=?)` returns a `FloeCost` priced
+  locally (or `None`, fail-closed, for an unpriceable model) — it never calls the
+  network, so the caller passes `remaining_usd` themselves (e.g. the result of
+  `hosted_remaining_usd()`, a hosted read) to show budget. `FloeCost.format()`
+  renders a one-line receipt (sub-$0.0001 costs get 6 decimals, not a misleading
+  `$0.0000`). Intended for adapters to emit once per turn; graduating to hosted is
+  a key swap, not a re-integration (identical shape). Adapter wiring and TS parity
+  land separately.
 
 ### Fixed (js)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.18.1 / js 0.14.0
+## Unreleased — py 0.19.0 / js 0.14.0
+
+### Added (py)
+
+- **`FloeCost` — the per-turn receipt contract, plus `turn_cost()`.** One shape
+  for cost whether it's a local estimate (`source="estimate"`, priced from the
+  bundled cost map — free, offline, no account) or hosted server-truth
+  (`source="hosted"`), with an optional `remaining_usd` filled from
+  `hosted_remaining_usd()` when a Floe key is present. `turn_cost(model,
+  prompt_tokens, completion_tokens)` returns a `FloeCost` (or `None`, fail-closed,
+  for an unpriceable model); `FloeCost.format()` renders a one-line receipt.
+  Adapters emit it once per turn so a developer sees what a call cost with no
+  extra config — and graduating to hosted is a key swap, not a re-integration
+  (identical shape). TS parity pending.
 
 ### Fixed (js)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.18.1"
+version = "0.19.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__init__.py
+++ b/src/floe_guard/__init__.py
@@ -46,6 +46,7 @@ from .pricing import (
     price_tokens,
     resolve_price,
 )
+from .receipt import FloeCost, turn_cost
 from .retry import RetryPlan, async_with_budget_retry, with_budget_retry
 from .store import SqliteStore, StateStore
 from .stream import StreamGuard, guard_stream
@@ -94,6 +95,8 @@ __all__ = [
     "cost_map_generated_at",
     "price_tokens",
     "resolve_price",
+    "FloeCost",
+    "turn_cost",
     "VoiceRate",
     "lookup_voice_rate",
     "resolve_voice_rate",

--- a/src/floe_guard/receipt.py
+++ b/src/floe_guard/receipt.py
@@ -39,10 +39,22 @@ class FloeCost:
     model: str | None = None
     remaining_usd: float | None = None
 
+    def __post_init__(self) -> None:
+        if self.source not in (SOURCE_ESTIMATE, SOURCE_HOSTED):
+            raise ValueError(
+                f"FloeCost.source must be {SOURCE_ESTIMATE!r} or {SOURCE_HOSTED!r}, "
+                f"got {self.source!r} — the estimate/hosted distinction is the honesty contract."
+            )
+
     def format(self) -> str:
-        """A one-line receipt, e.g. ``floe · gpt-4o · $0.0075 est · left $12.34``."""
+        """A one-line receipt, e.g. ``floe · gpt-4o · $0.0075 est · left $12.34``.
+
+        Per-call costs are often fractions of a cent, so sub-$0.0001 amounts get
+        6 decimals instead of rounding to a misleading ``$0.0000``.
+        """
         tag = "est" if self.source == SOURCE_ESTIMATE else "floe"
-        line = f"floe · {self.model or '?'} · ${self.usd:.4f} {tag}"
+        amount = f"${self.usd:.4f}" if round(self.usd, 4) != 0 else f"${self.usd:.6f}"
+        line = f"floe · {self.model or '?'} · {amount} {tag}"
         if self.remaining_usd is not None:
             line += f" · left ${self.remaining_usd:,.2f}"
         return line
@@ -56,12 +68,16 @@ def turn_cost(
     remaining_usd: float | None = None,
     overrides: dict[str, ManualPrice] | None = None,
 ) -> FloeCost | None:
-    """Per-turn receipt from token usage, priced by the bundled cost map.
+    """Per-turn receipt from token usage, priced locally by the cost map.
 
-    Returns ``None`` if the model cannot be priced — fail closed, never a
-    fabricated ``$0``. ``source`` is always ``"estimate"`` here; pass
-    ``remaining_usd`` (from :func:`~floe_guard.hosted_remaining_usd`, at whatever
-    cadence you like) to show budget without a network call every turn.
+    ``overrides`` (when given) are consulted before the bundled cost map, same as
+    :func:`~floe_guard.resolve_price`. Returns ``None`` if the model cannot be
+    priced — fail closed, never a fabricated ``$0``. ``source`` is always
+    ``"estimate"`` (this prices locally); to show remaining budget, pass
+    ``remaining_usd`` yourself — e.g. the result of
+    :func:`~floe_guard.hosted_remaining_usd` (a hosted read that needs a Floe
+    key), fetched at whatever cadence you like so there's no network call every
+    turn. ``turn_cost`` never calls the network.
     """
     priced = resolve_price(model, overrides)
     if priced is None:

--- a/src/floe_guard/receipt.py
+++ b/src/floe_guard/receipt.py
@@ -53,7 +53,7 @@ class FloeCost:
         6 decimals instead of rounding to a misleading ``$0.0000``.
         """
         tag = "est" if self.source == SOURCE_ESTIMATE else "floe"
-        amount = f"${self.usd:.4f}" if round(self.usd, 4) != 0 else f"${self.usd:.6f}"
+        amount = f"${self.usd:.6f}" if abs(self.usd) < 0.0001 else f"${self.usd:.4f}"
         line = f"floe · {self.model or '?'} · {amount} {tag}"
         if self.remaining_usd is not None:
             line += f" · left ${self.remaining_usd:,.2f}"

--- a/src/floe_guard/receipt.py
+++ b/src/floe_guard/receipt.py
@@ -1,0 +1,70 @@
+"""The per-turn receipt — one shape, local estimate or hosted truth.
+
+``FloeCost`` is the byte-for-byte contract the local meter and hosted Floe both
+speak, so graduating from free-local to hosted is a **key swap, not a
+re-integration**: the same object appears whether ``usd`` came from the bundled
+cost map (``source="estimate"``) or from hosted server-truth
+(``source="hosted"``), and ``remaining_usd`` is filled from hosted Floe when a
+key is present. Adapters (Pipecat, LiveKit, …) emit this once per turn so a
+developer sees *what that call cost* with no extra config — the receipt moment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pricing import ManualPrice, price_tokens, resolve_price
+
+# The two honest provenances of a cost figure. "estimate" is priced locally from
+# the bundled cost map (free, offline, no account); "hosted" is Floe's
+# server-truth. Never label an estimate as hosted — accuracy is the whole point.
+SOURCE_ESTIMATE = "estimate"
+SOURCE_HOSTED = "hosted"
+
+
+@dataclass(frozen=True)
+class FloeCost:
+    """One turn's receipt: what it cost, and what's left.
+
+    Attributes:
+        usd: cost of this turn, in USD.
+        source: ``"estimate"`` (local cost map) or ``"hosted"`` (server-truth).
+        model: the model the cost is for, when known.
+        remaining_usd: account budget remaining (hosted), or ``None`` when no
+            Floe key is present — the local, keyless path still shows cost.
+    """
+
+    usd: float
+    source: str
+    model: str | None = None
+    remaining_usd: float | None = None
+
+    def format(self) -> str:
+        """A one-line receipt, e.g. ``floe · gpt-4o · $0.0075 est · left $12.34``."""
+        tag = "est" if self.source == SOURCE_ESTIMATE else "floe"
+        line = f"floe · {self.model or '?'} · ${self.usd:.4f} {tag}"
+        if self.remaining_usd is not None:
+            line += f" · left ${self.remaining_usd:,.2f}"
+        return line
+
+
+def turn_cost(
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    *,
+    remaining_usd: float | None = None,
+    overrides: dict[str, ManualPrice] | None = None,
+) -> FloeCost | None:
+    """Per-turn receipt from token usage, priced by the bundled cost map.
+
+    Returns ``None`` if the model cannot be priced — fail closed, never a
+    fabricated ``$0``. ``source`` is always ``"estimate"`` here; pass
+    ``remaining_usd`` (from :func:`~floe_guard.hosted_remaining_usd`, at whatever
+    cadence you like) to show budget without a network call every turn.
+    """
+    priced = resolve_price(model, overrides)
+    if priced is None:
+        return None
+    usd = price_tokens(priced, prompt_tokens, completion_tokens)
+    return FloeCost(usd=usd, source=SOURCE_ESTIMATE, model=model, remaining_usd=remaining_usd)

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,43 @@
+"""The per-turn receipt contract (``FloeCost`` / ``turn_cost``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import FloeCost, turn_cost
+
+
+def test_turn_cost_prices_known_model() -> None:
+    cost = turn_cost("gpt-4o", 1000, 500)
+    assert cost is not None
+    assert cost.usd == pytest.approx(0.0075)  # 1000*2.5e-6 + 500*1e-5
+    assert cost.source == "estimate"
+    assert cost.model == "gpt-4o"
+    assert cost.remaining_usd is None
+
+
+def test_turn_cost_fails_closed_on_unpriceable() -> None:
+    assert turn_cost("no-such-model-anywhere", 1000, 500) is None
+
+
+def test_turn_cost_carries_remaining_budget() -> None:
+    cost = turn_cost("gpt-4o", 1000, 500, remaining_usd=12.34)
+    assert cost is not None
+    assert cost.remaining_usd == 12.34
+
+
+def test_format_estimate_only() -> None:
+    line = FloeCost(usd=0.0075, source="estimate", model="gpt-4o").format()
+    assert line == "floe · gpt-4o · $0.0075 est"
+
+
+def test_format_with_budget() -> None:
+    line = FloeCost(usd=0.0075, source="hosted", model="gpt-4o", remaining_usd=12.34).format()
+    assert line == "floe · gpt-4o · $0.0075 floe · left $12.34"
+
+
+def test_floecost_shape_is_identical_local_and_hosted() -> None:
+    # The contract's whole point: same fields whether estimated or hosted.
+    est = FloeCost(usd=0.01, source="estimate", model="m", remaining_usd=None)
+    hosted = FloeCost(usd=0.01, source="hosted", model="m", remaining_usd=5.0)
+    assert est.__dataclass_fields__.keys() == hosted.__dataclass_fields__.keys()

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -36,8 +36,19 @@ def test_format_with_budget() -> None:
     assert line == "floe · gpt-4o · $0.0075 floe · left $12.34"
 
 
-def test_floecost_shape_is_identical_local_and_hosted() -> None:
-    # The contract's whole point: same fields whether estimated or hosted.
-    est = FloeCost(usd=0.01, source="estimate", model="m", remaining_usd=None)
-    hosted = FloeCost(usd=0.01, source="hosted", model="m", remaining_usd=5.0)
-    assert est.__dataclass_fields__.keys() == hosted.__dataclass_fields__.keys()
+def test_format_micro_cost_does_not_round_to_zero() -> None:
+    # A real gpt-4o-mini short turn (~$0.000008) must not render as a misleading $0.0000.
+    line = FloeCost(usd=8e-6, source="estimate", model="gpt-4o-mini").format()
+    assert line == "floe · gpt-4o-mini · $0.000008 est"
+
+
+def test_source_must_be_estimate_or_hosted() -> None:
+    with pytest.raises(ValueError, match="honesty contract"):
+        FloeCost(usd=0.01, source="other", model="m")
+
+
+def test_turn_cost_returns_the_public_floecost_schema() -> None:
+    cost = turn_cost("gpt-4o", 1000, 500)
+    assert isinstance(cost, FloeCost)
+    # The byte-for-byte contract both local and hosted must speak.
+    assert tuple(cost.__dataclass_fields__) == ("usd", "source", "model", "remaining_usd")

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -42,6 +42,16 @@ def test_format_micro_cost_does_not_round_to_zero() -> None:
     assert line == "floe · gpt-4o-mini · $0.000008 est"
 
 
+def test_format_micro_cost_below_threshold_keeps_precision() -> None:
+    # Just under $0.0001 must keep 6 decimals, not round up to $0.0001.
+    assert FloeCost(usd=0.000099, source="estimate", model="m").format().endswith("$0.000099 est")
+
+
+def test_format_at_threshold_uses_four_decimals() -> None:
+    # At $0.0001 exactly, drop to the compact 4-decimal form.
+    assert FloeCost(usd=0.0001, source="estimate", model="m").format().endswith("$0.0001 est")
+
+
 def test_source_must_be_estimate_or_hosted() -> None:
     with pytest.raises(ValueError, match="honesty contract"):
         FloeCost(usd=0.01, source="other", model="m")


### PR DESCRIPTION
## What

Adds `FloeCost` — the one shape a call's cost takes whether it's a **local estimate** (priced from the bundled cost map — free, offline, no account) or **hosted server-truth**, plus `turn_cost(...)` to build it from token usage. This is the receipt-moment contract adapters emit once per turn, and it's deliberately **identical local vs hosted** so graduating to hosted Floe is a key swap, not a re-integration.

```python
from floe_guard import turn_cost, hosted_remaining_usd, hosted_enforcement_available

remaining = hosted_remaining_usd() if hosted_enforcement_available() else None
cost = turn_cost("gpt-4o", prompt_tokens=1200, completion_tokens=340, remaining_usd=remaining)
print(cost.format())   # floe · gpt-4o · $0.0064 est · left $12.34   (keyless: just the cost)
```

## Why this shape

- **Cost is the free/local hook**, budget is the hosted hook. `usd` is priced locally (works with no Floe account, BYOK-agnostic); `remaining_usd` is filled from `hosted_remaining_usd()` only when a Floe key is present — so the receipt shows the graduation value inline without coupling the cost figure to hosted.
- **`source` keeps it honest.** `"estimate"` vs `"hosted"` is always on the object; an estimate is never labelled as what Floe charged.
- **Fail closed.** `turn_cost` returns `None` for an unpriceable model — never a fabricated `$0`.
- `remaining_usd` is caller-supplied so the receipt can show budget without a network call every turn (fetch it at whatever cadence you like).

## Next

The Pipecat and LiveKit adapters will emit `FloeCost` per turn (zero-config receipt line) against this contract. TS parity (`floe-guard` npm) to follow.

## Tests
`tests/test_receipt.py`: pricing, fail-closed, budget passthrough, `format()`, and that the estimate/hosted shapes are identical. Full suite green (439).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cost receipts for tracking token usage, pricing source, model, and optional remaining budget.
  - Added local cost estimation with support for custom model pricing.
  - Added formatted, one-line receipt output for clearer cost reporting.
  - Unknown or unpriceable models now fail safely without producing misleading costs.
  - Made cost receipts and pricing tools available through the public Python package interface.

- **Documentation**
  - Documented the new pricing and receipt capabilities in the unreleased 0.19.0 changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->