### PR TITLE
feat: cache-aware token pricing (py 0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.20.0 / js 0.15.0
+
+### Added (py)
+
+- **Cache-aware token pricing, driven by per-model cost-map rates.** The bundled
+  cost map now carries each model's published `cache_read_input_token_cost` /
+  `cache_creation_input_token_cost` (added surgically — existing prices are
+  unchanged). `price_tokens` prices cache-read and cache-creation at the model's
+  own rate when present, so caching is correct **per provider** (Anthropic reads
+  at ~0.1x its input rate, OpenAI at ~0.5x) instead of the old hardcoded
+  Anthropic 0.1x for everyone; a model with no published cache rate falls back to
+  the conservative multiplier as before. `turn_cost(...)` accepts
+  `prompt_cached_tokens` (the subset of `prompt_tokens` served from cache): that
+  subset is priced at the cache-read rate rather than the full input rate, fixing
+  a systematic overcharge whenever prompt caching was on.
+
+### Changed (js)
+
+- **Bundled cost map now carries per-model cache rates.** The shared cost-map
+  snapshot gained `cache_read_input_token_cost` / `cache_creation_input_token_cost`
+  per model (byte-identical across the py/js copies). The TS `pricing.ts` does not
+  consume them yet — cache-aware TS pricing is a documented parity follow-up; this
+  data change is inert for existing js behavior.
+
 ## Unreleased — py 0.19.0 / js 0.14.0
 
 ### Added (py)

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -13,157 +13,209 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-3-haiku-20240307": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8,
+    "cache_creation_input_token_cost": 3e-7
   },
   "claude-3-opus-20240229": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-4-opus-20250514": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-4-sonnet-20250514": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-fable-5": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-haiku-4-5": {
     "input_cost_per_token": 0.000001,
     "output_cost_per_token": 0.000005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7,
+    "cache_creation_input_token_cost": 0.00000125
   },
   "claude-haiku-4-5-20251001": {
     "input_cost_per_token": 0.000001,
     "output_cost_per_token": 0.000005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7,
+    "cache_creation_input_token_cost": 0.00000125
   },
   "claude-mythos-5": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-mythos-preview": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-opus-4-1": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-1-20250805": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-20250514": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-5-20251101": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-6": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-6-20260205": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-7": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-7-20260416": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-8": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-sonnet-4-20250514": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-5": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-5-20250929": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-6": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-5": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7,
+    "cache_creation_input_token_cost": 0.0000025
   },
   "ft:gpt-3.5-turbo": {
     "input_cost_per_token": 0.000003,
@@ -199,67 +251,78 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-7
   },
   "ft:gpt-4.1-mini-2025-04-14": {
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.0000032,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "ft:gpt-4.1-nano-2025-04-14": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 8e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-8
   },
   "ft:gpt-4o-2024-08-06": {
     "input_cost_per_token": 0.00000375,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001875
   },
   "ft:gpt-4o-2024-11-20": {
     "input_cost_per_token": 0.00000375,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_creation_input_token_cost": 0.000001875
   },
   "ft:gpt-4o-mini-2024-07-18": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "ft:o4-mini-2025-04-16": {
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001
   },
   "gemini-2.0-flash": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-2.0-flash-001": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.75e-8
   },
   "gemini-2.0-flash-lite": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.875e-8
   },
   "gemini-2.0-flash-lite-001": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.875e-8
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "input_cost_per_token": 0.00000125,
@@ -271,25 +334,29 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-2.5-flash-lite": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-8
   },
   "gemini-2.5-flash-lite-preview-06-17": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-2.5-flash-lite-preview-09-2025": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-8
   },
   "gemini-2.5-flash-native-audio-latest": {
     "input_cost_per_token": 3e-7,
@@ -313,43 +380,50 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-2.5-pro": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-2.5-pro-preview-tts": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-3-flash-preview": {
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.000003,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-8
   },
   "gemini-3-pro-preview": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.1-flash-lite": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.0000015,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-3.1-flash-lite-preview": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.0000015,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-3.1-flash-live-preview": {
     "input_cost_per_token": 7.5e-7,
@@ -361,37 +435,43 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.1-pro-preview-customtools": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.5-flash": {
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.000009,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "gemini-3.5-flash-lite": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-3.6-flash": {
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.0000075,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "gemini-3.7-flash": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.00000375,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-embedding-001": {
     "input_cost_per_token": 1.5e-7,
@@ -415,19 +495,22 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-flash-latest": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-flash-lite-latest": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-gemma-2-27b-it": {
     "input_cost_per_token": 3.5e-7,
@@ -451,7 +534,8 @@
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-robotics-er-1.5-preview": {
     "input_cost_per_token": 3e-7,
@@ -469,7 +553,8 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-robotics-er-2-streaming-preview": {
     "input_cost_per_token": 0.000002,
@@ -553,43 +638,50 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-4.1-2025-04-14": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-4.1-mini": {
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.0000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7
   },
   "gpt-4.1-mini-2025-04-14": {
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.0000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7
   },
   "gpt-4.1-nano": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-4.1-nano-2025-04-14": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-4o": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-2024-05-13": {
     "input_cost_per_token": 0.000005,
@@ -601,13 +693,15 @@
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-2024-11-20": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-audio-preview": {
     "input_cost_per_token": 0.0000025,
@@ -631,13 +725,15 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-2024-07-18": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-audio-preview": {
     "input_cost_per_token": 1.5e-7,
@@ -655,199 +751,236 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-search-preview": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-search-preview-2025-03-11": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-5": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-2025-08-07": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-chat": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-chat-latest": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-mini": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.000002,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-5-mini-2025-08-07": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.000002,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-5-nano": {
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-9
   },
   "gpt-5-nano-2025-08-07": {
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-9
   },
   "gpt-5-search-api": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-search-api-2025-10-14": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1-2025-11-13": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1-chat-latest": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.2": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.2-2025-12-11": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.2-chat-latest": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.3-chat-latest": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.4": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-7
   },
   "gpt-5.4-2026-03-05": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-7
   },
   "gpt-5.4-mini": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.0000045,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-5.4-mini-2026-03-17": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.0000045,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-5.4-nano": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8
   },
   "gpt-5.4-nano-2026-03-17": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8
   },
   "gpt-5.5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-5.5-2026-04-23": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-5.6": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "gpt-5.6-luna": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.0000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8,
+    "cache_creation_input_token_cost": 2.5e-7
   },
   "gpt-5.6-sol": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "gpt-5.6-terra": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7,
+    "cache_creation_input_token_cost": 0.0000025
   },
   "gpt-audio": {
     "input_cost_per_token": 0.0000025,
@@ -907,67 +1040,78 @@
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00006,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000075
   },
   "o1-2024-12-17": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00006,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000075
   },
   "o3": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "o3-2025-04-16": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "o3-mini": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5.5e-7
   },
   "o3-mini-2025-01-31": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5.5e-7
   },
   "o4-mini": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.75e-7
   },
   "o4-mini-2025-04-16": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.75e-7
   },
   "openai/gpt-oss-120b": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "openai/gpt-oss-20b": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.75e-8
   },
   "openai/gpt-oss-safeguard-20b": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.7e-8
   },
   "qwen/qwen3-32b": {
     "input_cost_per_token": 2.9e-7,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.19.0"
+version = "0.20.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -326,6 +326,22 @@ for (const [k, v] of entries) {
     litellm_provider: v.litellm_provider,
     mode: v.mode,
   };
+  // Per-model prompt-cache rates, when upstream publishes them and they are
+  // finite and positive (mirrors the input/output finiteness handling). Kept
+  // optional so a model with no published cache rate simply omits them, and
+  // pricing falls back to the conservative per-provider multiplier.
+  if (
+    Number.isFinite(v.cache_read_input_token_cost) &&
+    v.cache_read_input_token_cost > 0
+  ) {
+    entry.cache_read_input_token_cost = v.cache_read_input_token_cost;
+  }
+  if (
+    Number.isFinite(v.cache_creation_input_token_cost) &&
+    v.cache_creation_input_token_cost > 0
+  ) {
+    entry.cache_creation_input_token_cost = v.cache_creation_input_token_cost;
+  }
   const existing = out[k];
   if (existing === undefined) {
     out[k] = entry;
@@ -356,6 +372,19 @@ for (const [k, v] of entries) {
     // and must not keep a mode that reads as "output is free".
     mode: output_cost_per_token === 0 ? "embedding" : "chat",
   };
+  // Merge cache rates toward the dearer rate too (Math.max), matching the
+  // under-metering-averse merge above. A rate present on only one side wins as-is;
+  // absent on both, the field stays omitted.
+  const cacheRead = Math.max(
+    existing.cache_read_input_token_cost ?? -Infinity,
+    entry.cache_read_input_token_cost ?? -Infinity,
+  );
+  if (Number.isFinite(cacheRead)) merged.cache_read_input_token_cost = cacheRead;
+  const cacheCreation = Math.max(
+    existing.cache_creation_input_token_cost ?? -Infinity,
+    entry.cache_creation_input_token_cost ?? -Infinity,
+  );
+  if (Number.isFinite(cacheCreation)) merged.cache_creation_input_token_cost = cacheCreation;
   out[k] = merged;
   console.warn(
     `NOTE: ${k} is listed more than once upstream — kept the dearer rate in each ` +

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -329,7 +329,8 @@ for (const [k, v] of entries) {
   // Per-model prompt-cache rates, when upstream publishes them and they are
   // finite and positive (mirrors the input/output finiteness handling). Kept
   // optional so a model with no published cache rate simply omits them, and
-  // pricing falls back to the conservative per-provider multiplier.
+  // pricing falls back to a single conservative multiplier (currently Anthropic's
+  // ~0.1x read ratio, applied to all providers) — see _CACHE_READ_MULTIPLIER.
   if (
     Number.isFinite(v.cache_read_input_token_cost) &&
     v.cache_read_input_token_cost > 0

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -13,157 +13,209 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-3-haiku-20240307": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8,
+    "cache_creation_input_token_cost": 3e-7
   },
   "claude-3-opus-20240229": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-4-opus-20250514": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-4-sonnet-20250514": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-fable-5": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-haiku-4-5": {
     "input_cost_per_token": 0.000001,
     "output_cost_per_token": 0.000005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7,
+    "cache_creation_input_token_cost": 0.00000125
   },
   "claude-haiku-4-5-20251001": {
     "input_cost_per_token": 0.000001,
     "output_cost_per_token": 0.000005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7,
+    "cache_creation_input_token_cost": 0.00000125
   },
   "claude-mythos-5": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-mythos-preview": {
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00005,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001,
+    "cache_creation_input_token_cost": 0.0000125
   },
   "claude-opus-4-1": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-1-20250805": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-20250514": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000015,
+    "cache_creation_input_token_cost": 0.00001875
   },
   "claude-opus-4-5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-5-20251101": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-6": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-6-20260205": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-7": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-7-20260416": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-4-8": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-opus-5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "claude-sonnet-4-20250514": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-5": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-5-20250929": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-4-6": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 0.00000375
   },
   "claude-sonnet-5": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "anthropic",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7,
+    "cache_creation_input_token_cost": 0.0000025
   },
   "ft:gpt-3.5-turbo": {
     "input_cost_per_token": 0.000003,
@@ -199,67 +251,78 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-7
   },
   "ft:gpt-4.1-mini-2025-04-14": {
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.0000032,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "ft:gpt-4.1-nano-2025-04-14": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 8e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-8
   },
   "ft:gpt-4o-2024-08-06": {
     "input_cost_per_token": 0.00000375,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001875
   },
   "ft:gpt-4o-2024-11-20": {
     "input_cost_per_token": 0.00000375,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_creation_input_token_cost": 0.000001875
   },
   "ft:gpt-4o-mini-2024-07-18": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "ft:o4-mini-2025-04-16": {
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.000001
   },
   "gemini-2.0-flash": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-2.0-flash-001": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.75e-8
   },
   "gemini-2.0-flash-lite": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.875e-8
   },
   "gemini-2.0-flash-lite-001": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.875e-8
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "input_cost_per_token": 0.00000125,
@@ -271,25 +334,29 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-2.5-flash-lite": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-8
   },
   "gemini-2.5-flash-lite-preview-06-17": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-2.5-flash-lite-preview-09-2025": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-8
   },
   "gemini-2.5-flash-native-audio-latest": {
     "input_cost_per_token": 3e-7,
@@ -313,43 +380,50 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-2.5-pro": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-2.5-pro-preview-tts": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-3-flash-preview": {
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.000003,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-8
   },
   "gemini-3-pro-preview": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.1-flash-lite": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.0000015,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-3.1-flash-lite-preview": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.0000015,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-3.1-flash-live-preview": {
     "input_cost_per_token": 7.5e-7,
@@ -361,37 +435,43 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.1-pro-preview-customtools": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-3.5-flash": {
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.000009,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "gemini-3.5-flash-lite": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-3.6-flash": {
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.0000075,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.5e-7
   },
   "gemini-3.7-flash": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.00000375,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-embedding-001": {
     "input_cost_per_token": 1.5e-7,
@@ -415,19 +495,22 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3e-8
   },
   "gemini-flash-latest": {
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gemini-flash-lite-latest": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gemini-gemma-2-27b-it": {
     "input_cost_per_token": 3.5e-7,
@@ -451,7 +534,8 @@
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gemini-robotics-er-1.5-preview": {
     "input_cost_per_token": 3e-7,
@@ -469,7 +553,8 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "gemini",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7
   },
   "gemini-robotics-er-2-streaming-preview": {
     "input_cost_per_token": 0.000002,
@@ -553,43 +638,50 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-4.1-2025-04-14": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-4.1-mini": {
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.0000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7
   },
   "gpt-4.1-mini-2025-04-14": {
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.0000016,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1e-7
   },
   "gpt-4.1-nano": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-4.1-nano-2025-04-14": {
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-4o": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-2024-05-13": {
     "input_cost_per_token": 0.000005,
@@ -601,13 +693,15 @@
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-2024-11-20": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-audio-preview": {
     "input_cost_per_token": 0.0000025,
@@ -631,13 +725,15 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-2024-07-18": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-audio-preview": {
     "input_cost_per_token": 1.5e-7,
@@ -655,199 +751,236 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-mini-search-preview-2025-03-11": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-4o-search-preview": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-4o-search-preview-2025-03-11": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.00000125
   },
   "gpt-5": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-2025-08-07": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-chat": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-chat-latest": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-mini": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.000002,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-5-mini-2025-08-07": {
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.000002,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-8
   },
   "gpt-5-nano": {
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-9
   },
   "gpt-5-nano-2025-08-07": {
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 4e-7,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-9
   },
   "gpt-5-search-api": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5-search-api-2025-10-14": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1-2025-11-13": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.1-chat-latest": {
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.25e-7
   },
   "gpt-5.2": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.2-2025-12-11": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.2-chat-latest": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.3-chat-latest": {
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 1.75e-7
   },
   "gpt-5.4": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-7
   },
   "gpt-5.4-2026-03-05": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.000015,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.5e-7
   },
   "gpt-5.4-mini": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.0000045,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-5.4-mini-2026-03-17": {
     "input_cost_per_token": 7.5e-7,
     "output_cost_per_token": 0.0000045,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "gpt-5.4-nano": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8
   },
   "gpt-5.4-nano-2026-03-17": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.00000125,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8
   },
   "gpt-5.5": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-5.5-2026-04-23": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "gpt-5.6": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "gpt-5.6-luna": {
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 0.0000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-8,
+    "cache_creation_input_token_cost": 2.5e-7
   },
   "gpt-5.6-sol": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00003,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7,
+    "cache_creation_input_token_cost": 0.00000625
   },
   "gpt-5.6-terra": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000012,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2e-7,
+    "cache_creation_input_token_cost": 0.0000025
   },
   "gpt-audio": {
     "input_cost_per_token": 0.0000025,
@@ -907,67 +1040,78 @@
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00006,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000075
   },
   "o1-2024-12-17": {
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00006,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 0.0000075
   },
   "o3": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "o3-2025-04-16": {
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5e-7
   },
   "o3-mini": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5.5e-7
   },
   "o3-mini-2025-01-31": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 5.5e-7
   },
   "o4-mini": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.75e-7
   },
   "o4-mini-2025-04-16": {
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "litellm_provider": "openai",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 2.75e-7
   },
   "openai/gpt-oss-120b": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 7.5e-8
   },
   "openai/gpt-oss-20b": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.75e-8
   },
   "openai/gpt-oss-safeguard-20b": {
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "litellm_provider": "groq",
-    "mode": "chat"
+    "mode": "chat",
+    "cache_read_input_token_cost": 3.7e-8
   },
   "qwen/qwen3-32b": {
     "input_cost_per_token": 2.9e-7,

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -31,11 +31,20 @@ class ManualPrice:
 
 @dataclass(frozen=True)
 class PricedModel:
-    """A resolved per-token price plus where it came from."""
+    """A resolved per-token price plus where it came from.
+
+    ``cache_read_cost_per_token`` / ``cache_creation_cost_per_token`` are the
+    model's published prompt-cache rates (from the cost map), or ``None`` when the
+    map has none — in which case :func:`price_tokens` falls back to a conservative
+    per-provider multiplier of the base input rate. Override-sourced prices leave
+    them ``None`` (an override carries only base input/output).
+    """
 
     input_cost_per_token: float
     output_cost_per_token: float
     source: str  # "override" | "cost_map"
+    cache_read_cost_per_token: float | None = None
+    cache_creation_cost_per_token: float | None = None
 
 
 def _load_cost_map() -> dict[str, Any]:
@@ -169,6 +178,10 @@ def resolve_price(
                 input_cost_per_token=float(input_cost),
                 output_cost_per_token=float(output_cost),
                 source="cost_map",
+                cache_read_cost_per_token=_finite_or_none(entry.get("cache_read_input_token_cost")),
+                cache_creation_cost_per_token=_finite_or_none(
+                    entry.get("cache_creation_input_token_cost")
+                ),
             )
     return None
 
@@ -189,6 +202,13 @@ def _both_finite(a: Any, b: Any) -> bool:
     )
 
 
+def _finite_or_none(x: Any) -> float | None:
+    """A finite float value, or ``None`` (missing, non-numeric, NaN, or inf)."""
+    if isinstance(x, (int, float)) and math.isfinite(x):
+        return float(x)
+    return None
+
+
 def price_tokens(
     priced: PricedModel,
     prompt_tokens: int,
@@ -205,9 +225,25 @@ def price_tokens(
     cc_1h = max(0, cache_creation_input_tokens_1h)
     cr = max(0, cache_read_input_tokens)
 
-    cache_creation_cost = cc * priced.input_cost_per_token * _CACHE_CREATION_MULTIPLIER
+    # Per-token cache rates: prefer the model's published rate (correct per
+    # provider — Anthropic reads at ~0.1x, OpenAI at ~0.5x), falling back to the
+    # conservative multiplier of the base input rate when the map has none. The
+    # 1h-creation rate has no published field (LiteLLM carries only the 5m
+    # creation rate), so it always uses its multiplier.
+    cache_creation_rate = (
+        priced.cache_creation_cost_per_token
+        if priced.cache_creation_cost_per_token is not None
+        else priced.input_cost_per_token * _CACHE_CREATION_MULTIPLIER
+    )
+    cache_read_rate = (
+        priced.cache_read_cost_per_token
+        if priced.cache_read_cost_per_token is not None
+        else priced.input_cost_per_token * _CACHE_READ_MULTIPLIER
+    )
+
+    cache_creation_cost = cc * cache_creation_rate
     cache_creation_1h_cost = cc_1h * priced.input_cost_per_token * _CACHE_CREATION_1H_MULTIPLIER
-    cache_read_cost = cr * priced.input_cost_per_token * _CACHE_READ_MULTIPLIER
+    cache_read_cost = cr * cache_read_rate
 
     cost = (
         (p * priced.input_cost_per_token)

--- a/src/floe_guard/pricing.py
+++ b/src/floe_guard/pricing.py
@@ -35,8 +35,9 @@ class PricedModel:
 
     ``cache_read_cost_per_token`` / ``cache_creation_cost_per_token`` are the
     model's published prompt-cache rates (from the cost map), or ``None`` when the
-    map has none — in which case :func:`price_tokens` falls back to a conservative
-    per-provider multiplier of the base input rate. Override-sourced prices leave
+    map has none — in which case :func:`price_tokens` falls back to a single
+    conservative multiplier of the base input rate (not provider-specific).
+    Override-sourced prices leave
     them ``None`` (an override carries only base input/output).
     """
 

--- a/src/floe_guard/receipt.py
+++ b/src/floe_guard/receipt.py
@@ -67,6 +67,7 @@ def turn_cost(
     *,
     remaining_usd: float | None = None,
     overrides: dict[str, ManualPrice] | None = None,
+    prompt_cached_tokens: int = 0,
 ) -> FloeCost | None:
     """Per-turn receipt from token usage, priced locally by the cost map.
 
@@ -78,9 +79,18 @@ def turn_cost(
     :func:`~floe_guard.hosted_remaining_usd` (a hosted read that needs a Floe
     key), fetched at whatever cadence you like so there's no network call every
     turn. ``turn_cost`` never calls the network.
+
+    ``prompt_cached_tokens`` is the subset of ``prompt_tokens`` served from the
+    provider's prompt cache (``prompt_tokens`` is the TOTAL input, inclusive of
+    cached). That subset is priced at the model's cache-read rate from the cost
+    map, falling back to a conservative multiplier for models without a published
+    cache rate — so caching is no longer billed at the full input rate. Clamped
+    to ``prompt_tokens``; ``0`` (the default) prices exactly as before.
     """
     priced = resolve_price(model, overrides)
     if priced is None:
         return None
-    usd = price_tokens(priced, prompt_tokens, completion_tokens)
+    cached = min(max(0, prompt_cached_tokens), max(0, prompt_tokens))
+    non_cached = max(0, prompt_tokens) - cached
+    usd = price_tokens(priced, non_cached, completion_tokens, cache_read_input_tokens=cached)
     return FloeCost(usd=usd, source=SOURCE_ESTIMATE, model=model, remaining_usd=remaining_usd)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -292,6 +292,73 @@ def test_cost_map_generated_at_returns_none_for_invalid_metadata(monkeypatch, me
 
     monkeypatch.setattr(pricing, "_META", meta)
     assert cost_map_generated_at() is None
+
+
+def test_cost_map_carries_per_provider_cache_rates() -> None:
+    # The migration added per-model cache_read rates from LiteLLM. Anthropic and
+    # OpenAI publish DIFFERENT read ratios (Anthropic ~0.1x input, OpenAI ~0.5x),
+    # so the map must reflect both — the whole point of provider-aware pricing.
+    from floe_guard.pricing import _COST_MAP
+
+    anthropic = _COST_MAP["claude-3-7-sonnet-20250219"]
+    openai = _COST_MAP["gpt-4o"]
+    assert "cache_read_input_token_cost" in anthropic
+    assert "cache_read_input_token_cost" in openai
+    a_ratio = anthropic["cache_read_input_token_cost"] / anthropic["input_cost_per_token"]
+    o_ratio = openai["cache_read_input_token_cost"] / openai["input_cost_per_token"]
+    assert a_ratio == pytest.approx(0.1)
+    assert o_ratio == pytest.approx(0.5)
+    assert a_ratio != o_ratio
+
+
+def test_resolve_price_populates_cache_rates() -> None:
+    anthropic = resolve_price("claude-3-7-sonnet-20250219")
+    assert anthropic is not None
+    assert anthropic.cache_read_cost_per_token == pytest.approx(3e-7)
+    assert anthropic.cache_creation_cost_per_token is not None
+
+    openai = resolve_price("gpt-4o")
+    assert openai is not None
+    assert openai.cache_read_cost_per_token == pytest.approx(1.25e-6)
+
+
+def test_resolve_price_cache_rates_none_when_absent_or_override() -> None:
+    # A priced model the map has no cache rate for → None (falls back at pricing time).
+    no_cache = resolve_price("claude-3-5-sonnet-20241022")
+    assert no_cache is not None
+    assert no_cache.cache_read_cost_per_token is None
+    assert no_cache.cache_creation_cost_per_token is None
+
+    # Override-sourced prices never carry cache rates.
+    ov = resolve_price("gpt-4o", {"gpt-4o": ManualPrice(1e-9, 2e-9)})
+    assert ov is not None and ov.source == "override"
+    assert ov.cache_read_cost_per_token is None
+    assert ov.cache_creation_cost_per_token is None
+
+
+def test_price_tokens_uses_model_cache_rate() -> None:
+    # Cache-read priced at the model's OWN rate, not a one-size-fits-all multiplier.
+    anthropic = resolve_price("claude-3-7-sonnet-20250219")
+    openai = resolve_price("gpt-4o")
+    assert anthropic is not None and openai is not None
+
+    a_cost = price_tokens(anthropic, 0, 0, cache_read_input_tokens=1000)
+    assert a_cost == pytest.approx(1000 * anthropic.cache_read_cost_per_token)
+
+    o_cost = price_tokens(openai, 0, 0, cache_read_input_tokens=1000)
+    assert o_cost == pytest.approx(1000 * openai.cache_read_cost_per_token)
+    # Different providers, different cache-read cost for the same token count.
+    assert a_cost != o_cost
+
+
+def test_price_tokens_falls_back_to_multiplier_without_cache_rate() -> None:
+    # cache_read_cost_per_token is None → old behavior: input * 0.10.
+    priced = PricedModel(input_cost_per_token=1e-6, output_cost_per_token=2e-6, source="cost_map")
+    assert priced.cache_read_cost_per_token is None
+    cost = price_tokens(priced, 0, 0, cache_read_input_tokens=1000)
+    assert cost == pytest.approx(1000 * 1e-6 * 0.10)
+
+
 def test_resolves_claude_3_5_family() -> None:
     # claude-3-5-sonnet and claude-3-5-haiku were missing from the cost map,
     # causing UnpriceableModelError for anyone still on these models.

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from floe_guard import FloeCost, turn_cost
+from floe_guard.pricing import price_tokens, resolve_price
 
 
 def test_turn_cost_prices_known_model() -> None:
@@ -55,6 +56,45 @@ def test_format_at_threshold_uses_four_decimals() -> None:
 def test_source_must_be_estimate_or_hosted() -> None:
     with pytest.raises(ValueError, match="honesty contract"):
         FloeCost(usd=0.01, source="other", model="m")
+
+
+def test_turn_cost_prices_cached_subset_at_cache_rate() -> None:
+    # gpt-4o: input 2.5e-6, cache_read 1.25e-6 (0.5x). 1000 total prompt tokens,
+    # 400 of them cached. The cached subset is priced at the cache-read rate, so
+    # the total must be LESS than pricing all 1000 at the full input rate.
+    model = "gpt-4o"
+    full = turn_cost(model, 1000, 500)
+    cached = turn_cost(model, 1000, 500, prompt_cached_tokens=400)
+    assert full is not None and cached is not None
+    assert cached.usd < full.usd
+
+    # And it matches price_tokens with the explicit non-cached / cached split.
+    priced = resolve_price(model)
+    assert priced is not None
+    expected = price_tokens(priced, 600, 500, cache_read_input_tokens=400)
+    assert cached.usd == pytest.approx(expected)
+
+
+def test_turn_cost_clamps_cached_to_prompt_tokens() -> None:
+    # prompt_cached_tokens above prompt_tokens is clamped: every input token is
+    # cached, none billed at the full rate.
+    model = "gpt-4o"
+    priced = resolve_price(model)
+    assert priced is not None
+    over = turn_cost(model, 1000, 500, prompt_cached_tokens=99_999)
+    assert over is not None
+    expected = price_tokens(priced, 0, 500, cache_read_input_tokens=1000)
+    assert over.usd == pytest.approx(expected)
+
+
+def test_turn_cost_cached_zero_is_unchanged() -> None:
+    # The default (0 cached) prices exactly as before the cache-aware change.
+    model = "gpt-4o"
+    default = turn_cost(model, 1000, 500)
+    explicit = turn_cost(model, 1000, 500, prompt_cached_tokens=0)
+    assert default is not None and explicit is not None
+    assert explicit.usd == pytest.approx(default.usd)
+    assert default.usd == pytest.approx(0.0075)  # 1000*2.5e-6 + 500*1e-5
 
 
 def test_turn_cost_returns_the_public_floecost_schema() -> None:


### PR DESCRIPTION
## What
Cached input tokens are billed at a per-provider discount, but pricing every input token at the full rate overstates the estimate when prompt caching is active (flagged on the plugin reconciler). This makes pricing cache-aware **from the data**, so it's correct per provider — and aligns the local estimate with the core service's bill, which already discounts cache via seeded catalog rates.

- **Cost map now carries per-model cache rates** (`cache_read_input_token_cost` / `cache_creation_input_token_cost`) from LiteLLM. Added **surgically** — a byte-preserving textual migration, **not** a regen (a regen would drift all prices to today's LiteLLM and break tests). Verified: 0 existing input/output price lines changed; 113 cache-rate fields added; py↔js byte-identical. The generator (`update-cost-map.mjs`) also keeps these on future regens.
- **`price_tokens`** uses the model's own cache rate (Anthropic 0.1×, OpenAI 0.5× — from data), falling back to the old multiplier only for models with no published rate.
- **`turn_cost`** gains `prompt_cached_tokens` so the receipt prices the cached subset at the cache rate.

## Notes
- js `pricing.ts` doesn't consume the new rates yet (data is inert there) — documented parity follow-up; the js version bump (0.15.0) is required only because the shared cost map changed.
- `claude-3-5-sonnet-20241022` is no longer Anthropic-native in LiteLLM, so it correctly gets no cache rate (falls back to the multiplier) — this is exactly why a full regen was avoided.

## Tests
451 py + 225 js pass, cost-map-sync green, both versions differ from main (version-guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added model-specific pricing for cached prompt tokens, including cache reads and supported cache creation rates.
  - Added support for reporting cached prompt tokens in turn cost calculations.
  - Retained fallback pricing for models without published cache rates.
- **Documentation**
  - Updated the changelog with Python 0.20.0 and JavaScript 0.15.0 release details.
  - Documented cache pricing coverage and current TypeScript pricing limitations.
- **Release Updates**
  - Published Python version 0.20.0 and JavaScript version 0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->