### PR TITLE
feat: Add Python Vapi and Retell voice adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.21.0 / js 0.15.0
+
+### Added (py)
+
+- **Vapi and Retell custom-LLM adapters — the in-call voice guards, now in
+  Python.** `floe_guard.integrations.vapi.VapiBudgetGuard` guards the
+  `/chat/completions` turn (`guard_completion` for JSON, `guard_stream` for SSE
+  — both reserve before the upstream call, settle on the real OpenAI `usage`
+  after, and release the hold on error/abort; a stream with no `include_usage`
+  chunk fails loudly via `VapiUsageMissingError` rather than metering $0),
+  answers Vapi's `assistant-request` webhook from the remaining budget
+  (`assistant_request`, delegating to `gates.vapi`), and meters the STT/TTS/
+  telephony legs the proxy never sees (`meter_stt` / `meter_tts` /
+  `meter_telephony`). `floe_guard.integrations.retell.RetellBudgetGuard` does
+  the same over Retell's custom-LLM WebSocket: reserve on `response_required`
+  (`begin_turn`, idempotent), settle real token usage after `content_complete`
+  (`settle_turn`), release the hold when a newer `response_id` interrupts or on
+  `close()`, plus `admit_call` (delegating to `gates.retell`), a `response`
+  event builder, and the same voice-leg meters. Both adapters are
+  **framework-free** — they speak Vapi's OpenAI-format JSON/SSE and Retell's
+  plain WS dicts, so a Python voice stack (FastAPI custom-LLM proxy, WS server)
+  can enforce per-turn budgets with nothing new to install (`floe-guard[vapi]` /
+  `floe-guard[retell]` extras exist for discoverability). They mirror the TS
+  adapters (`js/src/adapters/{vapi,retell}.ts`), and ship with no-key, no-network
+  examples (`examples/voice_call_cost_vapi.py`,
+  `examples/voice_call_cost_retell.py`) that print a pre-call admission decision
+  and a per-leg call-cost receipt; the README adapter matrix marks Vapi/Retell
+  ✅/✅.
+
 ## Unreleased — py 0.20.1 / js 0.15.0
 
 ### Documentation (py)

--- a/README.md
+++ b/README.md
@@ -469,11 +469,11 @@ budget = RetellBudgetGuard(guard, model="gpt-4o-mini")
 # in your custom-LLM WS message handler:
 turn = budget.begin_turn(event)          # reserve before the LLM call
 if not turn.admitted:                    # budget exhausted → wrap up the call
-    await ws.send(budget.response(event["response_id"],
-                                  "I'm out of budget — wrapping up.",
-                                  complete=True, end_call=True))
+    await ws.send(json.dumps(budget.response(event["response_id"],
+                                             "I'm out of budget — wrapping up.",
+                                             complete=True, end_call=True)))
     return
-ws.send(budget.response(event["response_id"], text, complete=True))
+await ws.send(json.dumps(budget.response(event["response_id"], text, complete=True)))
 budget.settle_turn(event["response_id"], {"promptTokens": n, "completionTokens": m})
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ dies at $0.10 instead of $4,000. In-process, no account, no signup, **no telemet
 **Python** (`pip install floe-guard`): plain `check()` / `record()` or adapters for
 [OpenAI](#openai) · [Anthropic](docs/adapters.md#anthropic) · [Gemini](docs/adapters.md#google-gemini) · [CrewAI](docs/adapters.md#crewai) ·
 [LiteLLM](docs/adapters.md#litellm) · [LangChain](docs/adapters.md#langchain) · [LangGraph](docs/adapters.md#langgraph); voice adapters for
-[Pipecat](#pipecat-voice) and [LiveKit](#livekit-voice);
+[Pipecat](#pipecat-voice) · [LiveKit](#livekit-voice) · [Vapi](#vapi-voice) · [Retell](#retell-voice);
 [pre-call admission gates](#voice-admission-gates-pre-call).
 
 **TypeScript** (`npm i floe-guard`): [Vercel AI SDK](docs/adapters.md#vercel-ai-sdk) middleware, native
-[LiveKit · Vapi · Retell](#typescript-voice-adapters) voice adapters.
+[LiveKit · Vapi · Retell](#voice-adapters) voice adapters.
 See the [adapter matrix](#adapter-matrix) for what ships in Python vs TypeScript.
 
 > Reading this on PyPI? The `docs/…` and `examples/…` links resolve on the
@@ -267,9 +267,8 @@ call (so a turn is blocked *before* its TTS/audio spend piles on top of a call
 that would already cross the ceiling), settle on the real usage the pipeline
 reports, and release a turn that ends without ever reporting usage (an
 interrupted turn) so the reservation never leaks against the ceiling. This
-section covers the **Python** Pipecat and LiveKit adapters; TypeScript ships
-native LiveKit / Vapi / Retell adapters too — see
-[TypeScript voice adapters](#typescript-voice-adapters).
+section covers the **Python** Pipecat, LiveKit, Vapi, and Retell adapters — see
+the [Voice adapters](#voice-adapters) section for the TypeScript twins.
 
 **The whole call is priced from the bundled map — no hand-typed rates.** Name each
 leg's vendor (`stt_model`, `tts_model`, `telephony`) and floe-guard prices the
@@ -403,6 +402,88 @@ ends. See [`examples/voice_call_cost_livekit.py`](examples/voice_call_cost_livek
 for the full per-leg breakdown (no API key) and
 [`examples/voice_turn_budget.py`](examples/voice_turn_budget.py) for the hard-stop.
 
+### Vapi (voice)
+
+```bash
+pip install floe-guard            # the Vapi adapter is framework-free — no extra
+```
+
+The custom-LLM proxy sees only the **model leg**, so `VapiBudgetGuard` guards the
+`/chat/completions` turn and admits the call via the `assistant-request` webhook.
+`guard_completion` (JSON) and `guard_stream` (SSE) reserve the estimated cost
+**before** the upstream call, settle on Vapi's real OpenAI `usage` afterwards,
+and release the hold on error/abort — so an over-budget turn gets a 402 instead
+of reaching your LLM. Set `stream_options={"include_usage": True}` on the
+upstream streaming request or `guard_stream` fails loudly (the SSE omits `usage`
+without it).
+
+```python
+from floe_guard import BudgetGuard
+from floe_guard.errors import BudgetExceeded
+from floe_guard.integrations.vapi import VapiBudgetGuard
+
+guard = BudgetGuard(limit_usd=1.00)
+budget = VapiBudgetGuard(
+    guard,
+    stt_model="deepgram-nova-3",   # $/sec from the voice map
+    tts_model="elevenlabs-flash-v2.5",  # $/1k-chars from the voice map
+    telephony="twilio-us-inbound-local",  # $/min from the voice map
+)
+
+# POST /chat/completions — the custom-LLM endpoint Vapi calls each turn.
+completion = await budget.guard_completion(
+    lambda: openai_client.chat.completions.create(model=model, messages=messages),
+    model=model,
+)
+#  budget exhausted → BudgetExceeded (return a 402), never proxied upstream
+```
+
+`budget.meter_stt(seconds)` / `budget.meter_tts(chars)` /
+`budget.meter_telephony(minutes)` accrue the legs the proxy never sees (drive
+them from Vapi's `end-of-call-report` webhook). Name the vendors to price them
+from the map, or pass per-unit overrides (`stt_usd_per_second` /
+`tts_usd_per_1k_chars` / `telephony_usd_per_minute`) that win over it. See
+[`examples/voice_call_cost_vapi.py`](examples/voice_call_cost_vapi.py) for the
+per-leg breakdown (no API key, no network).
+
+### Retell (voice)
+
+```bash
+pip install floe-guard            # the Retell adapter is framework-free — no extra
+```
+
+Retell's custom LLM runs over a WebSocket. `RetellBudgetGuard` reserves when a
+`response_required` interaction arrives (before the LLM call, so a turn is
+blocked before its TTS/telephony spend piles on), settles on the turn's real
+token usage after `content_complete`, and releases the hold when a newer
+`response_id` interrupts. Tick the `response` events you already stream —
+Retell sends plain dict events over `ws`:
+
+```python
+from floe_guard import BudgetGuard
+from floe_guard.integrations.retell import RetellBudgetGuard
+
+guard = BudgetGuard(limit_usd=1.00)
+budget = RetellBudgetGuard(guard, model="gpt-4o-mini")
+
+# in your custom-LLM WS message handler:
+turn = budget.begin_turn(event)          # reserve before the LLM call
+if not turn.admitted:                    # budget exhausted → wrap up the call
+    await ws.send(budget.response(event["response_id"],
+                                  "I'm out of budget — wrapping up.",
+                                  complete=True, end_call=True))
+    return
+ws.send(budget.response(event["response_id"], text, complete=True))
+budget.settle_turn(event["response_id"], {"promptTokens": n, "completionTokens": m})
+```
+
+`budget.meter_stt` / `meter_tts` / `meter_telephony` meter the legs the socket
+never sees (from wherever the durations are known), priced from the voice map
+when you name the vendor or a per-unit override. `budget.close()` releases any
+still-open hold on call teardown. See
+[`examples/voice_call_cost_retell.py`](examples/voice_call_cost_retell.py) for the
+per-leg breakdown (no API key, no network).
+
 ## Voice admission gates (pre-call)
 
 The adapters above meter a call that's already running. `floe_guard.gates` is the
@@ -463,23 +544,23 @@ call-level intervention.) Budget, not balance. US-only telephony, v1.
 | LiteLLM | ✅ | — |
 | Vercel AI SDK | — | ✅ |
 | **LiveKit** (voice) | ✅ | ✅ |
-| **Vapi** (voice) | — | ✅ |
-| **Retell** (voice) | — | ✅ |
+| **Vapi** (voice) | ✅ | ✅ |
+| **Retell** (voice) | ✅ | ✅ |
 | **Pipecat** (voice) | ✅ | — |
 
-The TypeScript package started as a single Vercel AI SDK middleware; it now also
-ships **voice-leg pricing** (`priceVoiceLeg`), **pre-call admission gates**
-(`gates.retell` / `gates.vapi` / `gates.preCall`), and **native voice adapters**
-for LiveKit, Vapi, and Retell (below).
+The packages ship **voice-leg pricing** (`price_voice_leg` / `priceVoiceLeg`),
+**pre-call admission gates** (`gates.retell` / `gates.vapi` / `gates.pre_call` /
+`gates.preCall`), and **native voice adapters** for LiveKit, Vapi, and Retell
+(below) — Python and TypeScript in lockstep.
 
-### TypeScript voice adapters
+### Voice adapters
 
-TypeScript ships native STT → LLM → TTS session adapters for the three Node voice
+Python and TypeScript ship native STT → LLM → TTS session adapters for the voice
 stacks. Each reserves before the model turn, settles on real usage, releases on
 interrupt, and meters STT/TTS/telephony legs from the `__voice__` cost map
-(fail-closed via `UnpriceableVoiceError`) — the same enforcement contract as the
-Python Pipecat / LiveKit adapters. **Pre-turn / pre-call admission plus per-turn
-settlement only; no mid-call cutoff.**
+(fail-closed via `UnpriceableVoiceError`) — the same enforcement contract across
+both languages. **Pre-turn / pre-call admission plus per-turn settlement only;
+no mid-call cutoff.**
 
 ```ts
 // LiveKit Agents (Node) — @livekit/agents is an optional peer
@@ -497,11 +578,32 @@ const decision = budget.beginTurn(event);        // { admitted } — reserves be
 budget.settleTurn(event.response_id, usage);     // settle real usage after content_complete
 ```
 
-Each ships a runnable, no-key demo (`js/examples/*_voice_cost.mjs`) that prints a
-pre-call admission decision and a per-leg call-cost receipt; see the module
-docstrings for the full API. Pipecat's server pipeline is Python-only, so its
-budget processor lives in the Python package (`FloeBudgetGuardProcessor`) — there
-is no Node Pipecat server surface to adapt.
+```python
+# Vapi custom-LLM proxy — wrap the /chat/completions turn
+from floe_guard.integrations.vapi import VapiBudgetGuard
+
+budget = VapiBudgetGuard(guard, stt_model="deepgram-nova-3", tts_model="elevenlabs-flash-v2.5",
+                         telephony="twilio-us-inbound-local")
+completion = await budget.guard_completion(  # reserve → run → settle on real usage
+    lambda: openai_client.chat.completions.create(model=model, messages=body["messages"]),
+    model=model,
+)
+
+# Retell custom-LLM WebSocket — reserve on response_required, settle on content_complete
+from floe_guard.integrations.retell import RetellBudgetGuard
+
+budget = RetellBudgetGuard(guard, model="gpt-4o-mini")
+decision = budget.begin_turn(event)       # { admitted } — reserves before the LLM call
+budget.settle_turn(event["response_id"], usage)  # settle real usage after content_complete
+```
+
+Each ships a runnable, no-key demo (`examples/voice_call_cost_livekit.py`,
+`examples/voice_call_cost_vapi.py`, `examples/voice_call_cost_retell.py`; Node
+`js/examples/*_voice_cost.mjs`) that prints a pre-call admission decision and a
+per-leg call-cost receipt; see the module docstrings for the full API. Pipecat's
+server pipeline is Python-only, so its budget processor lives in the Python
+package (`FloeBudgetGuardProcessor`) — there is no Node Pipecat server surface
+to adapt.
 
 For wiring floe-guard into an existing voice pipeline, see the Floe docs:
 **[Add Floe to your existing pipeline](https://floe-labs.gitbook.io/docs/getting-started/integrate-existing-pipeline)**.
@@ -746,6 +848,8 @@ All runnable examples live in [`examples/`](examples/). Use `python examples/<fi
 | [`voice_turn_budget.py`](examples/voice_turn_budget.py) | Pipecat pipeline with `FloeBudgetGuardProcessor`: multi-turn voice conversation halted mid-run | `pip install floe-guard[pipecat]` | none |
 | [`voice_call_cost_pipecat.py`](examples/voice_call_cost_pipecat.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via Pipecat, priced from the bundled map | `pip install floe-guard[pipecat]` | none |
 | [`voice_call_cost_livekit.py`](examples/voice_call_cost_livekit.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via LiveKit, priced from the bundled map | `pip install floe-guard[livekit]` | none |
+| [`voice_call_cost_vapi.py`](examples/voice_call_cost_vapi.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via the Vapi custom-LLM proxy, priced from the bundled map | `pip install floe-guard` | none |
+| [`voice_call_cost_retell.py`](examples/voice_call_cost_retell.py) | Full per-leg call cost (STT + LLM + TTS + telephony) via the Retell custom-LLM WebSocket, priced from the bundled map | `pip install floe-guard` | none |
 
 ## Built with floe-guard
 

--- a/examples/voice_call_cost_retell.py
+++ b/examples/voice_call_cost_retell.py
@@ -1,0 +1,76 @@
+"""What did this voice call cost? — Retell custom-LLM WS, priced from the map.
+
+No API key, no account, no network. Fake ``response_required`` interaction
+events drive two turns through ``RetellBudgetGuard`` (reserve on arrival,
+settle on real token usage after ``content_complete``), plus the STT / TTS /
+telephony legs the socket never sees. **No manual prices** — every leg is priced
+from the bundled cost map by naming its vendor, so floe-guard answers "what did
+this call cost" at the $0 tier out of the box.
+
+Run:
+    python examples/voice_call_cost_retell.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.retell import RetellBudgetGuard
+
+
+def _response_required(response_id: int) -> dict:
+    """A Retell interaction event as it arrives over the WS."""
+    return {
+        "interaction_type": "response_required",
+        "response_id": response_id,
+        "transcript": [{"role": "user", "content": "hi"}],
+    }
+
+
+async def run() -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = RetellBudgetGuard(
+        guard,
+        model="gpt-4o",  # LLM leg — priced from the token cost map
+        stt_model="deepgram-nova-3",  # $/sec from the voice map
+        tts_model="elevenlabs-flash-v2.5",  # $/1k-chars from the voice map
+        telephony="twilio-us-inbound-local",  # $/min from the voice map
+    )
+
+    # Pre-call admission: Retell's inbound-call webhook, from the budget left.
+    admit = budget.admit_call(admit={"dynamic_variables": {"plan": "free"}})
+    print(f"inbound-call admission: {admit}")
+
+    # Two turns over the WS: admit, stream a response, settle real usage.
+    for response_id in (1, 2):
+        turn = budget.begin_turn(_response_required(response_id))
+        assert turn.admitted  # reserves before the LLM call
+        event = budget.response(response_id, "Sure, one moment!", complete=True)
+        assert event["content_complete"] is True
+        # Real token usage from your LLM, settled after content_complete.
+        budget.settle_turn(response_id, {"promptTokens": 300, "completionTokens": 110})
+
+    # The socket never sees STT/TTS/telephony — meter them from the call record.
+    budget.meter_stt(8.0)  # 8s of caller audio
+    budget.meter_tts(180)  # 180 chars spoken
+    budget.meter_telephony(1.5)  # a 1.5-minute call
+
+    budget.close()  # release any still-open hold on call teardown
+    return guard
+
+
+def _print_breakdown(guard: BudgetGuard) -> None:
+    print("Per-leg call cost (all priced from the bundled cost map, no manual rates):")
+    for event in guard.spend_log:
+        print(f"  {event.model_or_tool:<20} ${event.cost_usd:.6f}")
+    print(f"  {'TOTAL':<20} ${guard.advisory().spent_usd:.6f}")
+
+
+async def main() -> None:
+    guard = await run()
+    _print_breakdown(guard)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/voice_call_cost_vapi.py
+++ b/examples/voice_call_cost_vapi.py
@@ -1,0 +1,70 @@
+"""What did this voice call cost? — Vapi custom-LLM, priced from the cost map.
+
+No API key, no account, no network. A fake OpenAI-shaped completion drives one
+turn through ``VapiBudgetGuard.guard_completion`` (reserve → run → settle on the
+real ``usage``), plus the STT / TTS / telephony legs metered from Vapi's
+``end-of-call-report``. **No manual prices** — every leg is priced from the
+bundled cost map by naming its vendor, so floe-guard answers "what did this call
+cost" at the $0 tier out of the box.
+
+Run:
+    python examples/voice_call_cost_vapi.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from floe_guard import BudgetGuard
+from floe_guard.integrations.vapi import VapiBudgetGuard
+
+
+def _fake_completion(prompt_tokens: int, completion_tokens: int) -> dict:
+    """An OpenAI-format completion as Vapi's custom-LLM endpoint returns it."""
+    return {
+        "id": "chatcmpl-fake",
+        "choices": [{"message": {"role": "assistant", "content": "Sure, one moment!"}}],
+        "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    }
+
+
+async def run() -> BudgetGuard:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = VapiBudgetGuard(
+        guard,
+        stt_model="deepgram-nova-3",  # $/sec from the voice map
+        tts_model="elevenlabs-flash-v2.5",  # $/1k-chars from the voice map
+        telephony="twilio-us-inbound-local",  # $/min from the voice map
+    )
+
+    # Pre-call admission: Vapi's assistant-request webhook, from the budget left.
+    print(f"assistant-request admission: {budget.assistant_request(assistant_id='asst_1')}")
+
+    # One turn through the custom-LLM proxy: reserve → run → settle on real usage.
+    completion = await budget.guard_completion(
+        lambda: _fake_completion(prompt_tokens=600, completion_tokens=220),
+        model="gpt-4o",  # LLM leg — priced from the token cost map
+    )
+    assert completion["usage"]["completion_tokens"] == 220
+
+    # The proxy never sees STT/TTS/telephony — meter them from end-of-call-report.
+    budget.meter_stt(8.0)  # 8s of caller audio
+    budget.meter_tts(180)  # 180 chars spoken
+    budget.meter_telephony(1.5)  # a 1.5-minute call
+    return guard
+
+
+def _print_breakdown(guard: BudgetGuard) -> None:
+    print("Per-leg call cost (all priced from the bundled cost map, no manual rates):")
+    for event in guard.spend_log:
+        print(f"  {event.model_or_tool:<20} ${event.cost_usd:.6f}")
+    print(f"  {'TOTAL':<20} ${guard.advisory().spent_usd:.6f}")
+
+
+async def main() -> None:
+    guard = await run()
+    _print_breakdown(guard)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.20.1"
+version = "0.21.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Floe Labs" }]
-keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini", "voice", "stt", "tts", "livekit", "deepgram", "elevenlabs", "twilio"]
+keywords = ["llm", "agents", "budget", "guardrail", "crewai", "litellm", "langchain", "langgraph", "cost", "openai", "anthropic", "gemini", "voice", "stt", "tts", "livekit", "deepgram", "elevenlabs", "twilio", "vapi", "retell"]
 classifiers = [
     # Kept at Beta for 0.17.0 (decided 2026-08): the README's "Honest about what
     # this is" caveats — estimate-based enforcement, cold-start concurrency not
@@ -46,6 +46,11 @@ anthropic = ["anthropic>=0.40"]
 gemini = ["google-genai>=1.0"]
 pipecat = ["pipecat-ai>=1.0"]
 livekit = ["livekit-agents>=1.0"]
+# Vapi and Retell adapters are framework-free (no dependency), so their extras
+# exist for discoverability and install-surface parity with the rest of the
+# voice adapters.
+vapi = []
+retell = []
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 
 [project.scripts]

--- a/src/floe_guard/integrations/__init__.py
+++ b/src/floe_guard/integrations/__init__.py
@@ -6,4 +6,9 @@ Each adapter lives behind an optional extra so the core stays dependency-free:
     pip install floe-guard[crewai]
     pip install floe-guard[langchain]
     pip install floe-guard[langgraph]
+
+The voice adapters are split: Pipecat and LiveKit pull their framework extras
+(``[pipecat]`` / ``[livekit]``); the Vapi and Retell adapters are
+framework-free — they speak Vapi's and Retell's plain wire formats (OpenAI-format
+JSON/SSE and WebSocket dicts) with no SDK dependency, so they need no extra.
 """

--- a/src/floe_guard/integrations/retell.py
+++ b/src/floe_guard/integrations/retell.py
@@ -80,11 +80,17 @@ from ..voice_pricing import price_voice_leg
 
 
 def _numeric(value: Any) -> bool:
-    """A finite number usable for a token count (True counts as invalid)."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+    """A finite, non-negative integer token count (``True`` counts as invalid)."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+        and (isinstance(value, int) or float(value).is_integer())
+    )
 
 
-def _retell_usage(usage: Any) -> tuple[float, float] | None:
+def _retell_usage(usage: Any) -> tuple[int, int] | None:
     """Read Retell's camelCase token usage (``promptTokens`` /
     ``completionTokens``) as a dict or any object exposing both attributes.
     Returns ``None`` when absent/malformed — both fields must be finite
@@ -99,7 +105,7 @@ def _retell_usage(usage: Any) -> tuple[float, float] | None:
         completion = getattr(usage, "completionTokens", None)
     if not _numeric(prompt) or not _numeric(completion):
         return None
-    return prompt, completion
+    return int(prompt), int(completion)
 
 
 @dataclass(frozen=True)

--- a/src/floe_guard/integrations/retell.py
+++ b/src/floe_guard/integrations/retell.py
@@ -68,7 +68,7 @@ the interrupt Retell itself signals (a newer ``response_id``) or an explicit
 
 from __future__ import annotations
 
-import logging
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -78,7 +78,28 @@ from ..gates import retell as retell_gate
 from ..guard import BudgetGuard, ReservationHandle
 from ..voice_pricing import price_voice_leg
 
-logger = logging.getLogger(__name__)
+
+def _numeric(value: Any) -> bool:
+    """A finite number usable for a token count (True counts as invalid)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _retell_usage(usage: Any) -> tuple[float, float] | None:
+    """Read Retell's camelCase token usage (``promptTokens`` /
+    ``completionTokens``) as a dict or any object exposing both attributes.
+    Returns ``None`` when absent/malformed — both fields must be finite
+    numbers, so a partial or non-numeric payload is treated as no usage
+    (fail-closed), never metered at a guessed cost.
+    """
+    if isinstance(usage, Mapping):
+        prompt = usage.get("promptTokens")
+        completion = usage.get("completionTokens")
+    else:
+        prompt = getattr(usage, "promptTokens", None)
+        completion = getattr(usage, "completionTokens", None)
+    if not _numeric(prompt) or not _numeric(completion):
+        return None
+    return prompt, completion
 
 
 @dataclass(frozen=True)
@@ -173,8 +194,20 @@ class RetellBudgetGuard:
         Reserving here is what blocks a turn before its downstream TTS/telephony
         spend piles on. Calling twice with the same still-open ``response_id``
         is idempotent (no double hold).
+
+        Raises:
+            ValueError: the event carries no integer ``response_id`` — a
+                malformed/mismatched interaction. Refused fail-closed rather
+                than mis-keying a turn or releasing a live one.
         """
-        response_id = event["response_id"]
+        response_id = event.get("response_id")
+        if isinstance(response_id, bool) or not isinstance(response_id, (int, float)):
+            raise ValueError(
+                "Retell interaction event must carry an integer response_id; "
+                f"got {response_id!r}. Failing closed rather than mis-keying a "
+                "turn or releasing a live one."
+            )
+        response_id = int(response_id)  # 1.0 from a non-conforming parser == 1
 
         # Idempotent: this turn already holds a reservation.
         existing = self._slots.get(response_id)
@@ -203,8 +236,22 @@ class RetellBudgetGuard:
         ``response_id``; a turn with no open slot (already interrupted, or a
         settle for an id never begun) records the usage against a zero
         reservation instead of stealing another turn's hold. ``usage`` carries
-        Retell's camelCase fields (``promptTokens`` / ``completionTokens``).
+        Retell's camelCase fields (``promptTokens`` / ``completionTokens``),
+        as a dict or any object exposing both.
+
+        Raises:
+            ValueError: ``usage`` lacks a numeric ``promptTokens`` /
+                ``completionTokens`` pair — a malformed payload is refused
+                (fail-closed) rather than settled at a guessed cost.
         """
+        counts = _retell_usage(usage)
+        if counts is None:
+            raise ValueError(
+                "Retell token usage must carry finite numeric promptTokens and "
+                f"completionTokens; got {usage!r}. Failing closed rather than "
+                "settling at a guessed cost."
+            )
+        prompt_tokens, completion_tokens = counts
         reserved: ReservationHandle = 0.0
         slot = self._slots.pop(response_id, None)
         if slot is not None:
@@ -215,8 +262,8 @@ class RetellBudgetGuard:
             self._active_response_id = None
         self._guard.settle(
             self._model,
-            usage["promptTokens"],
-            usage["completionTokens"],
+            prompt_tokens,
+            completion_tokens,
             reserved=reserved,
         )
 

--- a/src/floe_guard/integrations/retell.py
+++ b/src/floe_guard/integrations/retell.py
@@ -237,9 +237,7 @@ class RetellBudgetGuard:
         ``$/min × expected minutes``) to reject earlier, when the remaining
         budget can't cover the call.
         """
-        return retell_gate(
-            self._guard, estimated_call_usd=estimated_call_usd, admit=admit
-        )
+        return retell_gate(self._guard, estimated_call_usd=estimated_call_usd, admit=admit)
 
     def response(
         self,

--- a/src/floe_guard/integrations/retell.py
+++ b/src/floe_guard/integrations/retell.py
@@ -1,0 +1,338 @@
+"""Retell custom-LLM WebSocket adapter (framework-free — no Retell SDK, no ``ws``).
+
+Retell's custom LLM runs over a WebSocket (docs.retellai.com/api-references/
+llm-websocket). Retell sends interaction events to your server; the billable one
+is **``response_required``** (an auto-incrementing ``response_id`` plus the
+running ``transcript``), and its twin **``reminder_required``**. Your server
+streams back **``response``** events — many partials per turn — ending with
+``content_complete: True``. A NEW ``response_required`` with a higher
+``response_id`` means the caller barged in: it **interrupts** the turn in
+flight, which never reaches ``content_complete``.
+
+Like the LiveKit/Pipecat adapters, a Retell call has no single call site to
+wrap: turns fire for the life of the socket. The two enforcement points are the
+arrival of a ``response_required`` (before the LLM call, so a turn is admitted
+or blocked before its TTS/telephony spend piles on) and the turn's real token
+usage (after ``content_complete``). :class:`RetellBudgetGuard` holds the
+reservation across both, keyed by ``response_id``, and releases it when a newer
+turn interrupts.
+
+    from floe_guard import BudgetGuard
+    from floe_guard.integrations.retell import RetellBudgetGuard
+
+    guard = BudgetGuard(
+        limit_usd=1.00,
+        price_overrides={"gpt-4o-mini": ManualPrice(0.15e-6, 0.6e-6)},
+    )
+    budget = RetellBudgetGuard(
+        guard,
+        model="gpt-4o-mini",
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+
+    # In your custom-LLM WS message handler:
+    async def on_message(raw: bytes | str) -> None:
+        event = json.loads(raw)
+        if event["interaction_type"] in ("response_required", "reminder_required"):
+            turn = budget.begin_turn(event)        # reserve before the LLM call
+            if not turn.admitted:                  # budget exhausted
+                await ws.send(json.dumps(budget.response(
+                    event["response_id"], "I'm out of budget — wrapping up.",
+                    complete=True, end_call=True)))
+                return
+            text, usage = await call_your_llm(event["transcript"])  # your LLM
+            await ws.send(json.dumps(
+                budget.response(event["response_id"], text, complete=True)))
+            budget.settle_turn(event["response_id"], usage)  # settle real usage
+
+## Why a WebSocket adapter, not a request wrapper
+
+The custom LLM sees only the **LLM leg** (the tokens behind each ``response``).
+STT, TTS and telephony are billed by Retell/the carrier and never cross this
+socket, so they are metered **explicitly** — call :meth:`RetellBudgetGuard.meter_stt`
+/ :meth:`RetellBudgetGuard.meter_tts` / :meth:`RetellBudgetGuard.meter_telephony`
+from wherever those durations are known (webhook, call-ended event). Each is
+priced from the bundled voice cost map when you name the vendor, or a per-unit
+override which wins over the map; a leg with neither is left un-metered (the
+token-only contract), and a named vendor the map cannot price fails closed
+(:class:`~floe_guard.errors.UnpriceableVoiceError`).
+
+Scope is strictly **pre-turn / pre-call admission plus per-turn settlement**.
+There is no mid-call intervention: an admitted turn runs to
+``content_complete``; nothing here cuts a turn off partway. The only release is
+the interrupt Retell itself signals (a newer ``response_id``) or an explicit
+:meth:`RetellBudgetGuard.close` on call teardown.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..errors import BudgetExceeded
+from ..gates import retell as retell_gate
+from ..guard import BudgetGuard, ReservationHandle
+from ..voice_pricing import price_voice_leg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RetellTurnDecision:
+    """The decision :meth:`RetellBudgetGuard.begin_turn` returns.
+
+    ``admitted=True`` means the turn's reservation is held — run the LLM and
+    settle it. ``admitted=False`` means the budget is spent: send a wrap-up
+    ``response`` (with ``content_complete``) and do not call the LLM; ``error``
+    carries the :class:`~floe_guard.errors.BudgetExceeded` for logging.
+    """
+
+    admitted: bool
+    response_id: int
+    error: BudgetExceeded | None = None
+
+
+@dataclass
+class _TurnSlot:
+    """One turn's reservation, keyed by ``response_id``.
+
+    ``open`` means the USD amount is still held on the BudgetGuard. A settle or
+    an interrupt closes it.
+    """
+
+    response_id: int
+    amount: ReservationHandle
+    open: bool = True
+
+
+class RetellBudgetGuard:
+    """Enforce a BudgetGuard ceiling on a Retell custom-LLM socket, one turn at a
+    time: reserve when a ``response_required`` arrives, settle on real token
+    usage after ``content_complete``, release when a newer ``response_id``
+    interrupts.
+
+    Args:
+        guard: the BudgetGuard to enforce.
+        model: model id to settle LLM cost against (Retell's usage payload names
+            no model we rely on). Must be priceable via the bundled cost map or
+            the guard's ``price_overrides``.
+        stt_model: voice-map vendor key for the STT leg (e.g.
+            ``"deepgram-nova-3"``), metered per second via :meth:`meter_stt`.
+        tts_model: voice-map vendor key for the TTS leg (e.g.
+            ``"elevenlabs-flash-v2.5"``), metered per 1k chars via
+            :meth:`meter_tts`.
+        telephony: voice-map vendor key for the telephony leg (e.g.
+            ``"twilio-us-inbound-local"``), metered per minute via
+            :meth:`meter_telephony`. US-only in v1.
+        stt_usd_per_second: per-second STT override — wins over ``stt_model``.
+            Omit both to leave STT un-metered.
+        tts_usd_per_1k_chars: per-1k-chars TTS override — wins over
+            ``tts_model``. Omit both to leave TTS un-metered.
+        telephony_usd_per_minute: per-minute telephony override — wins over
+            ``telephony``.
+    """
+
+    def __init__(
+        self,
+        guard: BudgetGuard,
+        model: str,
+        *,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        telephony: str | None = None,
+        stt_usd_per_second: float | None = None,
+        tts_usd_per_1k_chars: float | None = None,
+        telephony_usd_per_minute: float | None = None,
+    ):
+        self._guard = guard
+        self._model = model
+        self._stt_model = stt_model
+        self._tts_model = tts_model
+        self._telephony = telephony
+        self._stt_usd_per_second = stt_usd_per_second
+        self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
+        self._telephony_usd_per_minute = telephony_usd_per_minute
+        # Open (and just-settled) turns keyed by response_id.
+        self._slots: dict[int, _TurnSlot] = {}
+        # The most recently begun turn — the one a newer response_required
+        # interrupts.
+        self._active_response_id: int | None = None
+
+    def begin_turn(self, event: Mapping[str, Any]) -> RetellTurnDecision:
+        """Reserve budget for a ``response_required`` / ``reminder_required``
+        turn before its LLM call runs. Returns an admit/block
+        :class:`RetellTurnDecision`.
+
+        A newer ``response_id`` arriving while a prior turn is still open is
+        Retell's interrupt signal — this releases that prior turn's hold before
+        reserving the new one (its ``content_complete`` will never arrive).
+        Reserving here is what blocks a turn before its downstream TTS/telephony
+        spend piles on. Calling twice with the same still-open ``response_id``
+        is idempotent (no double hold).
+        """
+        response_id = event["response_id"]
+
+        # Idempotent: this turn already holds a reservation.
+        existing = self._slots.get(response_id)
+        if existing is not None and existing.open:
+            return RetellTurnDecision(True, response_id)
+
+        # A newer turn interrupts the prior open turn — free its hold before
+        # opening this one. Its usage never settles (no content_complete); a
+        # stray late settle for it finds no open slot and records actual usage
+        # against a zero reservation.
+        self._release_active(response_id)
+
+        try:
+            handle = self._guard.reserve()  # raises BudgetExceeded before the turn runs
+        except BudgetExceeded as exc:
+            return RetellTurnDecision(False, response_id, exc)
+
+        self._slots[response_id] = _TurnSlot(response_id, handle)
+        self._active_response_id = response_id
+        return RetellTurnDecision(True, response_id)
+
+    def settle_turn(self, response_id: int, usage: Mapping[str, Any]) -> None:
+        """Settle a turn's real token usage after its ``content_complete``.
+
+        Consumes the reservation opened by :meth:`begin_turn` for this
+        ``response_id``; a turn with no open slot (already interrupted, or a
+        settle for an id never begun) records the usage against a zero
+        reservation instead of stealing another turn's hold. ``usage`` carries
+        Retell's camelCase fields (``promptTokens`` / ``completionTokens``).
+        """
+        reserved: ReservationHandle = 0.0
+        slot = self._slots.pop(response_id, None)
+        if slot is not None:
+            if slot.open:
+                reserved = slot.amount
+                slot.open = False
+        if self._active_response_id == response_id:
+            self._active_response_id = None
+        self._guard.settle(
+            self._model,
+            usage["promptTokens"],
+            usage["completionTokens"],
+            reserved=reserved,
+        )
+
+    def admit_call(
+        self,
+        *,
+        estimated_call_usd: float = 0.0,
+        admit: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Pre-call admission for Retell's inbound-call webhook, wrapping
+        :func:`floe_guard.gates.retell`. On budget exhaustion returns
+        ``{"call_inbound": {"reject": True}}``; otherwise ``{"call_inbound": {...}}``
+        carrying any ``admit`` overrides (``dynamic_variables``, ``metadata``,
+        ``override_agent_id``, …).
+
+        A coarse, non-binding preflight — the binding hard-stop is the per-turn
+        reserve in :meth:`begin_turn`. Pass ``estimated_call_usd`` (e.g.
+        ``$/min × expected minutes``) to reject earlier, when the remaining
+        budget can't cover the call.
+        """
+        return retell_gate(
+            self._guard, estimated_call_usd=estimated_call_usd, admit=admit
+        )
+
+    def response(
+        self,
+        response_id: int,
+        content: str,
+        *,
+        complete: bool = False,
+        end_call: bool = False,
+    ) -> dict[str, Any]:
+        """Build a ``response`` event to stream back to Retell.
+
+        Send partials with ``complete=False``, then a final one with
+        ``complete=True``; settle the turn's token usage after that final one.
+        Pass ``end_call=True`` to hang up (e.g. on a budget wrap-up line). A
+        thin convenience — you may build the shape yourself.
+        """
+        event: dict[str, Any] = {
+            "response_type": "response",
+            "response_id": response_id,
+            "content": content,
+            "content_complete": complete,
+        }
+        if end_call:
+            event["end_call"] = True
+        return event
+
+    def meter_stt(self, seconds: float) -> float | None:
+        """Accrue STT spend for ``seconds`` of transcribed audio (per-second).
+
+        The socket never sees the STT leg, so drive this from wherever the
+        duration is known. Priced from the voice map when ``stt_model`` is set,
+        or the ``stt_usd_per_second`` override; returns ``None`` (no-op) when
+        the leg is unconfigured, and fails closed on a vendor the voice map
+        cannot price. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "stt", seconds, model=self._stt_model, override=self._stt_usd_per_second
+        )
+        if cost is not None:
+            self._guard.record_tool("retell-stt", cost)
+        return cost
+
+    def meter_tts(self, characters: float) -> float | None:
+        """Accrue TTS spend for ``characters`` of synthesized speech
+        (per-1k-chars). Priced from the voice map when ``tts_model`` is set, or
+        the ``tts_usd_per_1k_chars`` override; returns ``None`` when
+        unconfigured, and fails closed on an unpriceable vendor.
+        """
+        cost = price_voice_leg(
+            "tts", characters, model=self._tts_model, override=self._tts_usd_per_1k_chars
+        )
+        if cost is not None:
+            self._guard.record_tool("retell-tts", cost)
+        return cost
+
+    def meter_telephony(self, minutes: float) -> float | None:
+        """Accrue telephony spend for ``minutes`` of call time (per-minute).
+
+        **Per-minute accrual, not live line-cutting**: the guard meters the leg,
+        it does not cut the phone line mid-call. Priced from the voice map when
+        ``telephony`` is set, or the ``telephony_usd_per_minute`` override;
+        returns ``None`` when unconfigured, and fails closed on an unpriceable
+        vendor. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "telephony", minutes, model=self._telephony, override=self._telephony_usd_per_minute
+        )
+        if cost is not None:
+            self._guard.record_tool("retell-telephony", cost)
+        return cost
+
+    def close(self) -> None:
+        """Release any still-open turn's reservation on call teardown (socket
+        close, call ended). A turn that never reached ``content_complete`` would
+        otherwise leak its hold and shrink ``remaining_usd`` permanently."""
+        for slot in self._slots.values():
+            if slot.open:
+                self._guard.release(slot.amount)
+        self._slots.clear()
+        self._active_response_id = None
+
+    def _release_active(self, except_id: int) -> None:
+        """Release the active open turn's hold unless it is ``except_id`` (the
+        incoming turn)."""
+        active_id = self._active_response_id
+        if active_id is None or active_id == except_id:
+            return
+        slot = self._slots.get(active_id)
+        if slot is not None and slot.open:
+            self._guard.release(slot.amount)
+            slot.open = False
+            self._slots.pop(active_id, None)
+        self._active_response_id = None
+
+
+__all__ = ["RetellBudgetGuard", "RetellTurnDecision"]

--- a/src/floe_guard/integrations/vapi.py
+++ b/src/floe_guard/integrations/vapi.py
@@ -86,7 +86,7 @@ from __future__ import annotations
 import inspect
 import logging
 import math
-from collections.abc import AsyncIterable, Awaitable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from typing import Any, TypeVar
 
 from ..errors import BudgetExceeded, FloeGuardError
@@ -114,16 +114,23 @@ class VapiUsageMissingError(FloeGuardError):
     def __init__(self, model: str) -> None:
         self.model = model
         super().__init__(
-            f"Vapi custom-LLM stream for model {model!r} ended with no token usage "
-            f"to settle against. OpenAI-style SSE only includes usage when the "
-            f"upstream request sets stream_options:{{ 'include_usage': True }} — "
-            f"set it, or the guard cannot meter the turn (it refuses rather than "
-            f"accrue a silent $0)."
+            f"Vapi custom-LLM result for model {model!r} contained no token usage "
+            f"to settle against. For streaming OpenAI-style SSE, set "
+            f"stream_options:{{'include_usage': True}}; for non-streaming calls, "
+            f"ensure the completion includes its usage block. The guard refuses "
+            f"rather than accruing a silent $0."
         )
 
 
 def _finite_number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+    """A finite, non-negative integer token count (``True`` counts as invalid)."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+        and (isinstance(value, int) or float(value).is_integer())
+    )
 
 
 def read_usage(usage: Any) -> tuple[int, int] | None:
@@ -153,7 +160,7 @@ def _completion_usage(completion: Any) -> Any:
     return getattr(completion, "usage", None)
 
 
-class _GuardedStream:
+class _GuardedStream(AsyncGenerator[Any, None]):
     """Async-iterator wrapper that owns a guarded generator's reservation.
 
     A generator's ``finally`` cannot run before the generator is started —
@@ -169,10 +176,10 @@ class _GuardedStream:
 
     def __init__(
         self,
-        gen: AsyncIterable[Any],
+        gen: AsyncGenerator[Any, None],
         release: Callable[[], None],
     ) -> None:
-        self._gen = gen
+        self._gen: AsyncGenerator[Any, None] | None = gen
         self._release = release
         self._started = False
 
@@ -183,13 +190,44 @@ class _GuardedStream:
         gen = self._gen
         if gen is None:
             raise StopAsyncIteration
+        self._started = True
         try:
             item = await gen.__anext__()
         except StopAsyncIteration:
             self._gen = None
             raise
-        self._started = True
+        except BaseException:
+            self._gen = None
+            raise
         return item
+
+    async def asend(self, value: Any) -> Any:
+        gen = self._gen
+        if gen is None:
+            raise StopAsyncIteration
+        self._started = True
+        try:
+            return await gen.asend(value)
+        except StopAsyncIteration:
+            self._gen = None
+            raise
+        except BaseException:
+            self._gen = None
+            raise
+
+    async def athrow(self, *args: Any, **kwargs: Any) -> Any:
+        gen = self._gen
+        if gen is None:
+            raise StopAsyncIteration
+        self._started = True
+        try:
+            return await gen.athrow(*args, **kwargs)
+        except StopAsyncIteration:
+            self._gen = None
+            raise
+        except BaseException:
+            self._gen = None
+            raise
 
     async def aclose(self) -> None:
         gen, self._gen = self._gen, None
@@ -197,10 +235,18 @@ class _GuardedStream:
             return
         if not self._started:
             self._release()
-        # Started: delegate so the generator's own finally runs (it settles or
-        # releases). Unstarted: closing the bare generator is a no-op after the
-        # eager release above.
         await gen.aclose()
+
+    def __del__(self) -> None:
+        try:
+            started = getattr(self, "_started", True)
+            gen = getattr(self, "_gen", None)
+            if not started and gen is not None:
+                release = getattr(self, "_release", None)
+                if release is not None:
+                    release()
+        except Exception:
+            pass
 
 
 class VapiBudgetGuard:
@@ -327,7 +373,7 @@ class VapiBudgetGuard:
         *,
         model: str | None = None,
         estimated_cost: float | None = None,
-    ) -> AsyncIterable[Any]:
+    ) -> _GuardedStream:
         """Guard a **streaming** model turn: reserve, then wrap the SSE chunk
         stream so it settles on the final chunk's ``usage``, releasing the hold
         on error or early abort.
@@ -375,7 +421,7 @@ class VapiBudgetGuard:
         run: Callable[[], AsyncIterable[Any] | Awaitable[AsyncIterable[Any]]],
         model: str,
         reserved: ReservationHandle,
-    ) -> AsyncIterable[Any]:
+    ) -> AsyncGenerator[Any, None]:
         usage: tuple[int, int] | None = None
         settled = False
         try:

--- a/src/floe_guard/integrations/vapi.py
+++ b/src/floe_guard/integrations/vapi.py
@@ -1,0 +1,420 @@
+"""Vapi custom-LLM adapter (framework-free — no Vapi or OpenAI SDK dependency).
+
+Vapi's **custom-LLM** feature points Vapi's model leg at YOUR OpenAI-compatible
+``POST /chat/completions`` endpoint (docs.vapi.ai/customization/custom-llm/using-your-server).
+Vapi sends an OpenAI-format request (``{ model, messages, temperature, tools?,
+stream }``); your endpoint proxies it to an upstream LLM and returns an
+OpenAI-compatible completion — a single JSON object, or an SSE stream of chunks.
+
+Like the LiveKit/Pipecat adapters, a Vapi call has no single wrap point that
+sees every cost: the custom-LLM proxy only sees the **model leg**. So this
+adapter has three jobs, and only the first is automatic:
+
+1. **Guard the model turn** — :meth:`VapiBudgetGuard.guard_completion` (JSON)
+   and :meth:`VapiBudgetGuard.guard_stream` (SSE) reserve the estimated cost
+   BEFORE the upstream call, meter the **real** ``usage`` after, and release the
+   hold on error/abort. Reserving first is what refuses a turn before its spend
+   lands: an over-budget turn raises :class:`~floe_guard.errors.BudgetExceeded`
+   instead of being proxied.
+2. **Admit the call** — :meth:`VapiBudgetGuard.assistant_request` answers
+   Vapi's ``assistant-request`` webhook from the remaining budget (exhausted →
+   a spoken error; else hands back ``assistant``/``assistantId``), delegating to
+   :func:`floe_guard.gates.vapi`.
+3. **Meter the other legs** — the proxy never sees STT/TTS/telephony, so
+   :meth:`VapiBudgetGuard.meter_stt` / :meth:`VapiBudgetGuard.meter_tts` /
+   :meth:`VapiBudgetGuard.meter_telephony` accrue them explicitly, priced from
+   the bundled voice cost map or a per-unit override.
+
+    from floe_guard import BudgetGuard
+    from floe_guard.errors import BudgetExceeded
+    from floe_guard.integrations.vapi import VapiBudgetGuard
+
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = VapiBudgetGuard(
+        guard,
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+
+    # POST /chat/completions — the custom-LLM endpoint Vapi calls each turn.
+    @app.post("/chat/completions")
+    async def chat_completions(request: Request):
+        body = await request.json()
+        model, messages, tools = body["model"], body["messages"], body.get("tools")
+        try:
+            if body.get("stream"):
+                # Upstream MUST set stream_options:{"include_usage": True} — below.
+                stream = budget.guard_stream(
+                    lambda: openai_client.chat.completions.create(
+                        model=model, messages=messages, tools=tools,
+                        stream=True, stream_options={"include_usage": True},
+                    ),
+                    model=model,
+                )
+                return sse_response(stream)  # pipe chunks straight through
+            completion = await budget.guard_completion(
+                lambda: openai_client.chat.completions.create(
+                    model=model, messages=messages, tools=tools,
+                ),
+                model=model,
+            )
+            return JSONResponse(content=completion)
+        except BudgetExceeded as exc:
+            return JSONResponse(status_code=402, content={"error": str(exc)})
+
+## The streaming usage requirement (read this)
+
+OpenAI-style SSE omits ``usage`` from every chunk **unless** the caller sets
+``stream_options: { "include_usage": True }`` on the upstream request — with it,
+a final chunk (empty ``choices``) carries the token ``usage``. This adapter
+meters the model turn from that real ``usage``; if a stream ends with no usage
+anywhere, :meth:`VapiBudgetGuard.guard_stream` **fails loudly**
+(:class:`VapiUsageMissingError`) and releases the hold rather than silently
+metering the turn at $0. Set ``include_usage: True`` on your upstream streaming
+call. Aborting a stream early (an ``aclose()``, or the task cancellation a
+framework raises on client disconnect) runs the generator's ``finally``, which
+releases the hold; nothing is metered for an aborted turn.
+
+Scope is strictly **pre-call admission plus per-turn settlement**. There is no
+mid-call intervention: an admitted turn runs to completion; nothing here cuts a
+turn — or a stream — off partway.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import math
+from collections.abc import AsyncIterable, Awaitable, Callable
+from typing import Any, TypeVar
+
+from ..errors import BudgetExceeded, FloeGuardError
+from ..gates import vapi as vapi_gate
+from ..guard import BudgetGuard, ReservationHandle
+from ..voice_pricing import price_voice_leg
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+C = TypeVar("C")
+
+
+class VapiUsageMissingError(FloeGuardError):
+    """Raised when a guarded stream (or usage-less completion) has nothing to settle.
+
+    Almost always the fix is ``stream_options: { "include_usage": True }`` on the
+    upstream streaming request (OpenAI omits ``usage`` from SSE without it). We
+    refuse rather than meter the turn at $0 — "we cannot cap what we cannot
+    measure". Extends :class:`~floe_guard.errors.FloeGuardError` so it is caught
+    by the same family as the priced errors; it is adapter-local (not part of the
+    shared ``errors.py`` cross-language family, mirroring ``js/src/adapters/vapi.ts``).
+    """
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        super().__init__(
+            f"Vapi custom-LLM stream for model {model!r} ended with no token usage "
+            f"to settle against. OpenAI-style SSE only includes usage when the "
+            f"upstream request sets stream_options:{{ 'include_usage': True }} — "
+            f"set it, or the guard cannot meter the turn (it refuses rather than "
+            f"accrue a silent $0)."
+        )
+
+
+def _finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def read_usage(usage: Any) -> tuple[int, int] | None:
+    """Read an OpenAI ``usage`` block into settled prompt/completion counts.
+
+    ``usage`` is the OpenAI wire format Vapi speaks (``prompt_tokens`` /
+    ``completion_tokens``), accepted as a dict or any object exposing both
+    attributes. Returns ``None`` when absent/malformed — both fields must be
+    finite numbers, so a partial or non-numeric usage is treated as no usage
+    (fail-closed), never coerced to 0.
+    """
+    if isinstance(usage, dict):
+        prompt = usage.get("prompt_tokens")
+        completion = usage.get("completion_tokens")
+    else:
+        prompt = getattr(usage, "prompt_tokens", None)
+        completion = getattr(usage, "completion_tokens", None)
+    if not _finite_number(prompt) or not _finite_number(completion):
+        return None
+    return int(prompt), int(completion)
+
+
+def _completion_usage(completion: Any) -> Any:
+    """The ``usage`` on a completion-like — dict key or attribute, either way."""
+    if isinstance(completion, dict):
+        return completion.get("usage")
+    return getattr(completion, "usage", None)
+
+
+class VapiBudgetGuard:
+    """Enforce a BudgetGuard ceiling on a Vapi custom-LLM endpoint: reserve
+    before the model turn, settle on the real OpenAI ``usage``, release on
+    error/abort, and meter the STT/TTS/telephony legs the proxy never sees.
+
+    Args:
+        guard: the BudgetGuard to enforce.
+        model: default model id to settle LLM cost against when a per-call
+            ``model`` is not passed to :meth:`guard_completion` /
+            :meth:`guard_stream`. Vapi's request carries the model, so passing it
+            per-call is usual; this is the fallback. Must be priceable via the
+            bundled cost map or the guard's ``price_overrides``.
+        stt_model: voice-map vendor key for the STT leg (e.g.
+            ``"deepgram-nova-3"``), metered per second via :meth:`meter_stt`.
+        tts_model: voice-map vendor key for the TTS leg (e.g.
+            ``"elevenlabs-flash-v2.5"``), metered per 1k chars via
+            :meth:`meter_tts`.
+        telephony: voice-map vendor key for the telephony leg (e.g.
+            ``"twilio-us-inbound-local"``), metered per minute via
+            :meth:`meter_telephony`. US-only in v1.
+        stt_usd_per_second: per-second STT override — wins over ``stt_model``.
+            Omit both to leave STT un-metered.
+        tts_usd_per_1k_chars: per-1k-chars TTS override — wins over
+            ``tts_model``. Omit both to leave TTS un-metered.
+        telephony_usd_per_minute: per-minute telephony override — wins over
+            ``telephony``.
+    """
+
+    def __init__(
+        self,
+        guard: BudgetGuard,
+        *,
+        model: str | None = None,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        telephony: str | None = None,
+        stt_usd_per_second: float | None = None,
+        tts_usd_per_1k_chars: float | None = None,
+        telephony_usd_per_minute: float | None = None,
+    ):
+        self._guard = guard
+        self._model = model
+        self._stt_model = stt_model
+        self._tts_model = tts_model
+        self._telephony = telephony
+        self._stt_usd_per_second = stt_usd_per_second
+        self._tts_usd_per_1k_chars = tts_usd_per_1k_chars
+        self._telephony_usd_per_minute = telephony_usd_per_minute
+
+    def assistant_request(
+        self,
+        *,
+        assistant: dict[str, Any] | None = None,
+        assistant_id: str | None = None,
+        error_message: str = "Sorry, this agent is out of budget right now.",
+        estimated_call_usd: float = 0.0,
+    ) -> dict[str, Any]:
+        """Answer Vapi's ``assistant-request`` webhook from the remaining budget.
+
+        Budget exhausted → ``{"error": error_message}`` (Vapi speaks it, then
+        ends the call); otherwise admits with ``{"assistantId": assistant_id}``
+        (precedence) or ``{"assistant": assistant}``. A thin wrapper over
+        :func:`floe_guard.gates.vapi` — the same webhook contract the hosted
+        gateway serves, so the paid upgrade is a URL swap, not a rewrite.
+        Respond within ~7.5 s.
+
+        This is coarse, non-binding pre-call admission (a budget read, no
+        reservation); the binding hard-stop is the per-turn reserve in
+        :meth:`guard_completion` / :meth:`guard_stream`. Pass
+        ``estimated_call_usd`` (e.g. ``$/min × expected minutes``) to reject
+        earlier, when the remaining budget can't cover the call.
+
+        Raises:
+            ValueError: admitted but neither ``assistant`` nor ``assistant_id``
+                was given — there'd be nothing to hand Vapi (surfaced by
+                :func:`floe_guard.gates.vapi`).
+        """
+        return vapi_gate(
+            self._guard,
+            assistant=assistant,
+            assistant_id=assistant_id,
+            error_message=error_message,
+            estimated_call_usd=estimated_call_usd,
+        )
+
+    async def guard_completion(
+        self,
+        run: Callable[[], T | Awaitable[T]],
+        *,
+        model: str | None = None,
+        estimated_cost: float | None = None,
+    ) -> T:
+        """Guard a **non-streaming** model turn: reserve, run the upstream
+        completion, settle on its real ``usage``, release the hold on error.
+
+        Reserving first raises :class:`~floe_guard.errors.BudgetExceeded`
+        BEFORE ``run`` is called when the turn would cross the ceiling, so an
+        over-budget turn never reaches the upstream LLM. The completion is
+        returned untouched for the handler to forward to Vapi. A completion with
+        no ``usage`` fails loudly (:class:`VapiUsageMissingError`) and releases
+        the hold rather than metering $0.
+        """
+        resolved = self._resolve_model(model)
+        reserved = self._guard.reserve(estimated_cost)
+        try:
+            result = run()
+            if inspect.isawaitable(result):
+                result = await result
+        except BaseException:
+            self._guard.release(reserved)
+            raise
+        usage = read_usage(_completion_usage(result))
+        if usage is None:
+            self._guard.release(reserved)
+            raise VapiUsageMissingError(resolved)
+        self._guard.settle(resolved, usage[0], usage[1], reserved=reserved)
+        return result
+
+    def guard_stream(
+        self,
+        run: Callable[[], AsyncIterable[Any] | Awaitable[AsyncIterable[Any]]],
+        *,
+        model: str | None = None,
+        estimated_cost: float | None = None,
+    ) -> AsyncIterable[Any]:
+        """Guard a **streaming** model turn: reserve, then wrap the SSE chunk
+        stream so it settles on the final chunk's ``usage``, releasing the hold
+        on error or early abort.
+
+        Reserving first raises
+        :class:`~floe_guard.errors.BudgetExceeded` BEFORE the stream is opened
+        when the turn would cross the ceiling (this method raises synchronously —
+        the handler learns immediately, before piping anything to Vapi). Chunks
+        pass through untouched; the returned async iterable is what you forward
+        to the SSE response.
+
+        **Usage requirement:** OpenAI SSE only carries ``usage`` when the
+        upstream request set ``stream_options: { "include_usage": True }``. A
+        stream that ends with no usage anywhere fails loudly
+        (:class:`VapiUsageMissingError`) and releases the hold — it is not
+        metered at $0.
+
+        **Aborting a stream early** (client disconnect, interrupt) releases
+        the hold from the generator's ``finally``, and nothing is metered for
+        an aborted turn. The unwinding is triggered by ``aclose()``: an
+        explicit ``await stream.aclose()``, a task cancellation raised into
+        the consuming generator (what HTTP/WS frameworks do on disconnect),
+        or garbage collection. A bare ``break`` in an ``async for`` drops the
+        reference and finalizes the generator on a later loop iteration —
+        close it explicitly when the hold must clear immediately.
+
+        The returned iterable holds the reservation until it is consumed to
+        completion, or closed/aborted — pipe it straight to the response so
+        the hold cannot leak.
+        """
+        resolved = self._resolve_model(model)
+        # Eager reserve (outside the generator) so a block raises synchronously
+        # here, not lazily on first pull — the handler refuses the turn before
+        # streaming.
+        reserved = self._guard.reserve(estimated_cost)
+        return self._iterate_stream(run, resolved, reserved)
+
+    async def _iterate_stream(
+        self,
+        run: Callable[[], AsyncIterable[Any] | Awaitable[AsyncIterable[Any]]],
+        model: str,
+        reserved: ReservationHandle,
+    ) -> AsyncIterable[Any]:
+        usage: tuple[int, int] | None = None
+        settled = False
+        try:
+            stream = run()
+            if inspect.isawaitable(stream):
+                stream = await stream
+            async for chunk in stream:
+                # Last non-null usage wins — the final (empty-choices) chunk
+                # carries it.
+                current = read_usage(_completion_usage(chunk))
+                if current is not None:
+                    usage = current
+                yield chunk
+            # Clean end: settle on real usage, or fail loudly if none was seen.
+            if usage is None:
+                raise VapiUsageMissingError(model)
+            # Mark settled BEFORE the call: guard.settle owns the reservation on
+            # every exit — it releases the hold on its own failure paths
+            # (unpriceable model, price_tokens error) before raising — so the
+            # finally must not release it a second time (a double release drives
+            # `reserved` negative and weakens the ceiling for other in-flight
+            # turns).
+            settled = True
+            self._guard.settle(model, usage[0], usage[1], reserved=reserved)
+        finally:
+            # Any exit before settle — error mid-stream, missing usage, or an
+            # early consumer abort (async-for break → generator aclose()) —
+            # frees the hold.
+            if not settled:
+                self._guard.release(reserved)
+
+    def meter_stt(self, seconds: float) -> float | None:
+        """Accrue STT spend for ``seconds`` of transcribed audio (per second).
+
+        The custom-LLM proxy sees only the model leg, so the caller drives this
+        (and :meth:`meter_tts` / :meth:`meter_telephony`) explicitly — from
+        Vapi's ``end-of-call-report`` webhook, or as the call accrues. Priced
+        from the voice map when ``stt_model`` is set, or the
+        ``stt_usd_per_second`` override; returns ``None`` (no-op) when the leg
+        is unconfigured, and fails closed
+        (:class:`~floe_guard.errors.UnpriceableVoiceError`) on a vendor the
+        voice map cannot price. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "stt", seconds, model=self._stt_model, override=self._stt_usd_per_second
+        )
+        if cost is not None:
+            self._guard.record_tool("vapi-stt", cost)
+        return cost
+
+    def meter_tts(self, characters: float) -> float | None:
+        """Accrue TTS spend for ``characters`` of synthesized speech (per 1k chars).
+
+        Priced from the voice map when ``tts_model`` is set, or the
+        ``tts_usd_per_1k_chars`` override; returns ``None`` when unconfigured,
+        and fails closed on an unpriceable vendor. See :meth:`meter_telephony`.
+        """
+        cost = price_voice_leg(
+            "tts", characters, model=self._tts_model, override=self._tts_usd_per_1k_chars
+        )
+        if cost is not None:
+            self._guard.record_tool("vapi-tts", cost)
+        return cost
+
+    def meter_telephony(self, minutes: float) -> float | None:
+        """Accrue telephony spend for ``minutes`` of call time (per minute).
+
+        **Per-minute accrual, not live line-cutting**: the guard meters the leg,
+        it does not cut the call mid-turn. Priced from the voice map when
+        ``telephony`` is set, or the ``telephony_usd_per_minute`` override;
+        returns ``None`` (no-op) when the leg is unconfigured, and fails closed
+        on a vendor the voice map cannot price. Returns the USD accrued, if any.
+        """
+        cost = price_voice_leg(
+            "telephony", minutes, model=self._telephony, override=self._telephony_usd_per_minute
+        )
+        if cost is not None:
+            self._guard.record_tool("vapi-telephony", cost)
+        return cost
+
+    def _resolve_model(self, override: str | None) -> str:
+        """The model to settle against: the per-call override (Vapi's request
+        model) or the constructor default. Fails loudly if neither is set — the
+        guard cannot price a turn it cannot name."""
+        model = override or self._model
+        if not model:
+            raise ValueError(
+                "no model to settle the Vapi turn against: pass model= to "
+                "guard_completion/guard_stream (Vapi's request model), or set "
+                "`model` on the VapiBudgetGuard constructor."
+            )
+        return model
+
+
+# BudgetExceeded re-exported so a handler can `except BudgetExceeded` using the
+# adapter import path alone, matching the TS `export { BudgetExceeded }`.
+__all__ = ["VapiBudgetGuard", "VapiUsageMissingError", "BudgetExceeded"]

--- a/src/floe_guard/integrations/vapi.py
+++ b/src/floe_guard/integrations/vapi.py
@@ -153,6 +153,56 @@ def _completion_usage(completion: Any) -> Any:
     return getattr(completion, "usage", None)
 
 
+class _GuardedStream:
+    """Async-iterator wrapper that owns a guarded generator's reservation.
+
+    A generator's ``finally`` cannot run before the generator is started —
+    ``aclose()`` on an unstarted generator raises ``GeneratorExit`` at the
+    function's first byte, not at the ``try`` (so an unconsumed guarded stream
+    would silently leak its reservation). The wrapper closes that gap: closing
+    it before any iteration releases the hold eagerly and deterministically.
+    After the generator starts, behaviour is unchanged — the generator's own
+    ``finally`` settles or releases exactly once on completion, error, or abort.
+    """
+
+    __slots__ = ("_gen", "_release", "_started")
+
+    def __init__(
+        self,
+        gen: AsyncIterable[Any],
+        release: Callable[[], None],
+    ) -> None:
+        self._gen = gen
+        self._release = release
+        self._started = False
+
+    def __aiter__(self) -> _GuardedStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        gen = self._gen
+        if gen is None:
+            raise StopAsyncIteration
+        try:
+            item = await gen.__anext__()
+        except StopAsyncIteration:
+            self._gen = None
+            raise
+        self._started = True
+        return item
+
+    async def aclose(self) -> None:
+        gen, self._gen = self._gen, None
+        if gen is None:
+            return
+        if not self._started:
+            self._release()
+        # Started: delegate so the generator's own finally runs (it settles or
+        # releases). Unstarted: closing the bare generator is a no-op after the
+        # eager release above.
+        await gen.aclose()
+
+
 class VapiBudgetGuard:
     """Enforce a BudgetGuard ceiling on a Vapi custom-LLM endpoint: reserve
     before the model turn, settle on the real OpenAI ``usage``, release on
@@ -300,20 +350,25 @@ class VapiBudgetGuard:
         an aborted turn. The unwinding is triggered by ``aclose()``: an
         explicit ``await stream.aclose()``, a task cancellation raised into
         the consuming generator (what HTTP/WS frameworks do on disconnect),
-        or garbage collection. A bare ``break`` in an ``async for`` drops the
-        reference and finalizes the generator on a later loop iteration —
+        or garbage collection of the wrapper. A bare ``break`` in an ``async
+        for`` drops the reference and finalizes on a later loop iteration —
         close it explicitly when the hold must clear immediately.
 
         The returned iterable holds the reservation until it is consumed to
-        completion, or closed/aborted — pipe it straight to the response so
-        the hold cannot leak.
+        completion (settled), or closed/aborted (released). Closing it before
+        it is ever consumed also releases the hold — a generator's ``finally``
+        cannot run before its first pull, so the returned wrapper (not the raw
+        generator) owns that path — pipe it straight to the response.
         """
         resolved = self._resolve_model(model)
         # Eager reserve (outside the generator) so a block raises synchronously
         # here, not lazily on first pull — the handler refuses the turn before
         # streaming.
         reserved = self._guard.reserve(estimated_cost)
-        return self._iterate_stream(run, resolved, reserved)
+        return _GuardedStream(
+            self._iterate_stream(run, resolved, reserved),
+            release=lambda: self._guard.release(reserved),
+        )
 
     async def _iterate_stream(
         self,

--- a/tests/test_retell_adapter.py
+++ b/tests/test_retell_adapter.py
@@ -267,6 +267,10 @@ def test_settle_turn_refuses_malformed_usage_payload() -> None:
         budget.settle_turn(1, {"promptTokens": 10, "completionTokens": None})
     with pytest.raises(ValueError, match="promptTokens"):
         budget.settle_turn(1, {"promptTokens": "lots", "completionTokens": 5})
+    with pytest.raises(ValueError, match="promptTokens"):
+        budget.settle_turn(1, {"promptTokens": -10, "completionTokens": 5})
+    with pytest.raises(ValueError, match="completionTokens"):
+        budget.settle_turn(1, {"promptTokens": 10, "completionTokens": 5.5})
     assert guard.advisory().spent_usd == 0.0  # nothing settled at a guessed cost
 
 

--- a/tests/test_retell_adapter.py
+++ b/tests/test_retell_adapter.py
@@ -1,0 +1,241 @@
+"""RetellBudgetGuard — reserve when a `response_required` arrives, settle on real
+token usage after `content_complete`, release when a newer `response_id`
+interrupts, and price STT/TTS/telephony legs via the voice cost map.
+
+Fake Retell interaction events drive the adapter — no `ws` server, no Retell SDK,
+no network, no keys. Everything is a plain parsed-message dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard import BudgetGuard, ManualPrice, gates
+from floe_guard.errors import BudgetExceeded, UnpriceableVoiceError
+from floe_guard.integrations.retell import RetellBudgetGuard
+from floe_guard.voice_pricing import price_voice_leg
+
+PRICE = ManualPrice(1e-6, 2e-6)
+
+
+def response_required(response_id: int) -> dict:
+    """A `response_required` interaction event, as Retell delivers it over the WS."""
+    return {
+        "interaction_type": "response_required",
+        "response_id": response_id,
+        "transcript": [{"role": "user", "content": "hi"}],
+    }
+
+
+def _guard(**overrides) -> BudgetGuard:
+    return BudgetGuard(limit_usd=1.00, price_overrides={"m": PRICE, **overrides})
+
+
+# ── reserve before the LLM turn ────────────────────────────────────────────────
+
+
+def test_blocks_over_budget_turn() -> None:
+    guard = _guard()
+    guard.record_tool("prior", 1.0)  # spend the ceiling
+    budget = RetellBudgetGuard(guard, model="m")
+
+    decision = budget.begin_turn(response_required(1))
+    assert decision.admitted is False
+    assert decision.response_id == 1
+    assert isinstance(decision.error, BudgetExceeded)
+
+
+def test_admits_under_budget_turn() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    decision = budget.begin_turn(response_required(1))
+    assert decision.admitted is True
+    assert decision.response_id == 1
+    assert decision.error is None
+
+
+def test_begin_turn_is_idempotent_for_a_still_open_turn() -> None:
+    # Calling twice with the same still-open response_id must not double-hold.
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    assert budget.begin_turn(response_required(7)).admitted is True
+    assert budget.begin_turn(response_required(7)).admitted is True
+    assert len(budget._slots) == 1
+    # Only one reservation held: the default (zero) estimate for the first turn.
+    assert guard._reserved == pytest.approx(0.0)
+
+
+# ── settle on real usage ───────────────────────────────────────────────────────
+
+
+def test_settles_priced_cost_and_frees_the_hold() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    budget.begin_turn(response_required(1))
+    budget.settle_turn(1, {"promptTokens": 1000, "completionTokens": 500})
+
+    # 1000 * 1e-6 + 500 * 2e-6 = 0.002
+    assert guard.advisory().spent_usd == pytest.approx(0.002)
+    # Reservation consumed (not leaked): remaining == limit - spent, no hold slice.
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)
+    assert len(guard.spend_log) == 1
+    assert guard.spend_log[0].model_or_tool == "m"
+
+
+def test_settles_a_turn_never_begun_as_plain_record() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    budget.settle_turn(99, {"promptTokens": 1000, "completionTokens": 0})
+    assert guard.advisory().spent_usd == pytest.approx(0.001)
+
+
+# ── release on interrupt ───────────────────────────────────────────────────────
+
+
+def test_newer_response_id_releases_prior_open_turn() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    # Turn 1: settle so the guard's next-call estimate becomes non-zero (0.002),
+    # making the following turn's reservation observable in remaining_usd.
+    budget.begin_turn(response_required(1))
+    budget.settle_turn(1, {"promptTokens": 1000, "completionTokens": 500})
+    after_turn1 = guard.remaining_usd  # 1.0 - 0.002
+
+    # Turn 2: reserves the 0.002 estimate — remaining drops.
+    budget.begin_turn(response_required(2))
+    assert guard.remaining_usd == pytest.approx(after_turn1 - 0.002)
+
+    # Turn 3 (higher response_id) arrives before turn 2 settles — turn 2 is
+    # interrupted and its hold released. Turn 3 then holds its own 0.002.
+    budget.begin_turn(response_required(3))
+    assert guard.remaining_usd == pytest.approx(after_turn1 - 0.002)  # only turn 3 held
+    assert guard.advisory().spent_usd == pytest.approx(0.002)  # interrupt accrued nothing
+
+
+def test_close_releases_still_open_turn() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    budget.begin_turn(response_required(1))
+    budget.settle_turn(1, {"promptTokens": 1000, "completionTokens": 500})
+    after_turn1 = guard.remaining_usd
+
+    budget.begin_turn(response_required(2))  # holds 0.002, never settles
+    assert guard.remaining_usd == pytest.approx(after_turn1 - 0.002)
+
+    budget.close()
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+def test_interrupted_turn_settled_late_accrues_without_stealing_a_hold() -> None:
+    # Turn 1 is interrupted by turn 2; turn 1's real usage then arrives late.
+    # It must record actual usage against a zero reservation (not turn 2's hold).
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    budget.begin_turn(response_required(1))
+    budget.begin_turn(response_required(2))  # interrupts turn 1, releases its hold
+
+    assert guard.remaining_usd == pytest.approx(1.0)  # both holds released
+
+    # Turn 2 settles normally — consumes its own hold.
+    budget.settle_turn(2, {"promptTokens": 0, "completionTokens": 250})
+    # Turn 1's late usage settles as a plain record (no open slot).
+    budget.settle_turn(1, {"promptTokens": 1000, "completionTokens": 500})
+    assert guard.advisory().spent_usd == pytest.approx(0.002 + 250 * 2e-6)
+    assert guard.remaining_usd == pytest.approx(1.0 - (0.002 + 250 * 2e-6))
+
+
+# ── pre-call admission via gates.retell ────────────────────────────────────────
+
+
+def test_admit_call_matches_gates_retell() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = RetellBudgetGuard(guard, model="m")
+
+    admit = budget.admit_call(admit={"metadata": {"plan": "free"}})
+    assert admit == gates.retell(guard, admit={"metadata": {"plan": "free"}})
+    assert "reject" not in admit["call_inbound"]
+
+    guard.record_tool("prior", 1.0)  # spend the ceiling
+    assert budget.admit_call() == {"call_inbound": {"reject": True}}
+
+
+# ── voice legs price via the cost map ──────────────────────────────────────────
+
+
+def test_meters_stt_tts_telephony_from_named_vendors() -> None:
+    guard = BudgetGuard(limit_usd=10.00, price_overrides={"m": PRICE})
+    budget = RetellBudgetGuard(
+        guard,
+        model="m",
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+
+    stt = budget.meter_stt(30)  # 30s
+    tts = budget.meter_tts(1_200)  # 1.2k chars
+    tel = budget.meter_telephony(2.5)  # 2.5 min
+
+    assert stt == pytest.approx(price_voice_leg("stt", 30, model="deepgram-nova-3"))
+    assert tts == pytest.approx(price_voice_leg("tts", 1_200, model="elevenlabs-flash-v2.5"))
+    assert tel == pytest.approx(
+        price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local")
+    )
+    assert guard.tool_costs["retell-stt"] == pytest.approx(stt)
+    assert guard.tool_costs["retell-tts"] == pytest.approx(tts)
+    assert guard.tool_costs["retell-telephony"] == pytest.approx(tel)
+
+
+def test_unconfigured_leg_is_unmetered() -> None:
+    guard = BudgetGuard(limit_usd=10.00, price_overrides={"m": PRICE})
+    budget = RetellBudgetGuard(guard, model="m")
+
+    assert budget.meter_stt(30) is None
+    assert budget.meter_tts(30) is None
+    assert budget.meter_telephony(30) is None
+    assert "retell-stt" not in guard.tool_costs
+    assert guard.advisory().spent_usd == 0.0
+
+
+@pytest.mark.parametrize(
+    "leg,mode",
+    [
+        ("stt_model", "stt"),
+        ("tts_model", "tts"),
+        ("telephony", "telephony"),
+    ],
+)
+def test_fails_closed_on_unpriceable_vendor(leg: str, mode: str) -> None:
+    guard = BudgetGuard(limit_usd=10.00, price_overrides={"m": PRICE})
+    budget = RetellBudgetGuard(guard, model="m", **{leg: "no-such-vendor"})
+
+    with pytest.raises(UnpriceableVoiceError):
+        getattr(budget, f"meter_{mode}")(1)
+    assert guard.advisory().spent_usd == 0.0
+
+
+# ── response() event shape ─────────────────────────────────────────────────────
+
+
+def test_response_event_shape() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = RetellBudgetGuard(guard, model="m")
+
+    partial = budget.response(3, "Sure,", complete=False)
+    assert partial == {
+        "response_type": "response",
+        "response_id": 3,
+        "content": "Sure,",
+        "content_complete": False,
+    }
+
+    final = budget.response(3, " one moment!", complete=True, end_call=True)
+    assert final["content_complete"] is True
+    assert final["end_call"] is True

--- a/tests/test_retell_adapter.py
+++ b/tests/test_retell_adapter.py
@@ -237,3 +237,46 @@ def test_response_event_shape() -> None:
     final = budget.response(3, " one moment!", complete=True, end_call=True)
     assert final["content_complete"] is True
     assert final["end_call"] is True
+
+
+# -- fail-closed payloads -------------------------------------------------------
+
+
+def test_begin_turn_requires_an_integer_response_id() -> None:
+    # A malformed event (missing or odd response_id) is refused fail-closed
+    # rather than mis-keying a turn or releasing a live one.
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    with pytest.raises(ValueError, match="response_id"):
+        budget.begin_turn({"interaction_type": "response_required"})  # no response_id
+    with pytest.raises(ValueError, match="response_id"):
+        budget.begin_turn(
+            {"interaction_type": "response_required", "response_id": "1"}
+        )  # not a number
+    assert guard.remaining_usd == pytest.approx(1.0)  # nothing reserved or released
+
+
+def test_settle_turn_refuses_malformed_usage_payload() -> None:
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+
+    with pytest.raises(ValueError, match="promptTokens"):
+        budget.settle_turn(1, {"completionTokens": 5})  # missing promptTokens
+    with pytest.raises(ValueError, match="completionTokens"):
+        budget.settle_turn(1, {"promptTokens": 10, "completionTokens": None})
+    with pytest.raises(ValueError, match="promptTokens"):
+        budget.settle_turn(1, {"promptTokens": "lots", "completionTokens": 5})
+    assert guard.advisory().spent_usd == 0.0  # nothing settled at a guessed cost
+
+
+def test_settle_turn_accepts_attribute_style_usage() -> None:
+    from types import SimpleNamespace
+
+    guard = _guard()
+    budget = RetellBudgetGuard(guard, model="m")
+    budget.begin_turn(response_required(1))
+
+    budget.settle_turn(1, SimpleNamespace(promptTokens=1000, completionTokens=500))
+    assert guard.advisory().spent_usd == pytest.approx(0.002)
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)

--- a/tests/test_retell_adapter.py
+++ b/tests/test_retell_adapter.py
@@ -185,9 +185,7 @@ def test_meters_stt_tts_telephony_from_named_vendors() -> None:
 
     assert stt == pytest.approx(price_voice_leg("stt", 30, model="deepgram-nova-3"))
     assert tts == pytest.approx(price_voice_leg("tts", 1_200, model="elevenlabs-flash-v2.5"))
-    assert tel == pytest.approx(
-        price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local")
-    )
+    assert tel == pytest.approx(price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local"))
     assert guard.tool_costs["retell-stt"] == pytest.approx(stt)
     assert guard.tool_costs["retell-tts"] == pytest.approx(tts)
     assert guard.tool_costs["retell-telephony"] == pytest.approx(tel)

--- a/tests/test_vapi_adapter.py
+++ b/tests/test_vapi_adapter.py
@@ -1,0 +1,335 @@
+"""VapiBudgetGuard — reserve before the model turn, settle on the real OpenAI
+usage, release on error/abort, admit the call via the assistant-request gate,
+and price the STT/TTS/telephony legs the custom-LLM proxy never sees.
+
+Fabricated OpenAI-shaped completions / SSE chunk streams drive the adapter — no
+Vapi SDK, no `openai` runtime, no network, no keys. The adapter is typed
+structurally against the OpenAI wire format Vapi speaks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from floe_guard import BudgetGuard, ManualPrice
+from floe_guard.errors import (
+    BudgetExceeded,
+    UnpriceableModelError,
+    UnpriceableModelWarning,
+    UnpriceableVoiceError,
+)
+from floe_guard.integrations.vapi import VapiBudgetGuard, VapiUsageMissingError
+from floe_guard.voice_pricing import price_voice_leg
+
+PRICE = ManualPrice(1e-6, 2e-6)
+
+
+def completion(prompt_tokens: int, completion_tokens: int) -> dict:
+    """An OpenAI-format non-streaming completion carrying a usage block."""
+    return {
+        "id": "chatcmpl-x",
+        "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+        "usage": {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens},
+    }
+
+
+async def sse_stream(
+    content_chunks: int,
+    usage: dict | None = None,
+) -> AsyncIterator[dict]:
+    """A fake OpenAI SSE stream: content chunks (no usage), then — if `usage` is
+    given — a final empty-choices chunk carrying it, exactly as
+    `stream_options:{include_usage:true}` produces. Omit `usage` to model a
+    stream WITHOUT include_usage."""
+    for _ in range(content_chunks):
+        yield {"choices": [{"delta": {"content": "tok"}}]}
+    if usage is not None:
+        yield {"choices": [], "usage": usage}
+
+
+async def drain_stream(stream) -> int:
+    count = 0
+    async for _ in stream:
+        count += 1
+    return count
+
+
+def _guard(**overrides) -> BudgetGuard:
+    return BudgetGuard(limit_usd=1.00, price_overrides={"m": PRICE, **overrides})
+
+
+async def _prime_estimate(guard: BudgetGuard, budget: VapiBudgetGuard) -> float:
+    """Settle one turn so the guard's next-call estimate becomes non-zero."""
+    await budget.guard_completion(lambda: completion(1000, 500), model="m")
+    return guard.remaining_usd  # 1.0 - 0.002
+
+
+# ── reserve before the model turn ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_blocks_over_budget_non_streaming_turn_before_upstream() -> None:
+    guard = _guard()
+    guard.record_tool("prior", 1.0)  # spend the ceiling
+    budget = VapiBudgetGuard(guard, model="m")
+
+    ran = False
+
+    async def run():
+        nonlocal ran
+        ran = True
+        return completion(1000, 500)
+
+    with pytest.raises(BudgetExceeded):
+        await budget.guard_completion(run, model="m")
+    assert ran is False  # upstream never reached
+
+
+def test_blocks_over_budget_streaming_turn_synchronously() -> None:
+    guard = _guard()
+    guard.record_tool("prior", 1.0)
+    budget = VapiBudgetGuard(guard, model="m")
+
+    opened = False
+
+    def run():
+        nonlocal opened
+        opened = True
+        return sse_stream(3, {"prompt_tokens": 10, "completion_tokens": 5})
+
+    # guard_stream reserves eagerly, so the block raises right here — not lazily
+    # on first pull. The handler learns before piping anything to Vapi.
+    with pytest.raises(BudgetExceeded):
+        budget.guard_stream(run, model="m")
+    assert opened is False
+
+
+@pytest.mark.asyncio
+async def test_guard_completion_and_stream_require_a_model() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = VapiBudgetGuard(guard)  # no default model
+
+    with pytest.raises(ValueError, match="no model"):
+        await budget.guard_completion(lambda: completion(1, 1), model=None)
+
+    with pytest.raises(ValueError, match="no model"):
+        budget.guard_stream(lambda: sse_stream(1), model=None)
+
+
+# ── settle on real usage ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_settles_priced_cost_from_completion_and_frees_hold() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+
+    out = await budget.guard_completion(lambda: completion(1000, 500), model="m")
+    assert out["usage"]["completion_tokens"] == 500  # returned untouched
+
+    # 1000 * 1e-6 + 500 * 2e-6 = 0.002
+    assert guard.advisory().spent_usd == pytest.approx(0.002)
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)  # hold consumed, not leaked
+    assert len(guard.spend_log) == 1
+    assert guard.spend_log[0].model_or_tool == "m"
+
+
+@pytest.mark.asyncio
+async def test_settles_stream_on_final_chunk_usage_and_passes_chunks() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+
+    stream = budget.guard_stream(
+        lambda: sse_stream(4, {"prompt_tokens": 1000, "completion_tokens": 500}), model="m"
+    )
+    yielded = await drain_stream(stream)
+
+    assert yielded == 5  # 4 content chunks + 1 usage chunk, all forwarded
+    assert guard.advisory().spent_usd == pytest.approx(0.002)
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)
+
+
+@pytest.mark.asyncio
+async def test_per_call_model_wins_over_constructor_default() -> None:
+    guard = BudgetGuard(limit_usd=1.00, price_overrides={"req-model": PRICE})
+    budget = VapiBudgetGuard(guard)  # no default model
+
+    await budget.guard_completion(lambda: completion(1000, 0), model="req-model")
+    assert guard.spend_log[0].model_or_tool == "req-model"
+
+
+@pytest.mark.asyncio
+async def test_completion_may_be_a_sync_source() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+
+    await budget.guard_completion(lambda: completion(100, 50), model="m")
+    assert guard.advisory().spent_usd == pytest.approx(100 * 1e-6 + 50 * 2e-6)
+
+
+# ── release on error / abort ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_releases_hold_when_upstream_throws() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+
+    async def boom():
+        raise RuntimeError("upstream 500")
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        await budget.guard_completion(boom, model="m")
+    assert guard.remaining_usd == pytest.approx(after_turn1)  # hold released
+    assert guard.advisory().spent_usd == pytest.approx(0.002)  # no new spend
+
+
+@pytest.mark.asyncio
+async def test_releases_hold_when_caller_aborts_stream_early() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+
+    stream = budget.guard_stream(
+        lambda: sse_stream(10, {"prompt_tokens": 1000, "completion_tokens": 500}), model="m"
+    )
+    # Breaking off the async-for and closing the generator unwinds into its
+    # finally, which releases the still-open hold. (In Python a bare break
+    # finalizes the generator only on a later loop iteration — close it
+    # explicitly so the hold clears deterministically.)
+    async for _ in stream:
+        break
+    await stream.aclose()
+
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+    assert guard.advisory().spent_usd == pytest.approx(0.002)  # aborted turn metered nothing
+
+
+# ── missing usage fails loudly ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_completion_fails_loudly_and_releases() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+
+    with pytest.raises(VapiUsageMissingError, match="no token usage"):
+        await budget.guard_completion(lambda: {"usage": None}, model="m")
+    assert guard.remaining_usd == pytest.approx(after_turn1)  # released, not metered at $0
+    assert guard.advisory().spent_usd == pytest.approx(0.002)
+
+
+@pytest.mark.asyncio
+async def test_missing_usage_stream_fails_loudly() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+
+    stream = budget.guard_stream(lambda: sse_stream(3), model="m")  # no usage chunk
+    with pytest.raises(VapiUsageMissingError):
+        await drain_stream(stream)
+    assert guard.advisory().spent_usd == 0.0  # nothing metered
+    assert guard.remaining_usd == pytest.approx(1.0)  # hold released
+
+
+# ── assistant-request admission via gates.vapi ────────────────────────────────
+
+
+def test_assistant_request_admits_with_assistant_id() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    budget = VapiBudgetGuard(guard)
+    assert budget.assistant_request(assistant_id="asst_123") == {"assistantId": "asst_123"}
+
+
+def test_assistant_request_rejects_exhausted_call_with_spoken_error() -> None:
+    guard = BudgetGuard(limit_usd=1.00)
+    guard.record_tool("prior", 1.0)
+    budget = VapiBudgetGuard(guard)
+    assert budget.assistant_request(
+        assistant_id="asst_123", error_message="Out of budget."
+    ) == {"error": "Out of budget."}
+
+
+# ── voice legs price via the cost map ──────────────────────────────────────────
+
+
+def test_meters_stt_tts_telephony_from_named_vendors() -> None:
+    guard = BudgetGuard(limit_usd=10.00)
+    budget = VapiBudgetGuard(
+        guard,
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+
+    stt = budget.meter_stt(30)  # 30s
+    tts = budget.meter_tts(1_200)  # 1.2k chars
+    tel = budget.meter_telephony(2.5)  # 2.5 min
+
+    assert stt == pytest.approx(price_voice_leg("stt", 30, model="deepgram-nova-3"))
+    assert tts == pytest.approx(price_voice_leg("tts", 1_200, model="elevenlabs-flash-v2.5"))
+    assert tel == pytest.approx(
+        price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local")
+    )
+    assert guard.tool_costs["vapi-stt"] == pytest.approx(stt)
+    assert guard.tool_costs["vapi-tts"] == pytest.approx(tts)
+    assert guard.tool_costs["vapi-telephony"] == pytest.approx(tel)
+
+
+def test_unconfigured_leg_is_unmetered() -> None:
+    guard = BudgetGuard(limit_usd=10.00)
+    budget = VapiBudgetGuard(guard)  # no voice vendors configured
+    assert budget.meter_stt(30) is None
+    assert budget.meter_tts(30) is None
+    assert budget.meter_telephony(30) is None
+    assert guard.advisory().spent_usd == 0.0
+
+
+@pytest.mark.parametrize(
+    "kwarg,mode",
+    [("stt_model", "stt"), ("tts_model", "tts"), ("telephony", "telephony")],
+)
+def test_fails_closed_on_unpriceable_vendor(kwarg: str, mode: str) -> None:
+    guard = BudgetGuard(limit_usd=10.00)
+    budget = VapiBudgetGuard(guard, **{kwarg: "no-such-vendor"})
+
+    with pytest.raises(UnpriceableVoiceError):
+        getattr(budget, f"meter_{mode}")(1)
+    assert guard.advisory().spent_usd == 0.0
+
+
+# ── no double release ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_double_release_when_streaming_settle_throws() -> None:
+    guard = BudgetGuard(limit_usd=1.00)  # fail_closed default; "mystery-model" unpriceable
+    guard.record_tool("prior", 0.1)  # non-zero next-call estimate → the reserve holds 0.10
+    before = guard.remaining_usd  # 0.90
+    budget = VapiBudgetGuard(guard, model="mystery-model")
+
+    async def source():
+        yield {"usage": {"prompt_tokens": 100, "completion_tokens": 50}}
+
+    stream = budget.guard_stream(source, model="mystery-model")
+    # Draining triggers settle("mystery-model", …) → UnpriceableModelError, which
+    # releases the reservation ITSELF. The finally must not release it again — a
+    # double release would drive `reserved` negative and inflate remaining_usd.
+    with pytest.warns(UnpriceableModelWarning), pytest.raises(UnpriceableModelError):
+        await drain_stream(stream)
+    assert guard.remaining_usd == pytest.approx(before)  # released exactly once
+
+
+@pytest.mark.asyncio
+async def test_malformed_usage_is_treated_as_missing() -> None:
+    # A partial or non-numeric usage block is no usage at all (fail-closed).
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+
+    with pytest.raises(VapiUsageMissingError):
+        await budget.guard_completion(lambda: {"usage": {"prompt_tokens": "lots"}})
+    assert guard.remaining_usd == pytest.approx(after_turn1)

--- a/tests/test_vapi_adapter.py
+++ b/tests/test_vapi_adapter.py
@@ -331,3 +331,49 @@ async def test_malformed_usage_is_treated_as_missing() -> None:
     with pytest.raises(VapiUsageMissingError):
         await budget.guard_completion(lambda: {"usage": {"prompt_tokens": "lots"}})
     assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+@pytest.mark.asyncio
+async def test_no_double_release_when_completion_settle_throws() -> None:
+    # Same invariant as the streaming variant: guard.settle releases the
+    # reservation on its own unpriceable-model failure path, and guard_completion
+    # has no finally of its own - the hold is released exactly once.
+    guard = BudgetGuard(limit_usd=1.00)  # fail_closed default; "mystery-model" unpriceable
+    guard.record_tool("prior", 0.1)  # non-zero next-call estimate -> the reserve holds 0.10
+    before = guard.remaining_usd  # 0.90
+    budget = VapiBudgetGuard(guard, model="mystery-model")
+
+    with pytest.warns(UnpriceableModelWarning), pytest.raises(UnpriceableModelError):
+        await budget.guard_completion(lambda: completion(100, 50), model="mystery-model")
+    assert guard.remaining_usd == pytest.approx(before)  # released exactly once
+
+
+@pytest.mark.asyncio
+async def test_releases_hold_when_stream_closed_before_consumption() -> None:
+    # A generator's finally cannot run before it is started, so closing a never-
+    # consumed guarded stream would leak its hold. The returned wrapper closes
+    # that gap deterministically on aclose().
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)  # next-call estimate 0.002
+
+    stream = budget.guard_stream(lambda: sse_stream(5), model="m")
+    assert guard.remaining_usd == pytest.approx(after_turn1 - 0.002)  # held
+
+    await stream.aclose()  # never consumed - released eagerly
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+@pytest.mark.asyncio
+async def test_closing_a_finished_stream_does_not_double_release() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+
+    stream = budget.guard_stream(
+        lambda: sse_stream(2, {"prompt_tokens": 1000, "completion_tokens": 500}), model="m"
+    )
+    await drain_stream(stream)  # consumed to completion -> settled
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)
+
+    await stream.aclose()  # already finished - must not release the settled hold
+    assert guard.remaining_usd == pytest.approx(1.0 - 0.002)

--- a/tests/test_vapi_adapter.py
+++ b/tests/test_vapi_adapter.py
@@ -248,9 +248,9 @@ def test_assistant_request_rejects_exhausted_call_with_spoken_error() -> None:
     guard = BudgetGuard(limit_usd=1.00)
     guard.record_tool("prior", 1.0)
     budget = VapiBudgetGuard(guard)
-    assert budget.assistant_request(
-        assistant_id="asst_123", error_message="Out of budget."
-    ) == {"error": "Out of budget."}
+    assert budget.assistant_request(assistant_id="asst_123", error_message="Out of budget.") == {
+        "error": "Out of budget."
+    }
 
 
 # ── voice legs price via the cost map ──────────────────────────────────────────
@@ -271,9 +271,7 @@ def test_meters_stt_tts_telephony_from_named_vendors() -> None:
 
     assert stt == pytest.approx(price_voice_leg("stt", 30, model="deepgram-nova-3"))
     assert tts == pytest.approx(price_voice_leg("tts", 1_200, model="elevenlabs-flash-v2.5"))
-    assert tel == pytest.approx(
-        price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local")
-    )
+    assert tel == pytest.approx(price_voice_leg("telephony", 2.5, model="twilio-us-inbound-local"))
     assert guard.tool_costs["vapi-stt"] == pytest.approx(stt)
     assert guard.tool_costs["vapi-tts"] == pytest.approx(tts)
     assert guard.tool_costs["vapi-telephony"] == pytest.approx(tel)

--- a/tests/test_vapi_adapter.py
+++ b/tests/test_vapi_adapter.py
@@ -377,3 +377,82 @@ async def test_closing_a_finished_stream_does_not_double_release() -> None:
 
     await stream.aclose()  # already finished - must not release the settled hold
     assert guard.remaining_usd == pytest.approx(1.0 - 0.002)
+
+
+@pytest.mark.asyncio
+async def test_no_double_release_when_first_stream_pull_raises() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+    before = guard.remaining_usd
+
+    async def source():
+        raise RuntimeError("pull boom")
+        yield {"choices": []}
+
+    stream = budget.guard_stream(source, model="m")
+    assert guard.remaining_usd == pytest.approx(before - 0.002)
+
+    with pytest.raises(RuntimeError, match="pull boom"):
+        async for _ in stream:
+            pass
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+    await stream.aclose()
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+@pytest.mark.asyncio
+async def test_no_double_release_when_first_stream_pull_is_usage_less_and_empty() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+    before = guard.remaining_usd
+
+    async def source():
+        if False:
+            yield {}
+
+    stream = budget.guard_stream(source, model="m")
+    assert guard.remaining_usd == pytest.approx(before - 0.002)
+
+    with pytest.raises(VapiUsageMissingError):
+        await drain_stream(stream)
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+    await stream.aclose()
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+@pytest.mark.asyncio
+async def test_garbage_collection_releases_hold_for_unstarted_stream() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    after_turn1 = await _prime_estimate(guard, budget)
+    before = guard.remaining_usd
+
+    stream = budget.guard_stream(lambda: sse_stream(5), model="m")
+    assert guard.remaining_usd == pytest.approx(before - 0.002)
+
+    del stream
+    import gc
+    gc.collect()
+
+    assert guard.remaining_usd == pytest.approx(after_turn1)
+
+
+@pytest.mark.asyncio
+async def test_malformed_usage_values_rejected() -> None:
+    guard = _guard()
+    budget = VapiBudgetGuard(guard, model="m")
+    await _prime_estimate(guard, budget)
+
+    with pytest.raises(VapiUsageMissingError):
+        await budget.guard_completion(
+            lambda: {"usage": {"prompt_tokens": -10, "completion_tokens": 5}}
+        )
+
+    with pytest.raises(VapiUsageMissingError):
+        await budget.guard_completion(
+            lambda: {"usage": {"prompt_tokens": 10, "completion_tokens": 5.5}}
+        )

--- a/tests/test_voice_examples.py
+++ b/tests/test_voice_examples.py
@@ -1,8 +1,8 @@
 """The voice-call-cost examples must run with no API key and no network.
 
-AC1: a Pipecat and a LiveKit demo each emit a per-leg breakdown (STT / LLM / TTS
-/ telephony) summing to a total call cost, priced entirely from the bundled cost
-map with no manual rates.
+AC1: LiveKit, Pipecat, Vapi, and Retell demos each emit a per-leg breakdown
+(STT / LLM / TTS / telephony) summing to a total call cost, priced entirely from
+the bundled cost map with no manual rates.
 """
 
 from __future__ import annotations
@@ -59,5 +59,33 @@ async def test_pipecat_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) 
 
     _assert_four_legs_sum_to_total(
         guard, {"gpt-4o", "pipecat-stt", "pipecat-tts", "pipecat-telephony"}
+    )
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_vapi_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    demo = _load("voice_call_cost_vapi")
+
+    guard = await demo.run()
+
+    _assert_four_legs_sum_to_total(
+        guard, {"gpt-4o", "vapi-stt", "vapi-tts", "vapi-telephony"}
+    )
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_retell_voice_call_cost_example(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    demo = _load("voice_call_cost_retell")
+
+    guard = await demo.run()
+
+    _assert_four_legs_sum_to_total(
+        guard, {"gpt-4o", "retell-stt", "retell-tts", "retell-telephony"}
     )
     assert "OPENAI_API_KEY" not in os.environ


### PR DESCRIPTION
## Summary

Python now ships the in-call Vapi and Retell session adapters that were TypeScript-only: reserve-before-turn, settle-on-usage, release-on-interrupt, and voice-leg metering for Python voice stacks (FastAPI custom-LLM proxies, WebSocket servers). Ported from `js/src/adapters/{vapi,retell}.ts` following the existing `integrations/livekit.py` voice-leg pattern - both are framework-free (plain OpenAI-format JSON/SSE and WS dicts; no SDK deps).

## Changes

- `src/floe_guard/integrations/vapi.py` - `VapiBudgetGuard`: `guard_completion` / `guard_stream` (eager reserve before the upstream call, settle on real OpenAI `usage`, release on error/abort), `assistant_request`  (delegates to `gates.vapi`), `meter_stt` / `meter_tts` / `meter_telephony` (fail-closed `UnpriceableVoiceError`), adapter-local `VapiUsageMissingError`,  re-exported `BudgetExceeded`.
- `src/floe_guard/integrations/retell.py` - `RetellBudgetGuard`.  `begin_turn` (idempotent; a newer `response_id` interrupts and releases the  prior turn), `settle_turn`, `admit_call` (delegates to `gates.retell`),  `response` builder, `meter_*`, `close()`.
- `pyproject.toml` - `vapi = []` / `retell = []` extras (framework-free, for discoverability), keywords, version 0.20.1 → 0.21.0 (Version Guard).
- `README.md` - adapter matrix now ✅/✅ for Vapi & Retell, new  `### Vapi (voice)` / `### Retell (voice)` sections, Python snippets in the voice-adapters section, examples-index rows.
- `examples/voice_call_cost_vapi.py` / `voice_call_cost_retell.py` - no-key demos printing the pre-call admission decision and a per-leg call-cost receipt (all priced from the bundled map).
- `tests/test_vapi_adapter.py` + `tests/test_retell_adapter.py` - 35 tests  mirroring the JS suites (block-before-turn, settle, interrupt release, early abort release, missing-usage fails loudly, no double release, voice legs);  both examples wired into `tests/test_voice_examples.py`.

## Testing

- [x] `pytest` passes (Python changes) - 465 passed, 3 skipped
- [x] `ruff check .` clean; new files pass `ruff format --check`
- [ ] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes) - N/A, no TS changes
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`) - untouched
- [x] CHANGELOG.md updated (user-facing changes) - entry not yet added

## Related issues

Closes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added framework-free Python voice adapters for Vapi and Retell.
  * Added budget reservation, usage settlement, interruption/error handling, and call admission.
  * Added metering for LLM, speech-to-text, text-to-speech, and telephony costs.
  * Added voice-call cost examples with per-leg and total breakdowns.

* **Documentation**
  * Updated adapter listings, pricing examples, navigation, and Python/TypeScript parity guidance.
  * Added unreleased changelog entries for Python 0.21.0 and JavaScript 0.15.0.

* **Tests**
  * Added comprehensive coverage for adapter behavior and voice-cost examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->