### PR TITLE
feat(js): implement estimateCall for request-sized pre-flight budgeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.20.1 / js 0.15.0
+## Unreleased — py 0.20.1 / js 0.15.1
+
+### Added (js)
+
+- **`estimateCall` method on `BudgetGuard`**. Prices the actual incoming request (given model, prompt tokens, and optional max completion tokens) offline using the cost map. Returns `undefined` if the model is unpriceable. Enables TypeScript users to pre-flight check or reserve request-sized budgets to protect against oversized first runs.
 
 ### Documentation (py)
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -164,6 +164,20 @@ except Exception:
     raise
 ```
 
+In TypeScript, `estimateCall()` uses the same offline pricing and options schema:
+
+```ts
+const est = guard.estimateCall("gpt-4o", 12_000, 4_096);
+const handle = guard.reserve(est);   // raises BudgetExceeded NOW if this call can't fit
+try {
+    const response = await callYourLlm({ model: "gpt-4o", ... });
+    guard.settle("gpt-4o", response.usage.promptTokens, response.usage.completionTokens, { reserved: handle });
+} catch (err) {
+    guard.release(handle);      // free the reservation if the call fails
+    throw err;
+}
+```
+
 The LiteLLM adapter does this automatically (prompt tokens via
 `litellm.token_counter`, output cap from `max_tokens`), and the LangChain
 handler sizes its pre-call `check()` the same way. Unpriceable or unsized

--- a/js/README.md
+++ b/js/README.md
@@ -64,6 +64,24 @@ const adv = guard.advisory();
 const model = adv.nearLimit ? openai("gpt-4o-mini") : openai("gpt-4o");
 ```
 
+## Request-sized estimates
+
+To ensure the ceiling is enforced on the first run or for a call much larger than the previous one, you can price the actual incoming request using `estimateCall()` and pass the estimate to `reserve()` or `check()`:
+
+```ts
+const est = guard.estimateCall("gpt-4o", 12_000, 4_096);
+const handle = guard.reserve(est); // throws BudgetExceeded NOW if this call alone would cross
+try {
+  const response = await callYourLlm({ model: "gpt-4o", ... });
+  guard.settle("gpt-4o", response.usage.promptTokens, response.usage.completionTokens, { reserved: handle });
+} catch (err) {
+  guard.release(handle);
+  throw err;
+}
+```
+
+If the model is unpriceable, `estimateCall()` returns `undefined` and `reserve(undefined)` / `check(undefined)` fall back gracefully to the last-cost prediction.
+
 ## Tool spend under the same ceiling
 
 Paid tool calls (Apollo, Exa, scrapers) burn the same budget as tokens. The

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.13.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.13.2",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -467,6 +467,41 @@ export class BudgetGuard {
   }
 
   /**
+   * Price the ACTUAL incoming request, for a request-sized {@link reserve} / {@link check}.
+   *
+   * {@link check} and {@link reserve} default to predicting the next call
+   * from the LAST call's cost — which is blind on the first call and wrong
+   * for a call much larger than the previous one. Feed this the request you
+   * are about to send (its real prompt size and output cap) and pass the
+   * result straight through:
+   *
+   *     const est = guard.estimateCall("gpt-4o", promptTokens, maxCompletionTokens);
+   *     const handle = guard.reserve(est);   // blocks NOW if this call alone would cross
+   *
+   * The estimate is worst-case on output (the model may stop well short of
+   * `maxCompletionTokens`); the hold is corrected to actual cost at
+   * {@link settle}. Returns `undefined` when the model is unpriceable — and
+   * `reserve(undefined)` / `check(undefined)` fall back to the last-cost
+   * prediction, so the wiring degrades gracefully instead of failing.
+   */
+  estimateCall(
+    model: string,
+    promptTokens: number,
+    maxCompletionTokens = 0,
+    options: { price?: ManualPrice } = {},
+  ): number | undefined {
+    let overrides = this.priceOverrides;
+    if (options.price !== undefined) {
+      overrides = { ...(overrides ?? {}), [model]: options.price };
+    }
+    const priced = resolvePrice(model, overrides);
+    if (priced === null) {
+      return undefined;
+    }
+    return priceTokens(priced, promptTokens, maxCompletionTokens);
+  }
+
+  /**
    * Atomically check the ceiling AND hold a tool call's cost in flight.
    *
    * The tool-spend counterpart of {@link BudgetGuard.reserve} — and STRONGER

--- a/js/test/estimate-call.test.ts
+++ b/js/test/estimate-call.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { BudgetExceeded, BudgetGuard } from "../src/index.js";
+
+const MODEL = "gpt-4o"; // $2.5e-6/input token, $1e-5/output token
+
+describe("BudgetGuard.estimateCall", () => {
+  it("prices the actual request", () => {
+    const guard = new BudgetGuard(1.00);
+    const est = guard.estimateCall(MODEL, 1_000, 2_000);
+    expect(est).toBeCloseTo(1_000 * 2.5e-6 + 2_000 * 1e-5, 12); // 0.0025 + 0.02
+  });
+
+  it("prices prompt only when no output cap", () => {
+    const guard = new BudgetGuard(1.00);
+    const est = guard.estimateCall(MODEL, 1_000);
+    expect(est).toBeCloseTo(0.0025, 12);
+  });
+
+  it("returns undefined when model is unpriceable", () => {
+    const guard = new BudgetGuard(1.00);
+    const est = guard.estimateCall("model-that-does-not-exist", 1_000, 1_000);
+    expect(est).toBeUndefined();
+  });
+
+  it("honors manual price", () => {
+    const guard = new BudgetGuard(1.00);
+    const price = { inputCostPerToken: 1e-6, outputCostPerToken: 2e-6 };
+    const est = guard.estimateCall("my-local-model", 1_000, 500, { price });
+    expect(est).toBeCloseTo(1_000 * 1e-6 + 500 * 2e-6, 12);
+  });
+
+  it("blocks oversized first call at its true size", () => {
+    // THE acceptance case: a FIRST call (no last-cost baseline) that alone would
+    // cross the cap must block pre-call once the reservation is request-sized.
+    const guard = new BudgetGuard(0.01, { onBlock: () => {} });
+    const est = guard.estimateCall(MODEL, 1_000, 100_000); // ≈ $1.0025 ≫ $0.01
+    expect(est).toBeDefined();
+    expect(est!).toBeGreaterThan(guard.limitUsd);
+    expect(() => guard.reserve(est)).toThrow(BudgetExceeded);
+    // Nothing was held: the budget is untouched for calls that DO fit.
+    expect(guard.remainingUsd).toBeCloseTo(guard.limitUsd, 12);
+    // The unsized default would have let the same first call through.
+    expect(guard.reserve()).toBe(0.0);
+  });
+
+  it("reserves its estimated size for fitting calls", () => {
+    const guard = new BudgetGuard(1.00);
+    const est = guard.estimateCall(MODEL, 1_000, 1_000);
+    const handle = guard.reserve(est);
+    expect(handle).toBeCloseTo(0.0125, 12);
+    expect(guard.remainingUsd).toBeCloseTo(1.00 - 0.0125, 12);
+    guard.release(handle);
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements `estimateCall(model, promptTokens, maxCompletionTokens?)` in the TypeScript `BudgetGuard` package (`js/src/guard.ts`), mirroring the Python package's `estimate_call` method. This allows TypeScript users to pre-flight request-sized checks and reservations, preventing oversized first runs from passing through unnoticed.

## Changes
- **JS Implementation**: Added [`estimateCall`](file:///d:/13.current-startups/2.floe-guard/floe-guard/js/src/guard.ts#L468-L498) to [`BudgetGuard`](file:///d:/13.current-startups/2.floe-guard/floe-guard/js/src/guard.ts) using the existing `resolvePrice` and `priceTokens` pricing modules.
- **Version Bump**: Bumped `js/package.json` to `0.15.1` to pass CI version guards.
- **Unit Tests**: Added a full test suite in [`js/test/estimate-call.test.ts`](file:///d:/13.current-startups/2.floe-guard/floe-guard/js/test/estimate-call.test.ts) covering request sizing, unpriceable model fallbacks, manual overrides, and reservation integration.
- **Documentation**: Updated [`js/README.md`](file:///d:/13.current-startups/2.floe-guard/floe-guard/js/README.md) and [`docs/advanced.md`](file:///d:/13.current-startups/2.floe-guard/floe-guard/docs/advanced.md) with usage guides for both Python and TypeScript estimate APIs.
- **Changelog**: Logged the unreleased `js 0.15.1` added feature in [`CHANGELOG.md`](file:///d:/13.current-startups/2.floe-guard/floe-guard/CHANGELOG.md).

## Testing
Tested manually in the local development environment:
1. Validated TypeScript types by running `npm run typecheck`.
2. Verified package bundle compilation by running `npm run build`.
3. Ran all TypeScript package tests with `npm test`, verifying that all 231 tests (including the 6 new unit tests for `estimateCall`) passed cleanly.

- [ ] `pytest` passes (Python changes)
- [ ] `ruff check .` and `ruff format .` are clean (Python changes)
- [x] `npm test` and `npm run typecheck` pass in `js/` (TypeScript changes)
- [x] Cost-map copies still match (`src/floe_guard/cost_map.json` == `js/src/cost_map.json`)
- [x] CHANGELOG.md updated (user-facing changes)

## Related issues
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-sized cost estimates through `BudgetGuard.estimateCall`.
  * Supports prompt tokens, optional maximum completion tokens, and manual model pricing.
  * Enables reserving estimated costs before requests, then settling or releasing reservations.
  * Unpriceable models fall back gracefully to existing prediction behavior.

* **Documentation**
  * Added usage examples and guidance for request estimation, reservations, settlement, and error handling.

* **Chores**
  * Updated JavaScript package version to 0.15.1 and documented the upcoming releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->