### PR TITLE
docs: align hosted-Floe blocks to cost -> margin -> invoicing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ next turn before it crosses your USD ceiling** — a runaway loop dies at $0.10
 instead of $4,000. Runs **in your process**: no account, no signup, no network,
 **no telemetry**. It also guards **any** LLM agent (OpenAI, Anthropic, CrewAI,
 LangChain, …) via plain `check()` / `record()` or an adapter. Python (`pip`) +
-TypeScript (`npm`). MIT. Built by [Floe](https://floelabs.xyz) — cost controls for Voice AI.
+TypeScript (`npm`). MIT. Built by [Floe](https://floelabs.xyz) — know what every AI call
+really costs: cost per call across every vendor, margin per client, and rebilling your own
+customers off the actuals.
 
 ## Add it to an agent — unattended steps
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ can't stop a call already made).
 
 ## Works best with the Floe skill
 
-`floe-guard` is a local ceiling — it stops paid work before your budget blows, standalone, no account needed. To govern your agent's **whole** vendor bill (LLM, voice, telephony, data) on one key with server-side spend controls, add the **Floe agent skill** — it teaches Claude Code / Cursor the same govern-your-spend workflow `floe-guard` enforces locally:
+`floe-guard` is a local ceiling — it stops paid work before your budget blows, standalone, no account needed. Hosted Floe is the system of record on top: it costs every call the moment it ends across every vendor (LLM, voice, telephony, data) on one ledger, shows your margin per client, and lets you invoice your own customers off the actuals — with spend controls enforced server-side. Add the **Floe agent skill** to teach Claude Code / Cursor the same govern-your-spend workflow `floe-guard` enforces locally:
 
 ```bash
 npx skills add floe-labs/agent-skills
@@ -806,14 +806,16 @@ on it raises, with zero network) — the [no-telemetry](#no-telemetry) default h
 ## When you outgrow local guardrails
 
 `floe-guard` stops overspend **per process, locally** — no account, no network.
-When the ceiling needs to hold across your whole fleet, hosted Floe moves
-enforcement server-side.
+When the ceiling needs to hold across your whole fleet, hosted Floe becomes the
+system of record: it costs every call across every vendor on one ledger, shows your
+margin per client, and lets you invoice your own customers off the actuals — with
+enforcement moved server-side.
 
 | | floe-guard (this repo) | Hosted Floe |
 |---|---|---|
 | Runs | Locally, in your process | Server-side |
 | Scope | One process | Every vendor and agent |
-| Control | Hard stop at your cap | Kill switch + one unified ledger |
+| Control | Hard stop at your cap | Kill switch + one ledger: cost, margin, rebilling |
 
 Already on hosted Floe? The package's only network call is the opt-in hosted
 budget read: set `FLOE_API_KEY` (agent key `floe_…`) and `hosted_remaining_usd()`


### PR DESCRIPTION
Deepen the Floe org positioning from a two-word swap to the full cost -> margin -> invoicing story (grounded in floelabs.xyz + the rebilling work). Keeps each tool's own function primary; no install commands, code samples, tables, badges, or counts touched.