### PR TITLE
fix: restore claude-3-5 cost map + pin generator; drop litellm on py3.10 (repair red main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,17 +79,18 @@ jobs:
       - run: python -m pip install --upgrade pip
       # Install the framework extras so the adapter handler tests actually run
       # (instead of skipping). langchain-core covers the LangChain handler
-      # tests; litellm covers the callback-swallowing regression tests (the
-      # CrewAI adapter tests stub crewai itself, so the heavy extra stays out);
-      # langgraph covers the fan-out reserve/settle and advisory-channel tests;
-      # livekit covers the LiveKit voice-agent reserve/settle/release tests
-      # (livekit-agents supports Python >=3.10, so it goes in the base install).
-      - run: pip install -e ".[dev,langchain,litellm,langgraph,livekit]"
-      # pipecat-ai requires Python >=3.11, so add it (and exercise the Pipecat
-      # adapter tests) on every matrix cell except 3.10 — there the tests
+      # tests; langgraph covers the fan-out reserve/settle and advisory-channel
+      # tests; livekit covers the LiveKit voice-agent reserve/settle/release
+      # tests (livekit-agents supports Python >=3.10, so it goes in the base
+      # install).
+      - run: pip install -e ".[dev,langchain,langgraph,livekit]"
+      # litellm >=1.92 (its Anthropic pass-through) imports NotRequired from
+      # typing, which only exists on Python >=3.11, so litellm no longer imports
+      # on 3.10. Add litellm (callback-swallowing regression tests) and pipecat
+      # (requires >=3.11) on every matrix cell except 3.10 — there both suites
       # importorskip cleanly.
       - if: matrix.python-version != '3.10'
-        run: pip install -e ".[pipecat]"
+        run: pip install -e ".[litellm,pipecat]"
       - name: Pytest
         run: pytest -q
 

--- a/js/src/cost_map.json
+++ b/js/src/cost_map.json
@@ -16,6 +16,24 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "claude-3-5-haiku-20241022": {
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.000004,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-5-sonnet-20240620": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-5-sonnet-20241022": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
   "claude-3-7-sonnet-20250219": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,

--- a/scripts/update-cost-map.mjs
+++ b/scripts/update-cost-map.mjs
@@ -73,6 +73,35 @@ const GROQ_KEY_MAP = new Map([
 // adapter detects them via `client.vertexai`.
 const PREFIX_STRIPPED_PROVIDERS = new Set(["gemini"]);
 
+// ── Pinned must-keep models ──────────────────────────────────────────────
+// Models we always ship even if LiteLLM stops listing them at their real
+// provider. Upstream dropped the claude-3-5 family from `litellm_provider:
+// "anthropic"` (refresh 2026-08-24), which nulled them out of the map and broke
+// pricing for the many users still on those models. Seeded into the LiteLLM
+// data below so they flow through the same isUsable filter, dedup, and sort as
+// everything else; a live upstream entry still wins (the seed only fills a gap).
+// Prices are Anthropic public list rates.
+const PINNED_MODELS = {
+  "claude-3-5-sonnet-20241022": {
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    litellm_provider: "anthropic",
+    mode: "chat",
+  },
+  "claude-3-5-sonnet-20240620": {
+    input_cost_per_token: 0.000003,
+    output_cost_per_token: 0.000015,
+    litellm_provider: "anthropic",
+    mode: "chat",
+  },
+  "claude-3-5-haiku-20241022": {
+    input_cost_per_token: 0.0000008,
+    output_cost_per_token: 0.000004,
+    litellm_provider: "anthropic",
+    mode: "chat",
+  },
+};
+
 // ── Voice rates (STT / TTS / telephony) ─────────────────────────────────────
 //
 // The token map above is fetched from LiteLLM; the voice map is NOT — LiteLLM
@@ -267,6 +296,12 @@ if (!res.ok) {
   throw new Error(`Failed to fetch LiteLLM cost map: HTTP ${res.status}`);
 }
 const raw = await res.json();
+
+// Seed pinned must-keep models when upstream has dropped them; a live upstream
+// entry wins. They then flow through isUsable/dedup/sort like any other model.
+for (const [k, v] of Object.entries(PINNED_MODELS)) {
+  if (!(k in raw)) raw[k] = v;
+}
 
 const entries = Object.entries(raw)
   .filter(([k, v]) => isUsable(k, v))

--- a/src/floe_guard/cost_map.json
+++ b/src/floe_guard/cost_map.json
@@ -16,6 +16,24 @@
     "litellm_provider": "openai",
     "mode": "chat"
   },
+  "claude-3-5-haiku-20241022": {
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.000004,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-5-sonnet-20240620": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
+  "claude-3-5-sonnet-20241022": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "litellm_provider": "anthropic",
+    "mode": "chat"
+  },
   "claude-3-7-sonnet-20250219": {
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,


### PR DESCRIPTION
Repairs a **red `main`** so every open PR can go green. Two independent breakages, both surfacing as failed `test` jobs:

## 1 · claude-3-5 cost map nulled (commit `a7982ff`)

PR #101 (`chore: refresh LiteLLM cost map`, `d7d4a74`) nulled `claude-3-5-sonnet-20241022`, `claude-3-5-sonnet-20240620`, `claude-3-5-haiku-20241022` — LiteLLM dropped them upstream. `resolve_price` is fail-closed → returns `None`, so `test_pricing.py::test_resolves_claude_3_5_family` and the cache-rate test fail on **every** cell.

- **Restore** the three entries in both vendored maps (byte-identical; `cost-map-sync` passes). sonnet `0.000003/0.000015`, haiku `0.0000008/0.000004`, provider `anthropic`, mode `chat`.
- **Pin them in `scripts/update-cost-map.mjs`** (`PINNED_MODELS` seeded into `raw` before filtering) so the weekly refresh **re-seeds** the price when upstream drops it instead of emitting `null`. A live upstream entry still wins; pins flow through `isUsable`/dedup/sort — map fully regenerated, diff is exactly the 3 entries.

**Can't silently recur in the weekly push:** the generator can no longer emit `null` for these, and if it ever did, `test_resolves_claude_3_5_family` reds the refresh PR (which is *not* auto-merged — its body says "review the price diff before merging").

## 2 · litellm dropped Python 3.10 support (commit `63246e6`)

Separately, `test (3.10)` is red because litellm **>=1.92** imports `NotRequired` from `typing` (Anthropic pass-through, `context_management/editors/compact.py`) — 3.11+ only. So `import litellm` raises `ImportError` on 3.10, turning `test_crewai_adapter.py`'s `importorskip("litellm")` into a **collection error** instead of a skip.

Move the `litellm` extra behind the same `matrix.python-version != '3.10'` guard that already gates `pipecat` (also 3.11+). On 3.10 litellm is absent → dependent tests `importorskip` cleanly; the core guardrail is still tested on 3.10. No `pyproject` change (consistent with pipecat); `requires-python` stays `>=3.10` for the core.

## Verification
- `.venv/bin/python -m pytest tests/test_pricing.py -q` → **38 passed**.
- On the litellm-only branch the 3.10 job went from a collection error to a clean `3 skipped` (only the pricing tests remained red — fixed here by part 1).
- Map regenerated via `node scripts/update-cost-map.mjs` (176 models) — not hand-edited.

Labeled `skip-version-guard`: data-only cost-map correction restoring already-published pricing (0.21.0/0.15.1 shipped the good map; #101 never published). Supersedes #106.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pricing support for Anthropic Claude 3.5 Haiku and Sonnet models, including accurate input and output token rates.
  - Claude 3.5 models are now recognized consistently across supported cost tracking workflows.

- **Tests**
  - Updated automated test environments to validate integrations across supported Python configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->