### PR TITLE
ci: don't install litellm on Python 3.10 (upstream dropped 3.10 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,17 +79,18 @@ jobs:
       - run: python -m pip install --upgrade pip
       # Install the framework extras so the adapter handler tests actually run
       # (instead of skipping). langchain-core covers the LangChain handler
-      # tests; litellm covers the callback-swallowing regression tests (the
-      # CrewAI adapter tests stub crewai itself, so the heavy extra stays out);
-      # langgraph covers the fan-out reserve/settle and advisory-channel tests;
-      # livekit covers the LiveKit voice-agent reserve/settle/release tests
-      # (livekit-agents supports Python >=3.10, so it goes in the base install).
-      - run: pip install -e ".[dev,langchain,litellm,langgraph,livekit]"
-      # pipecat-ai requires Python >=3.11, so add it (and exercise the Pipecat
-      # adapter tests) on every matrix cell except 3.10 — there the tests
+      # tests; langgraph covers the fan-out reserve/settle and advisory-channel
+      # tests; livekit covers the LiveKit voice-agent reserve/settle/release
+      # tests (livekit-agents supports Python >=3.10, so it goes in the base
+      # install).
+      - run: pip install -e ".[dev,langchain,langgraph,livekit]"
+      # litellm >=1.92 (its Anthropic pass-through) imports NotRequired from
+      # typing, which only exists on Python >=3.11, so litellm no longer imports
+      # on 3.10. Add litellm (callback-swallowing regression tests) and pipecat
+      # (requires >=3.11) on every matrix cell except 3.10 — there both suites
       # importorskip cleanly.
       - if: matrix.python-version != '3.10'
-        run: pip install -e ".[pipecat]"
+        run: pip install -e ".[litellm,pipecat]"
       - name: Pytest
         run: pytest -q
 


### PR DESCRIPTION
## Why

`test (3.10)` is **red on `main` and on every open PR** — independent of the cost-map issue. It's an upstream litellm break, not our code.

litellm **>=1.92** imports `NotRequired` from `typing` in its Anthropic pass-through (`context_management/editors/compact.py`). `NotRequired` only exists in `typing` on **Python >=3.11** (it's in `typing_extensions` on 3.10), so `import litellm` raises:

```
ImportError: cannot import name 'NotRequired' from 'typing'
```

Because litellm is installed on the 3.10 cell, `tests/test_crewai_adapter.py`'s `pytest.importorskip("litellm")` hits a *broken-but-present* litellm and errors **during collection** (`Interrupted: 1 error during collection`) instead of skipping.

## Fix

Move the `litellm` extra behind the same `matrix.python-version != '3.10'` guard that **already** gates `pipecat` (also >=3.11 only). On 3.10 litellm is now absent, so its dependent tests `importorskip` cleanly; the **core guardrail** (pricing, budget, reservations) is still exercised on 3.10.

No `pyproject` change — consistent with how pipecat is handled (CI-guard only). `requires-python` stays `>=3.10`: floe-guard's core still supports 3.10; only the optional `litellm`/`crewai` integration now requires 3.11+ (forced by upstream).

## Scope

Separate incident from #105 (which restores the claude-3-5 cost-map entries). Both are "repair red `main`" PRs; this one fixes the 3.10 cell, #105 fixes the pricing tests on 3.11–3.13. Both are needed for a fully green matrix.