### PR TITLE
fix: cache-aware pricing for the OpenAI and LiteLLM adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.21.1
+
+### Fixed (py)
+
+- **OpenAI and LiteLLM adapters: cached prompt tokens are priced at the
+  cache-read rate, not the full input rate.** Both adapters read only
+  `usage.prompt_tokens` / `usage.completion_tokens`, but `prompt_tokens`
+  *includes* the share served from the provider's prompt cache
+  (`usage.prompt_tokens_details.cached_tokens`) — so every cached token was
+  metered at the full input rate. This is the same systematic overcharge
+  `turn_cost(prompt_cached_tokens=…)` fixed for the receipt in py 0.20.0, and
+  that the Gemini adapter already avoids by carving
+  `cached_content_token_count` out of the prompt count. Both adapters now do
+  the same and pass the cached share to `settle(…,
+  cache_read_input_tokens=…)`, so it prices at the model's published cache-read
+  rate. OpenAI enables prompt caching automatically for prompts ≥1024 tokens,
+  so any agent loop with a stable system prompt was affected: a 10k-token
+  prompt that is 90% cached metered ~3.3x its real cost, hard-stopping the
+  agent well before its ceiling was actually reached. A response with no cache
+  hit (the block absent, or `cached_tokens` null) is unchanged, and a fully
+  cached prompt with no completion now settles its reservation instead of
+  taking the usage-less release path.
+
 ## Unreleased — py 0.21.0 / js 0.15.1
 
 ### Added (py)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   cache_read_input_tokens=…)`, so it prices at the model's published cache-read
   rate. OpenAI enables prompt caching automatically for prompts ≥1024 tokens,
   so any agent loop with a stable system prompt was affected: a 10k-token
-  prompt that is 90% cached metered ~3.3x its real cost, hard-stopping the
+  prompt that is 90% cached metered ~1.8x its real cost, hard-stopping the
   agent well before its ceiling was actually reached. A response with no cache
   hit (the block absent, or `cached_tokens` null) is unchanged, and a fully
   cached prompt with no completion now settles its reservation instead of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.21.0"
+version = "0.21.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -62,15 +62,40 @@ def _model_from(kwargs: dict[str, Any], response: Any) -> str:
     return str(model or "")
 
 
-def _usage_from(response: Any) -> tuple[int, int]:
-    """Pull (prompt_tokens, completion_tokens) from a LiteLLM/OpenAI response."""
+def _usage_from(response: Any) -> tuple[int, int, int]:
+    """Map a LiteLLM/OpenAI response's usage onto ``(prompt, completion, cache_read)``.
+
+    LiteLLM normalises every provider onto the OpenAI usage shape, including
+    ``usage.prompt_tokens_details.cached_tokens`` for the share of the prompt
+    served from the provider's prompt cache. ``prompt_tokens`` *includes* that
+    share, so it is subtracted out and returned separately to be re-priced at
+    the cheaper cache-read rate rather than at the full input rate.
+    """
     usage = getattr(response, "usage", None)
     if usage is None and isinstance(response, dict):
         usage = response.get("usage")
     if usage is None:
-        return 0, 0
+        return 0, 0, 0
     get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
-    return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
+    prompt = int(get("prompt_tokens", 0) or 0)
+    completion = int(get("completion_tokens", 0) or 0)
+    cached = _cached_tokens(get("prompt_tokens_details", None))
+    # max(0, …): the cached share is documented as part of prompt_tokens, but
+    # clamp so a malformed pair can never produce a negative input count.
+    return max(0, prompt - cached), completion, cached
+
+
+def _cached_tokens(details: Any) -> int:
+    """``prompt_tokens_details.cached_tokens``, as a dict or object; 0 when absent.
+
+    LiteLLM omits the block for a provider that reports no cache hit, and leaves
+    ``cached_tokens`` as ``None`` on providers that carry the field but not the
+    count, so both read as zero.
+    """
+    if details is None:
+        return 0
+    get = details.get if isinstance(details, dict) else lambda k, d=0: getattr(details, k, d)
+    return max(0, int(get("cached_tokens", 0) or 0))
 
 
 def _estimate_request(litellm: Any, guard: BudgetGuard, kwargs: Any) -> float | None:
@@ -116,8 +141,8 @@ def _record_response(
     if not isinstance(kwargs, dict):
         kwargs = {}
     model = _model_from(kwargs, response)
-    prompt_tokens, completion_tokens = _usage_from(response)
-    if prompt_tokens <= 0 and completion_tokens <= 0:
+    prompt_tokens, completion_tokens, cache_read = _usage_from(response)
+    if prompt_tokens <= 0 and completion_tokens <= 0 and cache_read <= 0:
         # No tokens were spent (e.g. a usage-less event) — nothing to meter, so
         # free any reservation we were holding for this call.
         guard.release(reserved)
@@ -126,7 +151,13 @@ def _record_response(
     # model id is missing, so the guard's configured policy applies (fail-closed
     # → warn + raise; fail-open → warn + skip). Silently skipping here would let
     # a real, completed call go unmetered and skew the next check().
-    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
+    guard.settle(
+        model,
+        prompt_tokens,
+        completion_tokens,
+        reserved=reserved,
+        cache_read_input_tokens=cache_read,
+    )
 
 
 def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -80,9 +80,12 @@ def _usage_from(response: Any) -> tuple[int, int, int]:
     prompt = int(get("prompt_tokens", 0) or 0)
     completion = int(get("completion_tokens", 0) or 0)
     cached = _cached_tokens(get("prompt_tokens_details", None))
-    # max(0, …): the cached share is documented as part of prompt_tokens, but
-    # clamp so a malformed pair can never produce a negative input count.
-    return max(0, prompt - cached), completion, cached
+    # Cap cached to prompt_tokens: the cached share is documented as part of
+    # prompt_tokens, so clamp a malformed pair (cached > prompt) — otherwise we
+    # price more input than the provider reported (overstating spend and
+    # blocking later calls early), and a negative fresh count could slip through.
+    cached = min(max(cached, 0), prompt)
+    return prompt - cached, completion, cached
 
 
 def _cached_tokens(details: Any) -> int:

--- a/src/floe_guard/integrations/openai.py
+++ b/src/floe_guard/integrations/openai.py
@@ -54,9 +54,12 @@ def _usage_from(response: Any) -> tuple[int, int, int]:
     prompt = int(get("prompt_tokens", 0) or 0)
     completion = int(get("completion_tokens", 0) or 0)
     cached = _cached_tokens(get("prompt_tokens_details", None))
-    # max(0, …): the cached share is documented as part of prompt_tokens, but
-    # clamp so a malformed pair can never produce a negative input count.
-    return max(0, prompt - cached), completion, cached
+    # Cap cached to prompt_tokens: the cached share is documented as part of
+    # prompt_tokens, so clamp a malformed pair (cached > prompt) — otherwise we
+    # price more input than the provider reported (overstating spend and
+    # blocking later calls early), and a negative fresh count could slip through.
+    cached = min(max(cached, 0), prompt)
+    return prompt - cached, completion, cached
 
 
 def _cached_tokens(details: Any) -> int:

--- a/src/floe_guard/integrations/openai.py
+++ b/src/floe_guard/integrations/openai.py
@@ -36,19 +36,39 @@ def _model_from(kwargs: dict[str, Any], response: Any) -> str:
     return str(model or "")
 
 
-def _usage_from(response: Any) -> tuple[int, int]:
-    """Pull (prompt_tokens, completion_tokens) from an OpenAI chat completion.
+def _usage_from(response: Any) -> tuple[int, int, int]:
+    """Map an OpenAI chat completion's usage onto ``(prompt, completion, cache_read)``.
 
-    OpenAI reports ``usage.prompt_tokens`` / ``usage.completion_tokens`` — the
-    same shape the guard settles on, so no remapping is needed.
+    OpenAI reports ``usage.prompt_tokens`` / ``usage.completion_tokens``, and
+    ``usage.prompt_tokens_details.cached_tokens`` for the share of the prompt
+    served from its prompt cache. ``prompt_tokens`` *includes* the cached share,
+    so it is subtracted out and returned separately to be re-priced at the
+    cheaper cache-read rate rather than being charged at the full input rate.
     """
     usage = getattr(response, "usage", None)
     if usage is None and isinstance(response, dict):
         usage = response.get("usage")
     if usage is None:
-        return 0, 0
+        return 0, 0, 0
     get = usage.get if isinstance(usage, dict) else lambda k, d=0: getattr(usage, k, d)
-    return int(get("prompt_tokens", 0) or 0), int(get("completion_tokens", 0) or 0)
+    prompt = int(get("prompt_tokens", 0) or 0)
+    completion = int(get("completion_tokens", 0) or 0)
+    cached = _cached_tokens(get("prompt_tokens_details", None))
+    # max(0, …): the cached share is documented as part of prompt_tokens, but
+    # clamp so a malformed pair can never produce a negative input count.
+    return max(0, prompt - cached), completion, cached
+
+
+def _cached_tokens(details: Any) -> int:
+    """``prompt_tokens_details.cached_tokens``, as a dict or object; 0 when absent.
+
+    The SDK leaves the block unset on a response with no cache hit, and reports
+    ``cached_tokens=None`` on some providers, so both read as zero.
+    """
+    if details is None:
+        return 0
+    get = details.get if isinstance(details, dict) else lambda k, d=0: getattr(details, k, d)
+    return max(0, int(get("cached_tokens", 0) or 0))
 
 
 def _settle_model(guard: BudgetGuard, kwargs: dict[str, Any], response: Any) -> str:
@@ -80,8 +100,8 @@ def _record_response(
     if not isinstance(kwargs, dict):
         kwargs = {}
     model = _settle_model(guard, kwargs, response)
-    prompt_tokens, completion_tokens = _usage_from(response)
-    if prompt_tokens <= 0 and completion_tokens <= 0:
+    prompt_tokens, completion_tokens, cache_read = _usage_from(response)
+    if prompt_tokens <= 0 and completion_tokens <= 0 and cache_read <= 0:
         # No tokens spent (e.g. a usage-less response) — free the reservation.
         guard.release(reserved)
         return
@@ -89,7 +109,13 @@ def _record_response(
     # model id is missing, so the guard's policy applies (fail-closed → warn +
     # raise; fail-open → warn + skip) rather than letting a completed call go
     # unmetered and skew the next check().
-    guard.settle(model, prompt_tokens, completion_tokens, reserved=reserved)
+    guard.settle(
+        model,
+        prompt_tokens,
+        completion_tokens,
+        reserved=reserved,
+        cache_read_input_tokens=cache_read,
+    )
 
 
 def _reject_streaming(kwargs: dict[str, Any]) -> None:

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -16,9 +16,15 @@ from floe_guard.integrations.litellm import _model_from, _record_response, _usag
 
 
 @dataclass
+class _PromptTokensDetails:
+    cached_tokens: int | None = None
+
+
+@dataclass
 class _Usage:
     prompt_tokens: int
     completion_tokens: int
+    prompt_tokens_details: _PromptTokensDetails | None = None
 
 
 @dataclass
@@ -44,8 +50,46 @@ def test_model_from_prefers_kwargs() -> None:
 
 
 def test_usage_from_dict_and_object() -> None:
-    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7)
-    assert _usage_from(_ObjResponse("gpt-4o", _Usage(5, 7))) == (5, 7)
+    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7, 0)
+    assert _usage_from(_ObjResponse("gpt-4o", _Usage(5, 7))) == (5, 7, 0)
+
+
+def test_cached_tokens_are_carved_out_of_the_prompt_not_added() -> None:
+    # prompt_tokens INCLUDES the cached share, so it is subtracted and re-priced
+    # at the cheaper cache-read rate. Charging both would bill it twice.
+    usage = _Usage(1_000, 40, _PromptTokensDetails(cached_tokens=800))
+    assert _usage_from(_ObjResponse("gpt-4o", usage)) == (200, 40, 800)
+    assert _usage_from(
+        {
+            "usage": {
+                "prompt_tokens": 1_000,
+                "completion_tokens": 40,
+                "prompt_tokens_details": {"cached_tokens": 800},
+            }
+        }
+    ) == (200, 40, 800)
+
+
+def test_missing_or_null_cached_tokens_read_as_zero() -> None:
+    # A provider with no cache hit omits the block, or carries it with no count.
+    assert _usage_from(_ObjResponse("gpt-4o", _Usage(10, 5, None))) == (10, 5, 0)
+    assert _usage_from(_ObjResponse("gpt-4o", _Usage(10, 5, _PromptTokensDetails()))) == (10, 5, 0)
+
+
+def test_cached_tokens_are_priced_at_the_cache_read_rate() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    resp = {
+        "model": "gpt-4o",
+        "usage": {
+            "prompt_tokens": 1_000,
+            "completion_tokens": 0,
+            "prompt_tokens_details": {"cached_tokens": 800},
+        },
+    }
+    _record_response(guard, {}, resp)
+    # 200 fresh input at 2.5e-6, plus 800 cached at gpt-4o's published 1.25e-6
+    # cache-read rate — NOT 1000 at the full input rate.
+    assert guard.spent_usd == pytest.approx(200 * 2.5e-06 + 800 * 1.25e-06)
 
 
 def test_record_response_accrues_dict_response() -> None:

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -76,6 +76,22 @@ def test_missing_or_null_cached_tokens_read_as_zero() -> None:
     assert _usage_from(_ObjResponse("gpt-4o", _Usage(10, 5, _PromptTokensDetails()))) == (10, 5, 0)
 
 
+def test_cached_tokens_capped_at_prompt_tokens() -> None:
+    # cached_tokens exceeding prompt_tokens must be capped at prompt, so we never
+    # price more input than the provider reported (zero fresh, cached == prompt).
+    usage = _Usage(1_000, 5, _PromptTokensDetails(cached_tokens=1_200))
+    assert _usage_from(_ObjResponse("gpt-4o", usage)) == (0, 5, 1_000)
+    assert _usage_from(
+        {
+            "usage": {
+                "prompt_tokens": 1_000,
+                "completion_tokens": 5,
+                "prompt_tokens_details": {"cached_tokens": 1_200},
+            }
+        }
+    ) == (0, 5, 1_000)
+
+
 def test_cached_tokens_are_priced_at_the_cache_read_rate() -> None:
     guard = BudgetGuard(limit_usd=1.0)
     resp = {

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -24,9 +24,15 @@ from floe_guard.integrations.openai import (
 
 
 @dataclass
+class _PromptTokensDetails:
+    cached_tokens: int | None = None
+
+
+@dataclass
 class _Usage:
     prompt_tokens: int
     completion_tokens: int
+    prompt_tokens_details: _PromptTokensDetails | None = None
 
 
 @dataclass
@@ -76,8 +82,30 @@ def _async_client(response: _Response) -> _Client:
 
 
 def test_usage_from_object_and_dict() -> None:
-    assert _usage_from(_Response("gpt-4o", _Usage(5, 7))) == (5, 7)
-    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7)
+    assert _usage_from(_Response("gpt-4o", _Usage(5, 7))) == (5, 7, 0)
+    assert _usage_from({"usage": {"prompt_tokens": 5, "completion_tokens": 7}}) == (5, 7, 0)
+
+
+def test_cached_tokens_are_carved_out_of_the_prompt_not_added() -> None:
+    # prompt_tokens INCLUDES the cached share, so it is subtracted and re-priced
+    # at the cheaper cache-read rate. Charging both would bill it twice.
+    usage = _Usage(1_000, 40, _PromptTokensDetails(cached_tokens=800))
+    assert _usage_from(_Response("gpt-4o", usage)) == (200, 40, 800)
+    assert _usage_from(
+        {
+            "usage": {
+                "prompt_tokens": 1_000,
+                "completion_tokens": 40,
+                "prompt_tokens_details": {"cached_tokens": 800},
+            }
+        }
+    ) == (200, 40, 800)
+
+
+def test_missing_or_null_cached_tokens_read_as_zero() -> None:
+    # No cache hit leaves the block unset, and some providers report a null count.
+    assert _usage_from(_Response("gpt-4o", _Usage(10, 5, None))) == (10, 5, 0)
+    assert _usage_from(_Response("gpt-4o", _Usage(10, 5, _PromptTokensDetails()))) == (10, 5, 0)
 
 
 def test_model_from_prefers_response_then_kwargs() -> None:
@@ -109,6 +137,26 @@ def test_record_response_accrues() -> None:
     resp = _Response("gpt-4o", _Usage(1_000, 1_000))
     _record_response(guard, {}, resp)
     assert guard.spent_usd == pytest.approx(0.0125)
+
+
+def test_cached_tokens_are_priced_at_the_cache_read_rate() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    usage = _Usage(1_000, 0, _PromptTokensDetails(cached_tokens=800))
+    _record_response(guard, {}, _Response("gpt-4o", usage))
+    # 200 fresh input at 2.5e-6, plus 800 cached at gpt-4o's published 1.25e-6
+    # cache-read rate — NOT 1000 at the full input rate.
+    assert guard.spent_usd == pytest.approx(200 * 2.5e-06 + 800 * 1.25e-06)
+
+
+def test_fully_cached_prompt_still_settles_rather_than_releasing() -> None:
+    # A cache hit that leaves zero fresh input and no completion is real spend,
+    # so it must settle the hold instead of taking the usage-less release path.
+    guard = BudgetGuard(limit_usd=1.0)
+    handle = guard.reserve(0.5)
+    usage = _Usage(800, 0, _PromptTokensDetails(cached_tokens=800))
+    _record_response(guard, {}, _Response("gpt-4o", usage), reserved=handle)
+    assert guard.spent_usd == pytest.approx(800 * 1.25e-06)
+    assert len(guard.spend_log) == 1
 
 
 def test_guarded_completion_records_and_calls_client() -> None:

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -108,6 +108,22 @@ def test_missing_or_null_cached_tokens_read_as_zero() -> None:
     assert _usage_from(_Response("gpt-4o", _Usage(10, 5, _PromptTokensDetails()))) == (10, 5, 0)
 
 
+def test_cached_tokens_capped_at_prompt_tokens() -> None:
+    # A malformed usage where cached_tokens exceeds prompt_tokens must not price
+    # more input than reported: cap cached at prompt, leaving zero fresh input.
+    usage = _Usage(1_000, 5, _PromptTokensDetails(cached_tokens=1_200))
+    assert _usage_from(_Response("gpt-4o", usage)) == (0, 5, 1_000)
+    assert _usage_from(
+        {
+            "usage": {
+                "prompt_tokens": 1_000,
+                "completion_tokens": 5,
+                "prompt_tokens_details": {"cached_tokens": 1_200},
+            }
+        }
+    ) == (0, 5, 1_000)
+
+
 def test_model_from_prefers_response_then_kwargs() -> None:
     # The response's served model wins over the requested alias; the kwarg is
     # only a fallback when the response omits the model.


### PR DESCRIPTION
## Summary

`usage.prompt_tokens` already includes the tokens served from the provider's prompt cache, so the OpenAI and LiteLLM adapters were metering the cached share at the full input rate. OpenAI turns prompt caching on automatically above 1024 prompt tokens, so any agent loop with a stable system prompt is affected. On a 10k-token prompt that is 90% cached the guard metered 3.3x the real bill, which hard-stops the agent well before its ceiling is actually reached, and the inflated cost then becomes the next call's default estimate.

This is the same overcharge `turn_cost(prompt_cached_tokens=...)` fixed for the receipt in py 0.20.0 (#94), and that `integrations/gemini.py` already avoids by carving `cached_content_token_count` out of the prompt count. These two adapters were the ones left behind.

## Changes

- `integrations/openai.py` now reads `usage.prompt_tokens_details.cached_tokens`, subtracts it from `prompt_tokens`, and passes it to `settle(..., cache_read_input_tokens=...)`.
- `integrations/litellm.py` does the same. LiteLLM normalises every provider onto the OpenAI usage shape and carries the identical field, so this also covers the CrewAI callback path.
- A response with no cache hit is unchanged. A fully cached prompt with no completion now settles its reservation instead of taking the usage-less release path.
- Both follow the shape `integrations/gemini.py` already uses. No new pattern, no new dependency.

## Testing

`pytest` 505 passed, up from 498 on `main` (7 new tests, Python 3.12 on Windows with all extras installed). Reverting only the source change turns 5 of the new OpenAI tests and 4 of the new LiteLLM tests red.

Also verified end to end through `guarded_completion` with a real `openai` SDK `ChatCompletion` for gpt-4.1 carrying `prompt_tokens=10000`, `prompt_tokens_details.cached_tokens=9000`, `completion_tokens=200`.

```
before   metered $0.021600   actual $0.008100   (2.67x)
after    metered $0.008100   actual $0.008100   (1.00x)
```

- [x] `pytest` passes (Python changes)
- [x] `ruff check .` is clean. `ruff format --check .` reports the same 21 files on this branch as on `main` (ruff 0.16.4 reformats fenced code in Markdown plus a few older-formatted files), so I left those untouched. The four files this PR changes are format-clean.
- [x] `npm test` and `npm run typecheck` pass in `js/`. No TypeScript changes here, run for the record.
- [x] Cost-map copies still match (both untouched)
- [x] CHANGELOG.md updated (user-facing changes)

## Related issues

No open issue. Follows up #94, which added `price_tokens(..., cache_read_input_tokens=...)` and wired `turn_cost` but not these adapters. TS parity is still the follow-up noted there and is not attempted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pricing for cached prompt tokens in OpenAI and LiteLLM integrations.
  * Improved handling of missing or malformed cache metadata.
  * Ensured fully cached prompts settle usage reservations correctly.
  * Preserved existing behavior for uncached prompts and responses without usage data.

* **Chores**
  * Updated the project version to 0.21.1.
  * Added changelog documentation for the pricing corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->