### PR TITLE
Add LiveKit record_tool for avatar/tool leg reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
-## Unreleased — py 0.21.0 / js 0.15.1
+## Unreleased — py 0.22.0 / js 0.15.1
 
 ### Added (py)
+
+- **LiveKit adapter now reconciles avatar and arbitrary-tool legs, not just
+  LLM/STT/TTS/telephony.** `LiveKitBudgetGuard.record_tool(tool, cost_usd,
+  label=…)` lands any paid leg LiveKit emits no metric for — avatar vendors
+  (Tavus, HeyGen, Simli, Beyond Presence) and paid tools/APIs the agent calls —
+  on the same ceiling and spend log as the existing voice legs. You supply the
+  USD cost (their price shapes vary by vendor, so there is no map to guess
+  from), and the leg flows through `guard.export_log()` / `guard.sync()` onto
+  Floe's ledger like every other leg, so a self-hosted LiveKit agent can
+  reconcile its WHOLE bill (LLM, STT, TTS, telephony, avatars, tools) with the
+  local-first / no-network-by-default invariant intact — the ledger leaves the
+  process only when you call `sync()`.
 
 - **Vapi and Retell custom-LLM adapters — the in-call voice guards, now in
   Python.** `floe_guard.integrations.vapi.VapiBudgetGuard` guards the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.21.0"
+version = "0.22.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/integrations/livekit.py
+++ b/src/floe_guard/integrations/livekit.py
@@ -35,6 +35,16 @@ since LiveKit emits no telephony metric. A leg with neither a vendor nor an
 override is left un-metered (the token-only contract); a vendor the voice map
 cannot price fails closed (:class:`~floe_guard.errors.UnpriceableVoiceError`).
 
+**Avatars and arbitrary paid tools.** Anything else a turn pays for — an avatar
+vendor's per-minute video (Tavus, HeyGen, Simli, Beyond Presence), or a paid
+API/tool the agent calls — lands on the same ledger via :meth:`record_tool`,
+which you call once with the leg's name and USD cost. LiveKit emits no metric
+for these, and their price shape varies by vendor (per-minute, per-session,
+per-frame), so you compute the cost and record it — there is no map to guess
+from. Like STT/TTS/telephony these flow through the guard's ``record_tool`` into
+the spend log, so ``guard.export_log()`` / ``guard.sync()`` reconciles EVERY
+paid leg (LLM, STT, TTS, telephony, avatars, tools) onto Floe's ledger.
+
 **Mid-call component swaps.** ``Agent.update_options()`` and
 ``AgentSession.update_agent()`` can replace the live LLM/STT/TTS objects mid-call.
 ``livekit-agents`` (verified against 1.6.6) emits **no swap-specific event** — the
@@ -373,6 +383,25 @@ class LiveKitBudgetGuard:
         if cost is not None:
             self._guard.record_tool("livekit-telephony", cost)
         return cost
+
+    def record_tool(self, tool: str, cost_usd: float, *, label: str | None = None) -> float:
+        """Record an arbitrary paid leg — an avatar frame or any paid tool/API call.
+
+        The catch-all for spend LiveKit emits no metric for: avatar vendors
+        (Tavus, HeyGen, Simli, Beyond Presence — usually per-minute video) and
+        paid tools/APIs the agent calls mid-turn. You supply the USD ``cost_usd``
+        directly (compute it from your vendor's rate — no voice-map lookup, since
+        their price shapes vary), and the leg accrues against the same ceiling and
+        lands in the spend log exactly like the STT/TTS/telephony legs — so
+        :meth:`~floe_guard.BudgetGuard.export_log` /
+        :meth:`~floe_guard.BudgetGuard.sync` reconciles it onto Floe's ledger.
+
+        A thin pass-through to :meth:`~floe_guard.BudgetGuard.record_tool`: name
+        the leg (e.g. ``"livekit-avatar-tavus"``), tag it with an optional
+        ``label`` (a task/customer id — synced as the row's task attribution).
+        Returns ``cost_usd``.
+        """
+        return self._guard.record_tool(tool, cost_usd, label=label)
 
     def _on_close(self, ev) -> None:
         # Session torn down with a turn still reserved — release it. Drop any

--- a/tests/test_livekit_adapter.py
+++ b/tests/test_livekit_adapter.py
@@ -12,6 +12,7 @@ room/runner isn't needed.
 from __future__ import annotations
 
 import asyncio
+import json
 import types
 
 import pytest
@@ -403,6 +404,91 @@ async def test_telephony_unconfigured_is_noop():
     budget, _, _ = _attached(guard)
     assert budget.meter_telephony(3.0) is None
     assert guard.advisory().spent_usd == 0.0
+
+
+# -- record_tool: avatar / arbitrary paid-tool legs ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_tool_accrues_avatar_leg_into_spend_log():
+    # An avatar vendor emits no LiveKit metric; the caller records the leg's cost
+    # and it lands on the ceiling and in the spend log like every other leg.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard)
+
+    returned = budget.record_tool("livekit-avatar-tavus", 0.42)
+
+    assert returned == pytest.approx(0.42)
+    assert guard.advisory().spent_usd == pytest.approx(0.42)
+    assert guard.tool_costs["livekit-avatar-tavus"] == pytest.approx(0.42)
+    legs = {e.model_or_tool: e.cost_usd for e in guard.spend_log}
+    assert legs == {"livekit-avatar-tavus": pytest.approx(0.42)}
+
+
+@pytest.mark.asyncio
+async def test_record_tool_label_tags_the_ledger_event():
+    # The label is the row's task/customer attribution once synced to Reconcile.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard)
+
+    budget.record_tool("apollo.people_lookup", 0.02, label="cust-acme")
+
+    (event,) = guard.spend_log
+    assert event.kind == "tool"
+    assert event.label == "cust-acme"
+
+
+@pytest.mark.asyncio
+async def test_record_tool_leg_flows_through_export_log():
+    # export_log() is exactly what push_ledger sends to /v1/agents/ledger/sync —
+    # a recorded tool leg must appear there as a kind="tool" line.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard)
+
+    budget.record_tool("livekit-avatar-heygen", 0.15)
+
+    lines = [json.loads(line) for line in guard.export_log().splitlines()]
+    assert len(lines) == 1
+    assert lines[0]["kind"] == "tool"
+    assert lines[0]["model_or_tool"] == "livekit-avatar-heygen"
+    assert lines[0]["cost_usd"] == pytest.approx(0.15)
+
+
+@pytest.mark.asyncio
+async def test_record_tool_counts_toward_full_call_total():
+    # AC: LLM + STT + TTS + telephony + avatar all sum to the call total.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, agent, session = _attached(
+        guard,
+        stt_model="deepgram-nova-3",
+        tts_model="elevenlabs-flash-v2.5",
+        telephony="twilio-us-inbound-local",
+    )
+    await _drive_turn(agent)
+    session.llm.emit("metrics_collected", _llm_metrics(500, 200))
+    session.stt.emit("metrics_collected", _stt_metric(30.0))
+    session.tts.emit("metrics_collected", _tts_metric(1200))
+    budget.meter_telephony(1.0)
+    budget.record_tool("livekit-avatar-tavus", 0.30)
+
+    legs = {e.model_or_tool: e.cost_usd for e in guard.spend_log}
+    assert set(legs) == {
+        "gpt-4o",
+        "livekit-stt",
+        "livekit-tts",
+        "livekit-telephony",
+        "livekit-avatar-tavus",
+    }
+    assert sum(legs.values()) == pytest.approx(guard.advisory().spent_usd)
+
+
+@pytest.mark.asyncio
+async def test_record_tool_rejects_negative_cost():
+    # Mirrors guard.record_tool's contract — a negative cost is a bug, not $0.
+    guard = BudgetGuard(limit_usd=100.00)
+    budget, _, _ = _attached(guard)
+    with pytest.raises(ValueError):
+        budget.record_tool("livekit-avatar-tavus", -0.01)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

A self-hosted LiveKit agent can now land **every** paid leg — including avatars and arbitrary paid tools — onto Floe's ledger, not just LLM/STT/TTS/telephony.

The adapter already meters LLM (via `LLMMetrics`), STT/TTS (via each plugin's `metrics_collected`), and telephony (via `meter_telephony`) — all routed through `BudgetGuard.record_tool(...)` into the spend log. But it exposed **no surface** for the paid legs LiveKit emits no metric for: avatar vendors (Tavus, HeyGen, Simli, Beyond Presence) and paid tools/APIs the agent calls mid-turn.

This adds `LiveKitBudgetGuard.record_tool(tool, cost_usd, *, label=None)` — a thin pass-through to `BudgetGuard.record_tool`. The caller supplies the USD cost (avatar/tool price shapes vary by vendor — per-minute, per-session, per-frame — so there is no voice-map to price from, and guessing would be wrong), and the leg accrues against the same ceiling and lands in the spend log exactly like the existing voice legs.

## Why this is the turnkey reconcile path

Every recorded leg flows through `guard.export_log()` → `guard.sync()` → `POST /v1/agents/ledger/sync`, which writes one reconciled `proxy_requests` row per leg (`model_or_tool` → modelId, `label` → task attribution, `cost_usd`). So recording avatars/tools via `record_tool` is all it takes to reconcile the **whole** call bill. The local-first / no-network-by-default invariant is untouched: the ledger leaves the process only on an explicit `sync()`.

## Scope note — direct call-end webhook emit was deliberately NOT built

The ticket asked whether to also add an optional direct per-turn emit to `/v1/webhooks/livekit/call-end/:token`. Skipped, because it does not cleanly match the contract:

- **Wrong granularity.** That endpoint ingests ONE aggregate call-total cost (`cost_usd` / `cost_micro_usdc`), deduped by `external_call_id` — it cannot express the per-leg breakdown that is the whole goal here. The per-leg reconcile path is `/v1/agents/ledger/sync`, which this PR builds on.
- **Wrong/absent auth model.** The webhook authenticates with a per-connection `webhook_token` (URL path) plus a Floe-issued per-connection secret used to compute `X-Floe-Signature` (HMAC-SHA256 over the raw body). floe-guard has no provisioning flow for those — it authenticates with the agent API key. Wiring it would mean guessing how the token/secret get into the guard, which the contract does not specify.

## Tests

`tests/test_livekit_adapter.py` — 5 new cases: avatar leg accrues into ceiling + spend log, `label` tags the ledger event, the leg appears in `export_log()` (what `sync` sends), it counts toward the full-call per-leg total alongside LLM/STT/TTS/telephony, and a negative cost is rejected.

- `pytest tests/test_livekit_adapter.py` → 28 passed
- full suite → 503 passed
- `ruff check` on changed files → clean

## Version

`pyproject.toml` py `0.21.0` → `0.22.0` (version-guard requires a bump on `src/floe_guard/` changes), CHANGELOG updated.

## Parity

Minor discoverability parity gap: the JS `LiveKitBudgetGuard` (`js/src/adapters/livekit.ts`) likewise has no public `recordTool` pass-through (it calls `guard.recordTool` internally for stt/tts/telephony). Out of scope for this PR (separate package/version); flagged for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recording avatar usage and other paid-tool costs in LiveKit sessions.
  - Paid-tool charges can include optional task or customer labels.
  - Recorded costs are included in spend totals, ledger exports, and reconciliation.

- **Bug Fixes**
  - Added validation to reject negative paid-tool costs.

- **Chores**
  - Updated the project version to 0.22.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->