### PR TITLE
chore: rebrand marketing website + email to floefinance.com (infra subdomains unchanged)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ next turn before it crosses your USD ceiling** — a runaway loop dies at $0.10
 instead of $4,000. Runs **in your process**: no account, no signup, no network,
 **no telemetry**. It also guards **any** LLM agent (OpenAI, Anthropic, CrewAI,
 LangChain, …) via plain `check()` / `record()` or an adapter. Python (`pip`) +
-TypeScript (`npm`). MIT. Built by [Floe](https://floelabs.xyz) — know what every AI call
+TypeScript (`npm`). MIT. Built by [Floe](https://floefinance.com) — know what every AI call
 really costs: cost per call across every vendor, margin per client, and rebilling your own
 customers off the actuals.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**hello@floelabs.xyz**. All complaints will be reviewed and investigated
+**hello@floefinance.com**. All complaints will be reviewed and investigated
 promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ Please upgrade to the latest version before reporting an issue.
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Report them privately by email to **security@floelabs.xyz**. If you do not get a
-response, use **hello@floelabs.xyz** as a fallback contact.
+Report them privately by email to **hello@floefinance.com**. If you do not get a
+response, use **hello@floefinance.com** as a fallback contact.
 
 Please include:
 

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,7 @@
     "middleware",
     "floe"
   ],
-  "homepage": "https://floelabs.xyz",
+  "homepage": "https://floefinance.com",
   "bugs": "https://github.com/Floe-Labs/floe-guard/issues",
   "repository": {
     "type": "git",

--- a/js/src/sync.ts
+++ b/js/src/sync.ts
@@ -23,7 +23,7 @@
  * (https-only, key-required, fail-closed), transported over `fetch` instead of
  * `urllib`.
  *
- *     Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+ *     Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floefinance.com
  */
 
 import { LedgerSyncError } from "./errors.js";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = ["pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.4"]
 floe-guard = "floe_guard.__main__:main"
 
 [project.urls]
-Homepage = "https://floelabs.xyz"
+Homepage = "https://floefinance.com"
 Dashboard = "https://dev-dashboard.floelabs.xyz"
 Source = "https://github.com/Floe-Labs/floe-guard"
 

--- a/src/floe_guard/hosted.py
+++ b/src/floe_guard/hosted.py
@@ -17,7 +17,7 @@ un-bypassable, cross-vendor *enforcement* is performed server-side by hosted Flo
 — not by this code. Use the returned number to inform a local ceiling; the
 server is the source of truth.
 
-    Upgrade: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+    Upgrade: https://dev-dashboard.floelabs.xyz  ·  https://floefinance.com
 """
 
 from __future__ import annotations

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -20,7 +20,7 @@ coverage/attribution; it does not move money or change any wallet balance.
 / ``reserved`` you set. **No prompts, no message content, no identifiers** beyond a
 ``label`` you choose.
 
-    Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floelabs.xyz
+    Opt in: https://dev-dashboard.floelabs.xyz  ·  https://floefinance.com
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Rebrand the marketing website and email references from floelabs.xyz to floefinance.com.

Infra subdomains (credit-api, marketplace, dev-dashboard, mcp, monitoring, api, app, dashboard, docs .floelabs.xyz) are intentionally left unchanged. All email mailboxes collapse to hello@floefinance.com.