### PR TITLE
Improve floe-guard first-run flow and add offline estimate CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Estimating 1,000 call(s) to gpt-4o (800 in / 300 out per call)
 
   per call:     $0.005000
   total:        $5.000000
-  price source: cost_map (snapshot 2026-08-24) — offline, no network
+  price source: cost_map (snapshot YYYY-MM-DD) — offline, no network
 
-Guard this exact workload with a ceiling at the run total:
+Guard this exact workload with a ceiling at (or above) the run total:
 
   from floe_guard import BudgetGuard
   guard = BudgetGuard(limit_usd=5.000000)   # covers 1,000 call(s)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ manual rates, no API key, no network:
 
 ```bash
 pip install "floe-guard[livekit]"     # the demo imports livekit-agents
-python examples/voice_call_cost_livekit.py
+python examples/voice_call_cost_livekit.py   # needs a repo checkout — examples/ aren't in the wheel
 ```
 
 ```text

--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ the loop" demo. Cloned the repo? The same demo is
 [`examples/runaway_loop.py`](examples/runaway_loop.py) (a thin wrapper around
 `floe_guard.demo.run_demo`).
 
+## Price a workload before you run it
+
+Straight from the install — no repository checkout, no API key, no network:
+
+```bash
+floe-guard estimate gpt-4o --calls 1000 --tokens-in 800 --tokens-out 300
+```
+
+```text
+Estimating 1,000 call(s) to gpt-4o (800 in / 300 out per call)
+
+  per call:     $0.005000
+  total:        $5.000000
+  price source: cost_map (snapshot 2026-08-24) — offline, no network
+
+Guard this exact workload with a ceiling at the run total:
+
+  from floe_guard import BudgetGuard
+  guard = BudgetGuard(limit_usd=5.000000)   # covers 1,000 call(s)
+```
+
+Priced from the same bundled cost map the guard enforces against — so the
+ceiling you set is the cost you just saw. Unpriceable models fail closed with a
+clean error, never a $0.00 guess.
+
 ## What did that call cost?
 
 The other demo — one voice call, every leg priced from the bundled map, no

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -1,10 +1,12 @@
 """floe-guard CLI.
 
-Two commands:
+Three commands:
 
 - ``floe-guard demo`` — run the no-key "stop a loop" demo (stub LLM, no account,
   no network) straight from the installed package. ``--limit-usd`` sets the
   ceiling (default $0.10).
+- ``floe-guard estimate`` — price an agent workload offline from the bundled
+  cost map and print the ``BudgetGuard`` ceiling that covers it.
 - ``floe-guard push`` — the **opt-in** ledger sync. It reads an
   :meth:`~floe_guard.BudgetGuard.export_log` JSONL ledger (from a file or stdin)
   and POSTs it to Floe's Reconcile Mode so your **Coverage Score** can count spend
@@ -22,6 +24,7 @@ from collections.abc import Sequence
 
 from .demo import run_demo
 from .errors import LedgerSyncError
+from .estimate import run_estimate
 from .sync import push_ledger
 
 
@@ -72,6 +75,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Spend ceiling for the demo, in USD (default: 0.10).",
     )
 
+    estimate = sub.add_parser(
+        "estimate",
+        help="Price a workload offline and print the BudgetGuard ceiling that covers it.",
+        description=(
+            "Price an agent workload (model, calls, tokens per call) from the "
+            "bundled cost map — no API key, no account, no network — and print "
+            "the BudgetGuard(limit_usd=...) ceiling that covers the run."
+        ),
+    )
+    estimate.add_argument("model", help="Model id as priced by the bundled cost map (e.g. gpt-4o).")
+    estimate.add_argument("--calls", type=int, default=1, help="Number of calls in the run (default: 1).")
+    estimate.add_argument(
+        "--tokens-in", type=int, default=1_000, help="Prompt tokens per call (default: 1000)."
+    )
+    estimate.add_argument(
+        "--tokens-out", type=int, default=1_000, help="Completion tokens per call (default: 1000)."
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "demo":
@@ -79,6 +100,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             run_demo(limit_usd=args.limit_usd)
         except ValueError as exc:
             # e.g. a negative/non-finite --limit-usd; surface a clean CLI error
+            # (exit 2) instead of a Python traceback.
+            parser.error(str(exc))
+        return 0
+
+    if args.command == "estimate":
+        try:
+            run_estimate(args.model, calls=args.calls, tokens_in=args.tokens_in, tokens_out=args.tokens_out)
+        except ValueError as exc:
+            # e.g. an unpriceable model or --calls 0; surface a clean CLI error
             # (exit 2) instead of a Python traceback.
             parser.error(str(exc))
         return 0

--- a/src/floe_guard/estimate.py
+++ b/src/floe_guard/estimate.py
@@ -10,6 +10,7 @@ cost?* and *what ceiling should I set?* — then shows the three lines that put 
 from __future__ import annotations
 
 import math
+from decimal import ROUND_CEILING, Decimal
 
 from .pricing import cost_map_generated_at, price_tokens, resolve_price
 
@@ -40,8 +41,14 @@ def run_estimate(
             "pass BudgetGuard(price_overrides=...) for models the map doesn't list"
         )
 
-    per_call = price_tokens(priced, tokens_in, tokens_out)
-    total = per_call * calls
+    try:
+        per_call = price_tokens(priced, tokens_in, tokens_out)
+        total = per_call * calls
+    except OverflowError as exc:
+        # A pathological --calls/--tokens-in overflows float math before the
+        # finite check below; surface it as the same clean CLI error (exit 2),
+        # not a traceback.
+        raise ValueError("workload is too large to estimate") from exc
     if not math.isfinite(total):
         raise ValueError("non-finite total — workload is too large to estimate")
 
@@ -55,8 +62,14 @@ def run_estimate(
     source_line += " — offline, no network"
     print(source_line + "\n")
 
-    print(f"Guard this exact workload with a ceiling at the run total:\n")
+    # Round the printed ceiling UP to 6 dp: a half-even round of the raw total
+    # can land a hair BELOW it, and the guard blocks at `projected > limit +
+    # 1e-12`, so a rounded-down ceiling would not actually cover the run it
+    # prints. Decimal(str(total)) rounds the shown value, not the float noise a
+    # plain ceil(total * 1e6) would bump on an already-exact total.
+    ceiling = float(Decimal(str(total)).quantize(Decimal("0.000001"), rounding=ROUND_CEILING))
+    print("Guard this exact workload with a ceiling at (or above) the run total:\n")
     print("  from floe_guard import BudgetGuard")
-    print(f"  guard = BudgetGuard(limit_usd={total:.6f})   # covers {calls:,} call(s)")
-    print("  # guard.check() before each call; guard.record(model, in, out) after")
+    print(f"  guard = BudgetGuard(limit_usd={ceiling:.6f})   # covers {calls:,} call(s)")
+    print("  # guard.check() before each call; guard.record('MODEL_ID', prompt_tokens, completion_tokens) after")
     print("\nAdd headroom for retries — the guard hard-stops AT the ceiling, not near it.")

--- a/src/floe_guard/estimate.py
+++ b/src/floe_guard/estimate.py
@@ -1,0 +1,62 @@
+"""Offline workload cost estimator — ``floe-guard estimate``.
+
+Prices an agent workload (model, calls, tokens per call) from the same bundled
+cost map the guard enforces against — no API key, no account, no network. The
+output answers the two questions a builder has before a run: *what will this
+cost?* and *what ceiling should I set?* — then shows the three lines that put a
+``BudgetGuard`` on exactly that workload.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .pricing import cost_map_generated_at, price_tokens, resolve_price
+
+
+def run_estimate(
+    model: str,
+    calls: int = 1,
+    tokens_in: int = 1_000,
+    tokens_out: int = 1_000,
+) -> None:
+    """Print the priced estimate for a workload. Raises ``ValueError`` on bad input.
+
+    Fail-closed like the guard itself: a model the bundled map cannot price is a
+    clean error, never a $0.00 guess.
+    """
+    if not model.strip():
+        raise ValueError("model id must not be empty")
+    if calls < 1:
+        raise ValueError(f"--calls must be >= 1 (got {calls})")
+    if tokens_in < 0 or tokens_out < 0:
+        raise ValueError(f"token counts must be >= 0 (got in={tokens_in}, out={tokens_out})")
+
+    priced = resolve_price(model)
+    if priced is None:
+        raise ValueError(
+            f"cannot price {model!r} from the bundled cost map "
+            "(unknown model or no published rates) — "
+            "pass BudgetGuard(price_overrides=...) for models the map doesn't list"
+        )
+
+    per_call = price_tokens(priced, tokens_in, tokens_out)
+    total = per_call * calls
+    if not math.isfinite(total):
+        raise ValueError("non-finite total — workload is too large to estimate")
+
+    print(f"Estimating {calls:,} call(s) to {model} ({tokens_in:,} in / {tokens_out:,} out per call)\n")
+    print(f"  per call:     ${per_call:.6f}")
+    print(f"  total:        ${total:.6f}")
+    source_line = f"  price source: {priced.source}"
+    generated = cost_map_generated_at()
+    if generated is not None:
+        source_line += f" (snapshot {generated})"
+    source_line += " — offline, no network"
+    print(source_line + "\n")
+
+    print(f"Guard this exact workload with a ceiling at the run total:\n")
+    print("  from floe_guard import BudgetGuard")
+    print(f"  guard = BudgetGuard(limit_usd={total:.6f})   # covers {calls:,} call(s)")
+    print("  # guard.check() before each call; guard.record(model, in, out) after")
+    print("\nAdd headroom for retries — the guard hard-stops AT the ceiling, not near it.")

--- a/tests/test_estimate.py
+++ b/tests/test_estimate.py
@@ -1,0 +1,45 @@
+"""Tests for the offline workload estimator (``floe-guard estimate``).
+
+gpt-4o in the bundled map is $2.5e-6 in / $1e-5 out per token, so the default
+1k/1k call prices at exactly $0.0125 — the same stub call the demo uses, which
+keeps these tests independent of cost-map drift for other models.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from floe_guard.estimate import run_estimate
+
+_PER_CALL = 0.0125  # gpt-4o: 1000 * $2.5e-6 + 1000 * $1e-5
+
+
+def test_estimate_prices_a_known_workload(capsys):
+    run_estimate("gpt-4o", calls=8, tokens_in=1_000, tokens_out=1_000)
+    out = capsys.readouterr().out
+    assert f"per call:     ${_PER_CALL:.6f}" in out
+    assert f"total:        ${_PER_CALL * 8:.6f}" in out
+    # The activation CTA: a copy-pasteable ceiling at the run total.
+    assert f"BudgetGuard(limit_usd={_PER_CALL * 8:.6f})" in out
+
+
+def test_estimate_scales_with_token_counts(capsys):
+    run_estimate("gpt-4o", calls=1, tokens_in=2_000, tokens_out=500)
+    out = capsys.readouterr().out
+    expected = 2_000 * 2.5e-6 + 500 * 1e-5
+    assert f"per call:     ${expected:.6f}" in out
+
+
+def test_estimate_fails_closed_on_unpriceable_model():
+    """A model the map cannot price is a clean error, never a $0.00 guess."""
+    with pytest.raises(ValueError, match="cannot price"):
+        run_estimate("not-a-real-model")
+
+
+def test_estimate_rejects_bad_arguments():
+    with pytest.raises(ValueError, match="--calls"):
+        run_estimate("gpt-4o", calls=0)
+    with pytest.raises(ValueError, match=">= 0"):
+        run_estimate("gpt-4o", tokens_in=-1)
+    with pytest.raises(ValueError, match="empty"):
+        run_estimate("   ")

--- a/tests/test_estimate.py
+++ b/tests/test_estimate.py
@@ -7,8 +7,12 @@ keeps these tests independent of cost-map drift for other models.
 
 from __future__ import annotations
 
+import re
+import socket
+
 import pytest
 
+from floe_guard.__main__ import main
 from floe_guard.estimate import run_estimate
 
 _PER_CALL = 0.0125  # gpt-4o: 1000 * $2.5e-6 + 1000 * $1e-5
@@ -43,3 +47,34 @@ def test_estimate_rejects_bad_arguments():
         run_estimate("gpt-4o", tokens_in=-1)
     with pytest.raises(ValueError, match="empty"):
         run_estimate("   ")
+
+
+def test_estimate_ceiling_is_never_below_the_run_total(capsys):
+    """The printed BudgetGuard ceiling must cover the raw total. gpt-4o at
+    1 in / 1 out per call = $0.0000125, which has a 7th decimal — a half-even
+    round of the shown total drops it to $0.000012 (BELOW the real cost), so the
+    ceiling has to round UP or it would not cover the run it prints."""
+    run_estimate("gpt-4o", calls=1, tokens_in=1, tokens_out=1)
+    out = capsys.readouterr().out
+    limit = float(re.search(r"limit_usd=([0-9.]+)", out).group(1))
+    assert limit >= 1 * 2.5e-6 + 1 * 1e-5  # 0.0000125, the true per-run cost
+
+
+def test_estimate_cli_rejects_oversized_input_cleanly():
+    """A pathological --calls overflows float math; the CLI must exit 2 (clean
+    parser error) rather than surface an OverflowError traceback."""
+    with pytest.raises(SystemExit) as exc:
+        main(["estimate", "gpt-4o", "--calls", str(10**400)])
+    assert exc.value.code == 2
+
+
+def test_estimate_touches_no_network(monkeypatch):
+    """The offline contract, enforced: estimate must open no socket and resolve
+    no name. (floe-guard's zero-telemetry default — proven, not just asserted.)"""
+
+    def _no_network(*_args, **_kwargs):
+        raise AssertionError("estimate must not touch the network")
+
+    monkeypatch.setattr(socket, "socket", _no_network)
+    monkeypatch.setattr(socket, "getaddrinfo", _no_network)
+    assert main(["estimate", "gpt-4o"]) == 0


### PR DESCRIPTION
Two commits from a first-time run of the funnel:

- Docs: the application/README flow pip install floe-guard → python examples/runaway_loop.py fails on a pip-only install (the wheel doesn't ship examples/). Noted that examples require a repo checkout.

- Feature: floe-guard estimate -- prices a workload offline from the same bundled cost map the guard enforces against, then prints the BudgetGuard(limit_usd=...) ceiling that covers the run as a copy-pasteable snippet. No key, no network; unpriceable models fail closed with a clean error. 4 new tests, full suite green (428 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an offline `floe-guard estimate` command to price workloads using bundled model pricing.
  - Supports specifying the model, call count, and input/output token usage.
  - Displays per-call and total costs, pricing details, and matching `BudgetGuard` configuration.

- **Documentation**
  - Added CLI usage guidance and clarified repository requirements for the LiveKit example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->