### PR TITLE
fix: point missing-key sync errors to API key creation

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.15.0",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.15.0",
+      "version": "0.15.2",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
   "type": "module",
   "license": "MIT",

--- a/js/src/sync.ts
+++ b/js/src/sync.ts
@@ -31,6 +31,7 @@ import { LedgerSyncError } from "./errors.js";
 const FLOE_API_KEY_ENV = "FLOE_API_KEY";
 const FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL";
 const DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz";
+const KEYS_URL = "https://dev-dashboard.floelabs.xyz/keys";
 const LEDGER_SYNC_PATH = "/v1/agents/ledger/sync";
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -175,7 +176,8 @@ export async function pushLedger(
   const key = ((apiKey ?? "") || envVar(FLOE_API_KEY_ENV)).trim();
   if (!key) {
     throw new LedgerSyncError(
-      `No Floe API key: pass apiKey or set ${FLOE_API_KEY_ENV}. ` +
+      `No Floe API key: pass apiKey or set ${FLOE_API_KEY_ENV} ` +
+        `(mint one at ${KEYS_URL} — sign-in is free). ` +
         "Sync is opt-in and needs your key.",
     );
   }

--- a/js/test/ledger-sync.test.ts
+++ b/js/test/ledger-sync.test.ts
@@ -226,6 +226,12 @@ describe("pushLedger fail-closed", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("missing key error points to key creation (the OSS→hosted handoff)", async () => {
+    await expect(pushLedger(ONE_EVENT)).rejects.toThrow(
+      /dev-dashboard\.floelabs\.xyz\/keys/,
+    );
+  });
+
   it("an empty/whitespace ledger is a no-op with no network", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     await expect(pushLedger("   ")).resolves.toBe(0);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.22.0"
+version = "0.22.1"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -38,6 +38,7 @@ FLOE_API_KEY_ENV = "FLOE_API_KEY"
 FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
 DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
 LEDGER_SYNC_PATH = "/v1/agents/ledger/sync"
+KEYS_URL = "https://dev-dashboard.floelabs.xyz/keys"
 
 # The ONLY keys allowed to leave the process — the export_log() schema. Enforced
 # (not just documented) below: a line carrying anything else is rejected, so a
@@ -176,7 +177,8 @@ def push_ledger(
     key = (api_key or os.environ.get(FLOE_API_KEY_ENV, "")).strip()
     if not key:
         raise LedgerSyncError(
-            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV}. "
+            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV} "
+            f"(mint one at {KEYS_URL} — sign-in is free). "
             "Sync is opt-in and needs your key."
         )
 

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -119,6 +119,15 @@ def test_push_ledger_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None
     urlopen.assert_not_called()
 
 
+def test_push_ledger_missing_key_points_to_key_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The missing-key error is the OSS→hosted handoff — it must say where keys come from.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with pytest.raises(LedgerSyncError, match=r"dev-dashboard\.floelabs\.xyz/keys"):
+        push_ledger(_ONE_EVENT)
+
+
 def test_push_ledger_empty_is_noop_no_network() -> None:
     with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
         assert push_ledger("   ") == 0


### PR DESCRIPTION
```markdown
The missing-key `LedgerSyncError` said an API key was required but not where to get one, leaving the user at a dead end when moving from local `floe-guard` usage to hosted sync.

This updates the error in both the Python and TypeScript packages to point directly to:

`https://dev-dashboard.floelabs.xyz/keys`

## Changes

- Add the API key creation URL to the missing-key sync error in Python.
- Add the same guidance to the TypeScript package.

## Testing

- [x] `pytest` passes
- [x] `ruff check .` and `ruff format .` are clean
- [x] `npm test` and `npm run typecheck` pass in `js/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated missing API key messages to direct you to the Floe dashboard for creating a key.
  * Clarified that dashboard sign-in is free.

* **Tests**
  * Added coverage to verify the key-creation guidance appears when no API key is configured.

* **Chores**
  * Updated package versions for the JavaScript and Python releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->