### PR TITLE
fix: unbreak main — estimate CLI lint (E501) + version bump to 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.23.0
+
+### Added (py)
+
+- **`floe-guard estimate` — offline workload cost estimator.** Price a planned
+  run (`estimate MODEL --calls N --tokens-in … --tokens-out …`) from the bundled
+  cost map — no key, no account, no network — and get a copy-pasteable
+  `BudgetGuard(limit_usd=…)` ceiling, rounded **up** so it always covers the run
+  it prints. Fail-closed on unpriceable models; oversized inputs exit cleanly.
+
 ## Unreleased — py 0.22.0 / js 0.15.1
 
 ### Added (py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.22.0"
+version = "0.23.0"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -85,7 +85,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     estimate.add_argument("model", help="Model id as priced by the bundled cost map (e.g. gpt-4o).")
-    estimate.add_argument("--calls", type=int, default=1, help="Number of calls in the run (default: 1).")
+    estimate.add_argument(
+        "--calls", type=int, default=1, help="Number of calls in the run (default: 1)."
+    )
     estimate.add_argument(
         "--tokens-in", type=int, default=1_000, help="Prompt tokens per call (default: 1000)."
     )
@@ -106,7 +108,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "estimate":
         try:
-            run_estimate(args.model, calls=args.calls, tokens_in=args.tokens_in, tokens_out=args.tokens_out)
+            run_estimate(
+                args.model, calls=args.calls, tokens_in=args.tokens_in, tokens_out=args.tokens_out
+            )
         except ValueError as exc:
             # e.g. an unpriceable model or --calls 0; surface a clean CLI error
             # (exit 2) instead of a Python traceback.

--- a/src/floe_guard/estimate.py
+++ b/src/floe_guard/estimate.py
@@ -52,7 +52,10 @@ def run_estimate(
     if not math.isfinite(total):
         raise ValueError("non-finite total — workload is too large to estimate")
 
-    print(f"Estimating {calls:,} call(s) to {model} ({tokens_in:,} in / {tokens_out:,} out per call)\n")
+    print(
+        f"Estimating {calls:,} call(s) to {model} "
+        f"({tokens_in:,} in / {tokens_out:,} out per call)\n"
+    )
     print(f"  per call:     ${per_call:.6f}")
     print(f"  total:        ${total:.6f}")
     source_line = f"  price source: {priced.source}"
@@ -71,5 +74,8 @@ def run_estimate(
     print("Guard this exact workload with a ceiling at (or above) the run total:\n")
     print("  from floe_guard import BudgetGuard")
     print(f"  guard = BudgetGuard(limit_usd={ceiling:.6f})   # covers {calls:,} call(s)")
-    print("  # guard.check() before each call; guard.record('MODEL_ID', prompt_tokens, completion_tokens) after")
+    print(
+        "  # guard.check() before each call; "
+        "guard.record('MODEL_ID', prompt_tokens, completion_tokens) after"
+    )
     print("\nAdd headroom for retries — the guard hard-stops AT the ceiling, not near it.")


### PR DESCRIPTION
#110 (offline `estimate` CLI) was admin-merged with **CI red** — the `lint` job (ruff) was failing, so `main` is currently red. Tests passed on every Python version; the failure was four `E501` line-too-long (>100) errors:

- `estimate.py:55` (`Estimating …` print) — from the original contribution
- `__main__.py:88` (`--calls` arg), `:109` (`run_estimate(...)` call) — from the original contribution
- `estimate.py:74` (the `record(...)` hint) — from my review follow-up, which lengthened the comment past 100

All four are wrapped under 100 cols; **CLI output is unchanged** (implicit string concatenation keeps the `record` hint one printed line). `ruff check .` is clean, `test_estimate.py` 7/7.

### Version bump (Version Guard)
Version Guard requires a version bump for any `src/floe_guard/` change, and #110 shipped none — so the estimate CLI (and the merged 0.22.0 LiveKit work) would **never publish**. Bumped `py 0.22.0 → 0.23.0` + changelog entry to carry it to release. If you'd rather batch differently, adjust the number or drop the bump and label this `skip-version-guard`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for the offline `floe-guard estimate` CLI, including cost estimation, budget ceiling output, handling of unpriceable models, and oversized inputs.

- **Chores**
  - Updated the project version to 0.23.0.
  - Improved formatting for command-line argument definitions and estimate output without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->