### PR TITLE
docs: point agent verify step at floe-guard demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ customers off the actuals.
    - **Voice** (per-turn): Python `floe_guard.integrations.pipecat` / `.livekit`;
      TS `floe-guard/adapters/{livekit,vapi,retell}` — reserve-before-turn.
    - **Paid tools**: `reserve_tool()` / `settle_tool()` block *before* the tool runs.
-3. **Verify offline** (no key, no network): `python examples/runaway_loop.py` — the
-   guard halts a stubbed loop after a few iterations.
+3. **Verify offline** (no key, no network): `floe-guard demo` — the
+   guard halts a stubbed loop after a few iterations. No repo checkout
+   (the wheel does not ship `examples/`).
 
 ## Rules — get these right
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   to get one — a dead end on the OSS→hosted handoff. Both packages now point to
   `dev-dashboard.floelabs.xyz/keys` (sign-in is free). Message-only; still raised
   before any network, so the no-network-by-default invariant is unchanged.
+- **Agent onboarding verify step uses `floe-guard demo`.** `AGENTS.md`,
+  `SKILL.md`, and `llms.txt` told a pip-only install to run
+  `python examples/runaway_loop.py`, which 404s because the wheel does not
+  ship `examples/`. The packaged command is the same demo README already
+  leads with.
 
 ## Unreleased — py 0.23.0
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -37,7 +37,7 @@ resp = call_your_llm(...)
 guard.record("gpt-4o", resp.usage.prompt_tokens, resp.usage.completion_tokens)
 ```
 
-Verify offline (no key, no network): `python examples/runaway_loop.py`.
+Verify offline (no key, no network): `floe-guard demo`.
 
 ## Skip the manual wiring — adapters
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@ it caps spend, holds no money, needs no account.
 
 - [README](https://github.com/Floe-Labs/floe-guard/blob/main/README.md): the full guide — quickstart, adapters, voice, gates, hosted, ledger sync.
 - [AGENTS.md](https://github.com/Floe-Labs/floe-guard/blob/main/AGENTS.md): step-by-step integration for a coding agent (install → wire → verify).
-- [Stop a loop (offline demo)](https://github.com/Floe-Labs/floe-guard#see-it-stop-a-loop-no-api-key-needed): `python examples/runaway_loop.py` — no key, no network.
+- [Stop a loop (offline demo)](https://github.com/Floe-Labs/floe-guard#see-it-stop-a-loop-no-api-key-needed): `floe-guard demo` — no key, no network.
 - [How it works](https://github.com/Floe-Labs/floe-guard#how-it-works): `check()` before, `record()` after; enforcement lives in the call path.
 
 ## Integrations

--- a/tests/test_agent_onboarding.py
+++ b/tests/test_agent_onboarding.py
@@ -25,3 +25,10 @@ def test_agent_verify_step_uses_packaged_demo() -> None:
             f"{path.name}: pip-install verify must use `floe-guard demo` "
             "(examples/runaway_loop.py is checkout-only)"
         )
+        # ...and the checkout-only command must be GONE, not merely accompanied:
+        # the wheel does not ship `examples/`, so a pip-only install cannot run
+        # it. Passing on presence alone would let both survive.
+        assert "examples/runaway_loop.py" not in text, (
+            f"{path.name}: drop the checkout-only `examples/runaway_loop.py` — "
+            "the wheel ships no `examples/`, so a pip-only install can't run it"
+        )

--- a/tests/test_agent_onboarding.py
+++ b/tests/test_agent_onboarding.py
@@ -1,0 +1,27 @@
+"""Pip-install onboarding for coding agents must verify without a repo checkout.
+
+``AGENTS.md``, ``SKILL.md``, and ``llms.txt`` are the unattended path
+(install → wire → verify). ``python examples/runaway_loop.py`` only works
+from a clone; the wheel does not ship ``examples/``. The packaged command is
+``floe-guard demo`` (see PR #89). README already leads with it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ONBOARDING = [
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "SKILL.md",
+    REPO_ROOT / "llms.txt",
+]
+
+
+def test_agent_verify_step_uses_packaged_demo() -> None:
+    for path in ONBOARDING:
+        text = path.read_text(encoding="utf-8")
+        assert "floe-guard demo" in text, (
+            f"{path.name}: pip-install verify must use `floe-guard demo` "
+            "(examples/runaway_loop.py is checkout-only)"
+        )


### PR DESCRIPTION
## Summary
Followed the unattended agent path (`pip install floe-guard`, then the verify command in AGENTS.md / SKILL.md / llms.txt) from a directory that is not this repo.

`python examples/runaway_loop.py` fails: the wheel does not ship `examples/`. `floe-guard demo` (PR #89) stops the stub loop at call #9 with no checkout.

README already leads with `floe-guard demo`. These three files still had the checkout-only command. This is not a new CLI (#89) and not the estimate work (#110).

## Changes
- AGENTS.md, SKILL.md, llms.txt: verify / stop-a-loop command is `floe-guard demo`
- tests/test_agent_onboarding.py: lock so a later README/docs slim cannot drop it
- CHANGELOG.md

## Testing
- [x] `pytest tests/test_agent_onboarding.py tests/test_examples_smoke.py::test_cli_demo` passes
- [x] `ruff check` / `ruff format` clean on the new test
- [ ] npm / JS (docs only, no js/ change)
- [ ] Cost-map copies (untouched)
- [x] CHANGELOG.md updated

Reproduced from `%TEMP%\floe-guard-pip-user` (no clone):
- old command: FileNotFoundError on `examples/runaway_loop.py`
- new command: `python -m floe_guard demo` halted at call #9

## Related issues
Not a close of an issue. Related: #89 (packaged demo), #92/#95 (README slims), #110 (estimate CLI; different leftover).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated offline verification instructions to use the packaged `floe-guard demo` command.
  * Clarified that the demo works without checking out the repository.
  * Updated the changelog to document the corrected onboarding guidance.

* **Tests**
  * Added coverage to verify that agent onboarding documentation references the working demo command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->