### PR TITLE
docs: reposition floe-guard around "know what every call costs" (not the budget guard)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,13 @@ an agent** (below); the last section covers **working on this repo**.
 
 ## What floe-guard is
 
-**The spend meter and budget gate for AI voice agents.** It meters
+**It tells you what every AI call really costs.** It meters
 STT + TTS + LLM + telephony **per call**, out of the box ([Pipecat](README.md#pipecat-voice)
-and [LiveKit](README.md#livekit-voice), Python & TypeScript), and **hard-stops the
-next turn before it crosses your USD ceiling** — a runaway loop dies at $0.10
-instead of $4,000. Runs **in your process**: no account, no signup, no network,
-**no telemetry**. It also guards **any** LLM agent (OpenAI, Anthropic, CrewAI,
+and [LiveKit](README.md#livekit-voice), Python & TypeScript), and keeps a **live ledger** of
+your agent's real spend. Connect free (one key) for your **Coverage Score** and **7-day
+history**. It also **hard-stops the next turn before it crosses your USD ceiling** — a
+runaway loop dies at $0.10 instead of $4,000. Runs **in your process**: no account, no
+signup, no network, **no telemetry**. It also guards **any** LLM agent (OpenAI, Anthropic, CrewAI,
 LangChain, …) via plain `check()` / `record()` or an adapter. Python (`pip`) +
 TypeScript (`npm`). MIT. Built by [Floe](https://floefinance.com) — know what every AI call
 really costs: cost per call across every vendor, margin per client, and rebilling your own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.23.2 / js 0.15.3
+
+### Changed (docs)
+
+- **Repositioned around the value, not the mechanism.** The README, package
+  one-liners (PyPI/npm), `AGENTS.md`, `SKILL.md`, and `llms.txt` now lead with
+  *"Know what every AI call really costs"* — the **live ledger** floe-guard keeps
+  locally, and the free **Coverage Score** + **7-day history** you get on connect
+  (matching floefinance.com's free tier) — with the budget hard-stop demoted to a
+  feature. No API change; the guard behaves exactly as before. Claims stay on the
+  right side of the line: the live ledger is local/OSS (`export_log()`), while
+  Coverage Score and 7-day history are the free hosted tier the ledger feeds.
+
 ## Unreleased — py 0.23.1 / js 0.15.2
 
 ### Fixed (py, js)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,14 @@
 [![CI](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/Floe-Labs/floe-guard/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**The spend meter and budget gate for AI agents.** Hard-stops the next LLM call,
-voice turn, or tool invocation *before* it crosses your USD ceiling — a runaway loop
-dies at $0.10 instead of $4,000. In-process, no account, no signup, **no telemetry by default**.
+**Know what every AI call really costs.** Your agent spends across a dozen vendors on
+every call — carrier, speech-to-text, model, voice, tools. floe-guard costs each call the
+moment it ends and keeps a **live ledger** of your agent's real spend. In-process, no
+account, no signup, **no telemetry by default**.
+
+Connect free (one key) for your **Coverage Score** and **7-day history** — the audit-grade
+picture of where every dollar went, up to $2K/month tracked, no card. And it *hard-stops* a
+runaway loop before it crosses your ceiling: $0.10 instead of $4,000.
 
 **Python** (`pip install floe-guard`): plain `check()` / `record()` or adapters for
 [OpenAI](#openai) · [Anthropic](docs/adapters.md#anthropic) · [Gemini](docs/adapters.md#google-gemini) · [CrewAI](docs/adapters.md#crewai) ·
@@ -29,9 +34,9 @@ tools, [`reserve_tool()` / `settle_tool()`](docs/advanced.md#tool-spend-under-th
 block *before* the call runs (`record_tool()` alone meters after the fact — it
 can't stop a call already made).
 
-## Works best with the Floe skill
+## Connect free for your Coverage Score + 7-day history
 
-`floe-guard` is a local ceiling — it stops paid work before your budget blows, standalone, no account needed. Hosted Floe is the system of record on top: it costs every call the moment it ends across every vendor (LLM, voice, telephony, data) on one ledger, shows your margin per client, and lets you invoice your own customers off the actuals — with spend controls enforced server-side. Add the **Floe agent skill** to teach Claude Code / Cursor the same govern-your-spend workflow `floe-guard` enforces locally:
+`floe-guard` keeps the live ledger locally — every call's real cost, in your process, no account. Connect it to hosted Floe (free, one key) and that ledger becomes your **Coverage Score** and **7-day history**: the audit-grade picture of where every dollar went, up to $2K/month tracked, no card. Hosted is the system of record on top — it costs every call the moment it ends across every vendor on one ledger, ties spend to client and campaign, shows your margin per client, and lets you invoice your own customers off the actuals, with spend controls enforced server-side. Add the **Floe agent skill** to teach Claude Code / Cursor the same govern-your-spend workflow:
 
 ```bash
 npx skills add floe-labs/agent-skills

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: floe-guard
-description: The spend meter and budget gate for AI voice agents — meters STT + TTS + LLM + telephony per call (Pipecat, LiveKit — Python & TypeScript) and hard-stops the next turn before it crosses a USD ceiling. Use when an agent's spend must be capped in-process with no account or telemetry; also guards any LLM agent and paid tool calls.
+description: Know what every AI call really costs — floe-guard meters STT + TTS + LLM + telephony per call (Pipecat, LiveKit — Python & TypeScript), keeps a live ledger of real spend, and hard-stops the next turn before it crosses a USD ceiling. Free Coverage Score + 7-day history on connect. Use when an agent's spend must be seen and capped in-process with no account or telemetry; also guards any LLM agent and paid tool calls.
 license: MIT
 homepage: https://github.com/Floe-Labs/floe-guard
 ---
 
-# floe-guard — local budget guardrail
+# floe-guard — know what every AI call costs
 
-The spend meter and budget gate for AI **voice** agents: it meters STT + TTS + LLM +
+floe-guard meters STT + TTS + LLM +
 telephony **per call** ([Pipecat](https://github.com/Floe-Labs/floe-guard#pipecat-voice),
 [LiveKit](https://github.com/Floe-Labs/floe-guard#livekit-voice) — Python & TypeScript)
-and hard-stops the next turn *before* it crosses a USD ceiling. In-process, no account,
-no telemetry. It also guards **any** LLM/tool call the same way. Budget, not balance —
+and keeps a **live ledger** of your agent's real spend. Connect free for your **Coverage
+Score** and **7-day history**. It also hard-stops the next turn *before* it crosses a USD
+ceiling. In-process, no account, no telemetry. Guards **any** LLM/tool call the same way. Budget, not balance —
 it caps spend, holds no money, needs no account.
 
 > This is the **library** skill. For the whole govern-your-spend workflow (spend

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floe-guard",
-  "version": "0.15.2",
-  "description": "A local budget guardrail for AI agents — hard-stops your agent before its next LLM call crosses a USD ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters.",
+  "version": "0.15.3",
+  "description": "Know what every AI call really costs — a live ledger of your agent's real spend, plus a hard-stop before runaway spend crosses your ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters. Local, no account, no telemetry.",
   "type": "module",
   "license": "MIT",
   "keywords": [

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,11 @@
 # floe-guard
 
-> The spend meter and budget gate for AI voice agents. It meters STT + TTS + LLM +
-> telephony per call (Pipecat, LiveKit — Python & TypeScript) and hard-stops the next
-> turn *before* it crosses a USD ceiling, so a runaway loop dies at $0.10 instead of
-> $4,000. Runs in your process: no account, no signup, no network, no telemetry. It
-> also guards any LLM/tool call the same way. Built by Floe — cost controls for Voice AI.
+> Know what every AI call really costs. floe-guard meters STT + TTS + LLM + telephony per
+> call (Pipecat, LiveKit — Python & TypeScript) and keeps a live ledger of your agent's real
+> spend. Connect free (one key) for your Coverage Score and 7-day history. It also hard-stops
+> the next turn *before* it crosses a USD ceiling, so a runaway loop dies at $0.10 instead of
+> $4,000. Runs in your process: no account, no signup, no network, no telemetry. Guards any
+> LLM/tool call the same way. Built by Floe — know what every AI call really costs.
 
 Install `pip install floe-guard` (Python) or `npm i floe-guard` (TypeScript). Drop in a
 voice adapter (Pipecat / LiveKit) for per-turn STT+TTS+LLM+telephony enforcement, or wire

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.23.1"
-description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
+version = "0.23.2"
+description = "Know what every AI call really costs — a live ledger of your agent's real spend (LLM, voice, telephony, tools), plus a hard-stop before runaway spend crosses your ceiling. Local, no account, no telemetry."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
The README, PyPI/npm one-liners, `AGENTS.md`, `SKILL.md` and `llms.txt` all led with the **mechanism** — *"the spend meter and budget gate … hard-stops before your ceiling."* Measured on `main`: `ceiling` 40×, `hard-stop` 22×, but `"live ledger"` 0×, `"7-day"` 0×, and `Coverage Score` only ever inside the hosted-sync aside. The value props we actually sell were absent or buried.

This flips the lead to match **floefinance.com** (hero: *"Know what every AI call really costs"*; free tier = **Live ledger · Coverage Score · 7-day history**, up to $2K/mo):

- **README** hero + the hosted section (now "Connect free for your Coverage Score + 7-day history").
- **PyPI + npm one-liners** (`pyproject`/`package.json` description) — the highest-leverage change; first thing anyone sees.
- **AGENTS.md / SKILL.md / llms.txt** intros.

Order is now: cost visibility (**live ledger**) → free hosted value (**Coverage Score + 7-day history**) → the hard-stop as *a feature*, not the pitch.

### Honesty line held (OSS vs hosted)
- **Live ledger** — real in OSS (`spend_log` / `export_log()`), so we lead with it.
- **Coverage Score / 7-day history** — hosted free tier; framed as *"connect free (one key)"*, never as something the package computes locally.
- The budget guard is **demoted, not deleted** — it's a real capability and the honest "it also stops overspend" proof point.

No code change; guard behaves exactly as before. Bumps **py 0.23.2 / js 0.15.3** (Version Guard: `pyproject` + js metadata changed) + changelog. ruff clean, tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product messaging to highlight live, per-call AI spend tracking across LLM, STT, TTS, and telephony.
  * Clarified local budget hard-stop protection, no-telemetry operation, Coverage Score, and 7-day history.
  * Reframed hosted connectivity and attribution capabilities while distinguishing local and hosted functionality.
  * Expanded descriptions to cover protection for paid tool calls and broader AI workflows.

* **Chores**
  * Updated package versions to the latest patch releases.
  * Added an Unreleased changelog entry confirming no API or guard behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->