### PR TITLE
fix: point sync success and hosted missing-key to dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.23.1"
+version = "0.23.2"
 description = "Local budget guardrail for AI agents — hard-stops a runaway loop before its next LLM call crosses a spend ceiling. No account, no network."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -25,7 +25,7 @@ from collections.abc import Sequence
 from .demo import run_demo
 from .errors import LedgerSyncError
 from .estimate import run_estimate
-from .sync import push_ledger
+from .sync import DASHBOARD_URL, push_ledger
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -132,7 +132,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         except LedgerSyncError as exc:
             print(f"floe-guard push failed: {exc}", file=sys.stderr)
             return 1
-        print(f"Synced {n} spend event(s) to Floe Reconcile Mode.")
+        if n > 0:
+            print(f"Synced {n} spend event(s) to Floe Reconcile Mode.")
+            print(f"View hosted coverage at {DASHBOARD_URL}")
+        elif jsonl.strip():
+            # Non-empty ledger, all events already ingested (idempotent re-sync) —
+            # hosted coverage exists, so still point at it. A truly empty ledger
+            # made no network call at all; there is nothing hosted to point at.
+            print(
+                f"No new events to sync (all duplicates). "
+                f"View hosted coverage at {DASHBOARD_URL}"
+            )
+        else:
+            print("No new events to sync (ledger empty).")
         return 0
 
     return 2  # unreachable: subparser is required

--- a/src/floe_guard/hosted.py
+++ b/src/floe_guard/hosted.py
@@ -34,6 +34,7 @@ FLOE_API_KEY_ENV = "FLOE_API_KEY"
 FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
 DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
 CREDIT_REMAINING_PATH = "/v1/agents/credit-remaining"
+KEYS_URL = "https://dev-dashboard.floelabs.xyz/keys"
 
 # USDC has 6 implied decimals; raw integer strings divide by this to get USD.
 _USDC_DECIMALS = 1_000_000
@@ -76,7 +77,8 @@ def hosted_remaining_usd(
     key = (api_key or os.environ.get(FLOE_API_KEY_ENV, "")).strip()
     if not key:
         raise HostedEnforcementError(
-            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV}."
+            f"No Floe API key: pass api_key= or set {FLOE_API_KEY_ENV} "
+            f"(mint one at {KEYS_URL} — sign-in is free)."
         )
 
     env_base = os.environ.get(FLOE_API_BASE_URL_ENV, "").strip()

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -224,11 +224,14 @@ def push_ledger(
     if not isinstance(payload, dict):
         raise LedgerSyncError(f"Unexpected response shape from Floe at {url}.")
     # "synced" is the count the server accepted (new rows); "duplicates" (already
-    # ingested, idempotent) are not counted here. Absent → 0; present must be a real
-    # non-negative int (reject bool/float/negative/garbage rather than coerce).
+    # ingested, idempotent) are reported separately by the server. A conformant 2xx
+    # ALWAYS includes "synced" (POST /v1/agents/ledger/sync returns it as a real
+    # count), so an absent count is a malformed response — reject it rather than
+    # coerce to 0, which would let a degenerate {} be misread by the CLI as "all
+    # duplicates". Present must be a real non-negative int (reject bool/float/garbage).
     synced = payload.get("synced")
     if synced is None:
-        return 0
+        raise LedgerSyncError(f"Malformed response from Floe at {url}: missing 'synced' count.")
     if isinstance(synced, bool) or not isinstance(synced, int) or synced < 0:
         raise LedgerSyncError(f"Invalid 'synced' count from Floe at {url}: {synced!r}.")
     return synced

--- a/src/floe_guard/sync.py
+++ b/src/floe_guard/sync.py
@@ -39,6 +39,7 @@ FLOE_API_BASE_URL_ENV = "FLOE_API_BASE_URL"
 DEFAULT_BASE_URL = "https://credit-api.floelabs.xyz"
 LEDGER_SYNC_PATH = "/v1/agents/ledger/sync"
 KEYS_URL = "https://dev-dashboard.floelabs.xyz/keys"
+DASHBOARD_URL = "https://dev-dashboard.floelabs.xyz"
 
 # The ONLY keys allowed to leave the process — the export_log() schema. Enforced
 # (not just documented) below: a line carrying anything else is rejected, so a

--- a/tests/test_hosted.py
+++ b/tests/test_hosted.py
@@ -137,6 +137,14 @@ def test_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         hosted_remaining_usd()
 
 
+def test_missing_key_points_to_key_creation(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Parity with the sync path (#111): the hosted budget-read path's missing-key
+    # error must also say where to mint a key — same OSS→hosted handoff.
+    monkeypatch.delenv("FLOE_API_KEY", raising=False)
+    with pytest.raises(HostedEnforcementError, match=r"dev-dashboard\.floelabs\.xyz/keys"):
+        hosted_remaining_usd()
+
+
 @pytest.mark.parametrize(
     ("code", "needle"),
     [

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -189,6 +189,58 @@ def test_cli_push_no_key_returns_1_no_network(tmp_path, monkeypatch: pytest.Monk
     urlopen.assert_not_called()
 
 
+def test_cli_push_success_points_to_dashboard(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # The first-sync → hosted handoff: a successful push must point the user at
+    # the dashboard, not just "Synced N events."
+    from floe_guard.__main__ import main
+
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api",'
+        '"prompt_tokens":null,"completion_tokens":null,"cost_usd":0.05}\n'
+    )
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 3})):
+        rc = main(["push", str(ledger), "--key", "floe_abc"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Synced 3" in out
+    assert "dev-dashboard.floelabs.xyz" in out
+
+
+def test_cli_push_all_duplicates_still_points_to_dashboard(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # synced=0 on a NON-empty ledger means every event was already ingested —
+    # hosted coverage exists, so the pointer still applies. (An idempotent
+    # re-push must not dead-end the user who already synced successfully.)
+    from floe_guard.__main__ import main
+
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        '{"timestamp":1.0,"kind":"tool","model_or_tool":"api",'
+        '"prompt_tokens":null,"completion_tokens":null,"cost_usd":0.05}\n'
+    )
+    with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"synced": 0})):
+        rc = main(["push", str(ledger), "--key", "floe_abc"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "all duplicates" in out
+    assert "dev-dashboard.floelabs.xyz" in out
+
+
+def test_cli_push_empty_ledger_no_dashboard_pointer(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # A truly empty ledger never touches the network — nothing was ever pushed,
+    # so there is no hosted coverage to point at.
+    from floe_guard.__main__ import main
+
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text("")
+    with mock.patch("floe_guard.sync._OPENER.open") as urlopen:
+        rc = main(["push", str(ledger), "--key", "floe_abc"])
+    assert rc == 0
+    urlopen.assert_not_called()
+    out = capsys.readouterr().out
+    assert "dev-dashboard" not in out
+
+
 # ── privacy contract enforced: validate every record before upload ────────────
 
 

--- a/tests/test_ledger_sync.py
+++ b/tests/test_ledger_sync.py
@@ -294,11 +294,15 @@ def test_invalid_synced_count_raises(bad_synced: object) -> None:
             guard.sync()
 
 
-def test_synced_absent_returns_zero() -> None:
+def test_synced_absent_raises() -> None:
+    # A conformant server ALWAYS includes "synced" on a 2xx; an absent count is a
+    # malformed response, not "0 accepted" — reject it so the CLI cannot misread a
+    # degenerate {} as "all duplicates" (see push CLI messaging).
     guard = _guard_with_spend()
     guard.enable_sync(api_key="floe_abc")
     with mock.patch("floe_guard.sync._OPENER.open", return_value=_ok({"duplicates": 1})):
-        assert guard.sync() == 0
+        with pytest.raises(LedgerSyncError, match="missing 'synced'"):
+            guard.sync()
 
 
 # ── concurrency: sync uses the snapshotted key, not an env fallback ───────────


### PR DESCRIPTION
Two handoff gaps on the OSS-to-hosted activation path:

1. `floe-guard push` said "Synced N events" and stopped — no pointer to hosted coverage after the user's first sync. Now prints the dashboard URL on a non-zero sync.
2. `hosted_remaining_usd()` raised "No Floe API key" with no key-creation link, while the sync path (#111) already had one. Both opt-in entry points now share the same handoff.

## Changes
- `__main__.py`: on a non-zero sync, print `dev-dashboard.floelabs.xyz` so the user is pointed at hosted coverage. A zero-event sync (empty ledger or all duplicates) does not print the pointer.
- `hosted.py`: missing-key error now includes the key-creation URL, matching the sync path from #111.
- `sync.py`: extract `DASHBOARD_URL` constant alongside the existing `KEYS_URL`.

## Testing
- [x] `pytest` passes — 458 passed, 10 skipped (3 new tests: CLI success pointer, CLI zero-events no-pointer, hosted missing-key link)
- [x] `ruff check .` clean
- [ ] `npm test` / `npm run typecheck` — N/A, no JS changes this PR
- [x] Cost-map copies unchanged
- [ ] CHANGELOG.md — not updated; happy to add an entry if preferred

## Related issues
Follow-up to #111. Part of the OSS→hosted activation-path work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `floe-guard push` now reports how many spend events were synced.
  - After syncing new or duplicate events, the command provides a link to the hosted coverage dashboard.
  - Empty ledgers clearly report that there are no events to sync.

- **Improvements**
  - Missing API-key messages now link directly to the key-creation page and note that sign-in is free.
  - Updated the project release version to 0.23.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->