### PR TITLE
Fix broken demo → push activation funnel (write a local ledger)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ venv/
 .vscode/
 .idea/
 .venv-fg/
+
+# Demo output (floe-guard demo writes this to CWD)
+floe-ledger.jsonl

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ response = call_your_llm(...)         # your existing call
 guard.record("gpt-4o", response.usage.prompt_tokens, response.usage.completion_tokens)
 ```
 
+Ready to land that spend on your **Coverage Score**? Save the ledger with
+`guard.export_log()` to a JSONL file, then run `floe-guard push <file>` — opt-in,
+priced spend events only, no prompts or content leave your process.
+
 When the next call would cross the ceiling, the guard raises `BudgetExceeded` and
 prints:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.23.4"
+version = "0.23.5"
 description = "Know what every AI call really costs — a live ledger of your agent's real spend (LLM, voice, telephony, tools), plus a hard-stop before runaway spend crosses your ceiling. Local, no account, no telemetry."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/__main__.py
+++ b/src/floe_guard/__main__.py
@@ -104,6 +104,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             # e.g. a negative/non-finite --limit-usd; surface a clean CLI error
             # (exit 2) instead of a Python traceback.
             parser.error(str(exc))
+        except OSError as exc:
+            # The demo itself ran; only the ledger write failed (read-only CWD,
+            # full disk). Report it cleanly instead of dumping a traceback.
+            print(f"floe-guard demo: could not write the spend ledger: {exc}", file=sys.stderr)
+            return 1
         return 0
 
     if args.command == "estimate":

--- a/src/floe_guard/demo.py
+++ b/src/floe_guard/demo.py
@@ -53,7 +53,9 @@ def run_demo(limit_usd: float = 0.10) -> None:
             # account (the demo's promise holds). ``push`` below is the explicit
             # opt-in step that actually sends it.
             ledger_path = "./floe-ledger.jsonl"
-            with open(ledger_path, "w", encoding="utf-8") as fh:
+            # newline="\n": export_log() is \n-terminated; force LF so Windows text
+            # mode doesn't rewrite it to \r\n and desync byte-for-byte concat/diff.
+            with open(ledger_path, "w", encoding="utf-8", newline="\n") as fh:
                 fh.write(guard.export_log())
             print(f"\nWrote spend ledger to {ledger_path}", flush=True)
             print(

--- a/src/floe_guard/demo.py
+++ b/src/floe_guard/demo.py
@@ -49,6 +49,18 @@ def run_demo(limit_usd: float = 0.10) -> None:
                 f"\nLoop stopped at call #{call}. The agent never got to spend past the budget.",
                 flush=True,
             )
+            # Write the recorded spend ledger to a LOCAL file — no network, no
+            # account (the demo's promise holds). ``push`` below is the explicit
+            # opt-in step that actually sends it.
+            ledger_path = "./floe-ledger.jsonl"
+            with open(ledger_path, "w", encoding="utf-8") as fh:
+                fh.write(guard.export_log())
+            print(f"\nWrote spend ledger to {ledger_path}", flush=True)
+            print(
+                f"Opt-in next step (priced spend events only — no prompts, no content):\n"
+                f"  floe-guard push {ledger_path}",
+                flush=True,
+            )
             break
 
         response = _stub_llm()

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -25,6 +25,25 @@ def test_demo_blocks_the_first_call_when_ceiling_is_below_one_call(capsys):
     assert not re.search(r"call #1: \+\$", out)
 
 
+def test_cli_demo_ledger_write_failure_returns_nonzero(capsys, monkeypatch):
+    """A failed ledger write (read-only CWD / full disk) must exit non-zero with a
+    clean message — not an unhandled OSError traceback. The demo already ran; only
+    the convenience ledger write failed."""
+    from floe_guard.__main__ import main
+
+    real_open = open
+
+    def failing_open(path, *args, **kwargs):
+        if str(path).endswith("floe-ledger.jsonl"):
+            raise OSError("read-only file system")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", failing_open)
+    rc = main(["demo"])
+    assert rc == 1
+    assert "could not write the spend ledger" in capsys.readouterr().err
+
+
 def test_demo_never_records_spend_above_the_ceiling(capsys):
     """For a ceiling that is NOT an exact multiple of the per-call cost, the last
     recorded running total must stay at or below the ceiling."""


### PR DESCRIPTION
## The funnel was broken

The packaged activation path is `demo` → `push` → **Coverage Score** (the reason to connect hosted). It dead-ends today:

- `run_demo()` in `src/floe_guard/demo.py` prints the hard-stop and returns — **it never writes a ledger.**
- `floe-guard push` (`src/floe_guard/__main__.py`) requires an `export_log()` JSONL ledger file as its input.

So the shipped sequence is: `demo` (produces nothing) → `push` (needs a file nothing produced) → dead end. Coverage Score is unreachable from the shipped commands.

## The fix (surgical, two parts)

1. **`run_demo()`** — after the loop hard-stops, write the guard's recorded ledger to `./floe-ledger.jsonl` via `guard.export_log()`, then print the ledger path and the exact opt-in next command (`floe-guard push ./floe-ledger.jsonl`), annotated as opt-in / priced spend events only (no prompts, no content). Writing a **local** file keeps the demo's promise intact — no API key, no account, **no network**; `push` stays the explicit opt-in send.
2. **README quickstart** — one line after the `BudgetGuard` wiring example so real integrators (not just the demo) know the bridge: `guard.export_log()` → save JSONL → `floe-guard push <file>` lands that spend on their Coverage Score (opt-in, zero-telemetry framing preserved).

No push/sync logic changed. No other refactors.

## Verification

- Ran `floe-guard demo` from a scratch dir: `./floe-ledger.jsonl` is created with valid JSONL (8 recorded events from the calls that ran before the hard-stop) and the push hint prints.
- Ran `floe-guard push ./floe-ledger.jsonl`: it **finds and parses** the file, failing only on the missing API key (expected opt-in behavior) — not a "cannot read" error.
- Full pytest suite: **521 passed**. `ruff` clean on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in way to export the local spend ledger for uploading.
  * Demo runs now save priced spend events to a ledger file when the budget guard stops the loop.
  * Added instructions for uploading the ledger through the command line.
  * Prompts and content are excluded from exported data and are never uploaded automatically.

* **Documentation**
  * Updated the README with ledger export and upload guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->