### PR TITLE
fix: reject LiteLLM stream=True before the unmetered call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
 
 - **LiteLLM `stream=True` is rejected before the call.** A streamed LiteLLM
   response has no final `usage` to settle, so `guarded_completion` /
-  `guarded_acompletion` and the callback's `log_pre_api_call` were fail-open:
-  the call ran unmetered (and CrewAI via the callback settled `$0`). Matches
-  the OpenAI/Anthropic adapters: `stream=True` raises `ValueError` before
-  reserve or the provider call. The callback also latches `tripped` so
-  `budget_guarded_llm` re-raises on the next step after LiteLLM swallows the
-  hook exception.
+  `guarded_acompletion` were fail-open: the call ran unmetered. Matches the
+  OpenAI/Anthropic adapters: `stream=True` raises `ValueError` before reserve
+  or the provider call. `budget_guarded_llm` refuses the same config on this
+  `call`/`acall` (constructor `stream=True` or a per-call kwarg) before
+  dispatch, so LiteLLM never sees the request. The callback still cannot stop
+  an in-flight call — LiteLLM swallows hook exceptions — but it latches
+  `tripped` so a later guarded call stops. Callback-only registration
+  (`guard_crew`) remains best-effort.
 
 ## Unreleased — py 0.23.2 / js 0.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ both packages adhere to [Semantic Versioning](https://semver.org/).
   `guarded_acompletion` were fail-open: the call ran unmetered. Matches the
   OpenAI/Anthropic adapters: `stream=True` raises `ValueError` before reserve
   or the provider call. `budget_guarded_llm` refuses the same config on this
-  `call`/`acall` (constructor `stream=True` or a per-call kwarg) before
-  dispatch, so LiteLLM never sees the request. The callback still cannot stop
+  `call`/`acall` (constructor `stream=True`, a per-call kwarg, or CrewAI's
+  call-scoped `_effective_stream` used by `stream_events()`) before dispatch,
+  so LiteLLM never sees the request. The callback still cannot stop
   an in-flight call — LiteLLM swallows hook exceptions — but it latches
   `tripped` so a later guarded call stops. Callback-only registration
   (`guard_crew`) remains best-effort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.23.6 / js 0.15.4
+
+### Fixed (py)
+
+- **LiteLLM `stream=True` is rejected before the call.** A streamed LiteLLM
+  response has no final `usage` to settle, so `guarded_completion` /
+  `guarded_acompletion` and the callback's `log_pre_api_call` were fail-open:
+  the call ran unmetered (and CrewAI via the callback settled `$0`). Matches
+  the OpenAI/Anthropic adapters: `stream=True` raises `ValueError` before
+  reserve or the provider call. The callback also latches `tripped` so
+  `budget_guarded_llm` re-raises on the next step after LiteLLM swallows the
+  hook exception.
+
 ## Unreleased — py 0.23.2 / js 0.15.3
 
 ### Changed (docs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "floe-guard"
-version = "0.23.5"
+version = "0.23.6"
 description = "Know what every AI call really costs — a live ledger of your agent's real spend (LLM, voice, telephony, tools), plus a hard-stop before runaway spend crosses your ceiling. Local, no account, no telemetry."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/floe_guard/integrations/crewai.py
+++ b/src/floe_guard/integrations/crewai.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..guard import BudgetGuard
-from .litellm import budget_guard_callback
+from .litellm import _reject_streaming, budget_guard_callback
 
 
 def _require_crewai() -> Any:
@@ -86,6 +86,9 @@ def budget_guarded_llm(guard: BudgetGuard, model: str, **kwargs: Any) -> Any:
     callback recorded (``tripped``) and runs ``guard.check()``. A crew whose
     spend crosses the ceiling — or that hits an unpriceable model with
     ``fail_closed=True`` — stops at the next call instead of running unmetered.
+    ``stream=True`` (constructor or per-call kwarg) is refused on *this* call,
+    before ``super().call()`` / ``acall()``, because a stream has no usage to
+    settle and LiteLLM would otherwise dispatch it after swallowing the hook.
 
     A recorded violation latches: it persists for the life of the callback
     (which :func:`guard_crew` reuses per guard) even if you later add a price
@@ -106,16 +109,28 @@ def budget_guarded_llm(guard: BudgetGuard, model: str, **kwargs: Any) -> Any:
             raise tripped.with_traceback(None)
         guard.check()
 
+    def _reject_stream(llm: Any, call_kwargs: dict[str, Any]) -> None:
+        stream = call_kwargs.get("stream")
+        if stream is None:
+            stream = getattr(llm, "stream", None)
+        if stream is None:
+            stored = getattr(llm, "kwargs", None)
+            if isinstance(stored, dict):
+                stream = stored.get("stream")
+        _reject_streaming({"stream": stream})
+
     class BudgetGuardedLLM(LLM):  # type: ignore[misc]
         """``crewai.LLM`` that enforces the budget outside LiteLLM's callbacks."""
 
         def call(self, *args: Any, **call_kwargs: Any) -> Any:
+            _reject_stream(self, call_kwargs)
             _enforce()
             return super().call(*args, **call_kwargs)
 
         async def acall(self, *args: Any, **call_kwargs: Any) -> Any:
             # CrewAI 1.x async crews await acall(); without this override they
             # would bypass enforcement entirely. Harmless on 0.x (never invoked).
+            _reject_stream(self, call_kwargs)
             _enforce()
             return await super().acall(*args, **call_kwargs)
 

--- a/src/floe_guard/integrations/crewai.py
+++ b/src/floe_guard/integrations/crewai.py
@@ -112,6 +112,10 @@ def budget_guarded_llm(guard: BudgetGuard, model: str, **kwargs: Any) -> Any:
     def _reject_stream(llm: Any, call_kwargs: dict[str, Any]) -> None:
         stream = call_kwargs.get("stream")
         if stream is None:
+            effective = getattr(llm, "_effective_stream", None)
+            if callable(effective):
+                stream = effective()
+        if stream is None:
             stream = getattr(llm, "stream", None)
         if stream is None:
             stored = getattr(llm, "kwargs", None)

--- a/src/floe_guard/integrations/litellm.py
+++ b/src/floe_guard/integrations/litellm.py
@@ -163,6 +163,16 @@ def _record_response(
     )
 
 
+def _reject_streaming(kwargs: dict[str, Any]) -> None:
+    if kwargs.get("stream"):
+        raise ValueError(
+            "floe-guard's LiteLLM adapter does not support stream=True: a streamed "
+            "response has no final usage to meter, so the call would go unaccounted. "
+            "Use a non-streaming call, or meter the stream yourself with "
+            "guard.reserve()/guard.settle()."
+        )
+
+
 def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
     """``litellm.completion`` with a pre-call budget reservation and post-call accrual.
 
@@ -170,7 +180,12 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
     would be crossed — the request never reaches LiteLLM. The reservation is
     sized to the actual request (prompt tokens + ``max_tokens`` cap) when it
     can be, so even a FIRST call that alone would cross the cap is blocked.
+
+    Streaming is not supported: a streamed response has no final ``usage`` to
+    settle from, so the call would silently go unmetered. Passing ``stream=True``
+    raises ``ValueError``.
     """
+    _reject_streaming(kwargs)
     litellm = _require_litellm()
     reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
     try:
@@ -183,7 +198,12 @@ def guarded_completion(guard: BudgetGuard, **kwargs: Any) -> Any:
 
 
 async def guarded_acompletion(guard: BudgetGuard, **kwargs: Any) -> Any:
-    """Async counterpart of :func:`guarded_completion`."""
+    """Async counterpart of :func:`guarded_completion`.
+
+    Streaming is not supported (see :func:`guarded_completion`); ``stream=True``
+    raises ``ValueError``.
+    """
+    _reject_streaming(kwargs)
     litellm = _require_litellm()
     reserved = guard.reserve(_estimate_request(litellm, guard, kwargs))
     try:
@@ -204,7 +224,8 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         litellm.callbacks = [budget_guard_callback(guard)]
 
     ``log_pre_api_call`` reserves the call's budget (raising
-    :class:`~floe_guard.BudgetExceeded` to abort), ``log_success_event`` settles
+    :class:`~floe_guard.BudgetExceeded` to abort, or ``ValueError`` for
+    ``stream=True``), ``log_success_event`` settles
     the response's actual token cost, and ``log_failure_event`` releases the
     reservation. Reservations are keyed per call, so parallel crew calls each
     hold their own slice of the ceiling instead of racing one shared total.
@@ -223,11 +244,11 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
         def __init__(self) -> None:
             super().__init__()
             self.guard = guard
-            # The first enforcement violation (BudgetExceeded or fail-closed
-            # UnpriceableModelError). Survives LiteLLM swallowing the raise, so a
-            # call-path owner can re-raise it outside the callback machinery.
-            # Latches until reset() — a config change on the guard alone does
-            # not clear it.
+            # The first enforcement violation (BudgetExceeded, fail-closed
+            # UnpriceableModelError, or stream=True). Survives LiteLLM swallowing
+            # the raise, so a call-path owner can re-raise it outside the callback
+            # machinery. Latches until reset() — a config change on the guard
+            # alone does not clear it.
             self.tripped: Exception | None = None
             self._reservations: dict[Any, float] = {}
             self._rlock = threading.Lock()
@@ -260,6 +281,12 @@ def budget_guard_callback(guard: BudgetGuard) -> Any:
                 self.tripped = None
 
         def _hold(self, kwargs: Any) -> None:
+            if isinstance(kwargs, dict):
+                try:
+                    _reject_streaming(kwargs)
+                except ValueError as exc:
+                    self._trip(exc)
+                    raise
             try:
                 # Request-sized when possible (see _estimate_request); raises
                 # BudgetExceeded -> aborts the call.

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -49,8 +49,16 @@ def _stub_crewai(monkeypatch: pytest.MonkeyPatch) -> None:
             # CrewAI stores constructor `stream` on the instance and later
             # passes it to litellm.completion; the wrapper must see it here.
             self.stream = kwargs.get("stream", False)
+            self._stream_override = None
             self.calls = 0
             self.acalls = 0
+
+        def _effective_stream(self) -> bool:
+            # Mirrors CrewAI BaseLLM: stream_events() sets a call-scoped
+            # override, then call() with no stream kwarg.
+            if self._stream_override is not None:
+                return self._stream_override
+            return bool(self.stream)
 
         def call(self, *args: Any, **kwargs: Any) -> str:
             self.calls += 1
@@ -177,6 +185,17 @@ def test_streaming_is_rejected_before_this_crewai_acall() -> None:
     with pytest.raises(ValueError, match="stream"):
         asyncio.run(llm.acall("this step"))
     assert llm.acalls == 0
+
+
+def test_call_scoped_stream_override_is_rejected_before_dispatch() -> None:
+    # CrewAI stream_events() sets a context-local override then calls
+    # self.call() with no stream kwarg. Instance.stream stays False.
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    llm._stream_override = True
+    with pytest.raises(ValueError, match="stream"):
+        llm.call("this step")
+    assert llm.calls == 0
 
 
 def test_wrapper_passes_through_while_under_budget() -> None:

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -122,6 +122,28 @@ def test_ceiling_hard_stops_next_call_despite_swallowed_pre_call_block() -> None
         llm.call("next step")
 
 
+def test_streaming_hard_stops_next_call_despite_swallowed_pre_call() -> None:
+    # stream=True has no usage to settle. LiteLLM swallows the callback's
+    # ValueError, so without latching tripped the crew would keep running
+    # unmetered. The wrapper must re-raise on the next call.
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    (cb,) = [cb for cb in litellm.callbacks if getattr(cb, "guard", None) is guard]
+
+    _swallow(
+        cb.log_pre_api_call,
+        "gpt-4o",
+        [],
+        {"litellm_call_id": "c-stream", "model": "gpt-4o", "stream": True},
+    )
+    assert isinstance(cb.tripped, ValueError)
+    assert guard.spent_usd == 0.0
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)
+
+    with pytest.raises(ValueError, match="stream"):
+        llm.call("next step")
+
+
 def test_wrapper_passes_through_while_under_budget() -> None:
     guard = BudgetGuard(limit_usd=1.0)
     llm = budget_guarded_llm(guard, "gpt-4o")

--- a/tests/test_crewai_adapter.py
+++ b/tests/test_crewai_adapter.py
@@ -46,11 +46,18 @@ def _stub_crewai(monkeypatch: pytest.MonkeyPatch) -> None:
         def __init__(self, model: str, **kwargs: Any) -> None:
             self.model = model
             self.kwargs = kwargs
+            # CrewAI stores constructor `stream` on the instance and later
+            # passes it to litellm.completion; the wrapper must see it here.
+            self.stream = kwargs.get("stream", False)
+            self.calls = 0
+            self.acalls = 0
 
         def call(self, *args: Any, **kwargs: Any) -> str:
+            self.calls += 1
             return "stub-response"
 
         async def acall(self, *args: Any, **kwargs: Any) -> str:
+            self.acalls += 1
             return "stub-async-response"
 
     stub = types.ModuleType("crewai")
@@ -142,6 +149,34 @@ def test_streaming_hard_stops_next_call_despite_swallowed_pre_call() -> None:
 
     with pytest.raises(ValueError, match="stream"):
         llm.call("next step")
+
+
+def test_streaming_is_rejected_before_this_crewai_call() -> None:
+    # LiteLLM swallows the callback raise, so the wrapper must refuse stream
+    # on THIS call — before super().call() — not only latch for the next step.
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o", stream=True)
+    with pytest.raises(ValueError, match="stream"):
+        llm.call("this step")
+    assert llm.calls == 0
+
+
+def test_streaming_kwarg_on_call_is_rejected_before_dispatch() -> None:
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o")
+    with pytest.raises(ValueError, match="stream"):
+        llm.call("this step", stream=True)
+    assert llm.calls == 0
+
+
+def test_streaming_is_rejected_before_this_crewai_acall() -> None:
+    import asyncio
+
+    guard = BudgetGuard(limit_usd=1.0)
+    llm = budget_guarded_llm(guard, "gpt-4o", stream=True)
+    with pytest.raises(ValueError, match="stream"):
+        asyncio.run(llm.acall("this step"))
+    assert llm.acalls == 0
 
 
 def test_wrapper_passes_through_while_under_budget() -> None:

--- a/tests/test_litellm_adapter.py
+++ b/tests/test_litellm_adapter.py
@@ -7,12 +7,19 @@ even in CI without the optional extra.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 import pytest
 
 from floe_guard import BudgetGuard, UnpriceableModelError, UnpriceableModelWarning
-from floe_guard.integrations.litellm import _model_from, _record_response, _usage_from
+from floe_guard.integrations.litellm import (
+    _model_from,
+    _record_response,
+    _usage_from,
+    guarded_acompletion,
+    guarded_completion,
+)
 
 
 @dataclass
@@ -164,3 +171,62 @@ def test_record_response_tolerates_non_dict_kwargs() -> None:
     resp = {"model": "gpt-4o", "usage": {"prompt_tokens": 1_000, "completion_tokens": 1_000}}
     _record_response(guard, None, resp)  # type: ignore[arg-type]
     assert guard.spent_usd > 0
+
+
+def test_streaming_is_rejected_before_the_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A streamed response has no final usage to settle, so it would go unmetered.
+    # Reject it up front, before reserving or calling LiteLLM.
+    called = {"n": 0}
+
+    class _LiteLLM:
+        @staticmethod
+        def completion(**kwargs: object) -> object:
+            called["n"] += 1
+            return {"model": "gpt-4o", "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+        @staticmethod
+        def token_counter(**kwargs: object) -> int:
+            return 1
+
+    monkeypatch.setattr("floe_guard.integrations.litellm._require_litellm", lambda: _LiteLLM)
+    guard = BudgetGuard(limit_usd=1.0)
+    with pytest.raises(ValueError, match="stream"):
+        guarded_completion(guard, model="gpt-4o", messages=[], stream=True)
+    assert called["n"] == 0
+    assert guard.spent_usd == 0.0
+
+
+def test_streaming_is_rejected_before_the_async_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"n": 0}
+
+    class _LiteLLM:
+        @staticmethod
+        async def acompletion(**kwargs: object) -> object:
+            called["n"] += 1
+            return {"model": "gpt-4o", "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+        @staticmethod
+        def token_counter(**kwargs: object) -> int:
+            return 1
+
+    monkeypatch.setattr("floe_guard.integrations.litellm._require_litellm", lambda: _LiteLLM)
+    guard = BudgetGuard(limit_usd=1.0)
+    with pytest.raises(ValueError, match="stream"):
+        asyncio.run(guarded_acompletion(guard, model="gpt-4o", messages=[], stream=True))
+    assert called["n"] == 0
+    assert guard.spent_usd == 0.0
+
+
+def test_callback_rejects_streaming_before_reserve() -> None:
+    # CrewAI and other callback users never wrap litellm.completion themselves.
+    # stream=True through the callback would reserve, then settle $0 on a
+    # usageless stream — fail-open. Reject before the hold.
+    pytest.importorskip("litellm")
+    from floe_guard.integrations.litellm import budget_guard_callback
+
+    guard = BudgetGuard(limit_usd=1.0)
+    cb = budget_guard_callback(guard)
+    with pytest.raises(ValueError, match="stream"):
+        cb.log_pre_api_call("gpt-4o", [], {"model": "gpt-4o", "stream": True})
+    assert guard.spent_usd == 0.0
+    assert guard._reserved == pytest.approx(0.0, abs=1e-9)


### PR DESCRIPTION
## Summary
- LiteLLM `stream=True` has no final `usage` to settle, so `guarded_completion` / `guarded_acompletion` and the callback's `log_pre_api_call` were fail-open: the provider call ran, spend was unmetered, and CrewAI settled ``.
- Reject `stream=True` before reserve or the provider call, same as the OpenAI/Anthropic adapters. The callback latches `tripped` as `ValueError` so `budget_guarded_llm` re-raises after LiteLLM swallows the hook.

## Test plan
- [x] `py -m pytest -q` — 477 passed, 5 skipped
- [x] `py -m ruff check .` clean
- [x] New tests: wrapper sync/async never call LiteLLM; callback rejects before reserve; CrewAI wrapper re-raises on the next step

No JS change. py 0.23.6.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - LiteLLM and CrewAI streaming requests are rejected with a clear `ValueError` before provider calls, reservations, or spending occur.
  - Applies to synchronous, asynchronous, and callback-based integrations.
  - Budget protection preserves and re-raises streaming errors even when underlying hooks swallow exceptions.

- **Documentation**
  - Added unreleased changelog entries for Python 0.23.6 and JavaScript 0.15.4.

- **Tests**
  - Added coverage confirming streaming requests are blocked without affecting budgets or reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->