### PR TITLE
fix: price JS cached tokens at the cache-read rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — py 0.23.6 / js 0.15.5
+
+### Fixed (js)
+
+- **Cache-aware token pricing, wired through the guard.** `priceTokens` /
+  `resolvePrice` now consume the cost map's `cache_read_input_token_cost` /
+  `cache_creation_input_token_cost` (the JS map already carried them; pricing
+  ignored them). `record` / `settle` accept `cacheReadInputTokens` (and
+  creation buckets). `promptTokens` is the fresh/uncached count — cache buckets
+  are additive, not a subset. Middleware and the Vapi adapter subtract cached
+  tokens from provider `prompt_tokens` before settle, matching Python. gpt-4o
+  with a 90% cache hit now bills ~0.55× the uncached prompt instead of
+  ~1.8× Python.
+
 ## Unreleased — py 0.23.6 / js 0.15.4
 
 ### Fixed (py)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.15.3",
+  "version": "0.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.15.3",
+      "version": "0.15.5",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Know what every AI call really costs — a live ledger of your agent's real spend, plus a hard-stop before runaway spend crosses your ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters. Local, no account, no telemetry.",
   "type": "module",
   "license": "MIT",

--- a/js/src/adapters/vapi.ts
+++ b/js/src/adapters/vapi.ts
@@ -87,6 +87,7 @@ import { priceVoiceLeg } from "../voice-pricing.js";
 export interface OpenAiUsageLike {
   readonly prompt_tokens: number;
   readonly completion_tokens: number;
+  readonly prompt_tokens_details?: { readonly cached_tokens?: number };
 }
 
 /** A non-streaming OpenAI `ChatCompletion` — we read its `usage`. */
@@ -241,7 +242,10 @@ export class VapiBudgetGuard {
       this.guard.release(reserved);
       throw new VapiUsageMissingError(model);
     }
-    this.guard.settle(model, usage.prompt, usage.completion, { reserved });
+    this.guard.settle(model, usage.prompt, usage.completion, {
+      reserved,
+      cacheReadInputTokens: usage.cacheRead,
+    });
     return completion;
   }
 
@@ -279,7 +283,7 @@ export class VapiBudgetGuard {
     model: string,
     reserved: ReservationHandle,
   ): AsyncIterableIterator<C> {
-    let usage: { prompt: number; completion: number } | null = null;
+    let usage: { prompt: number; completion: number; cacheRead: number } | null = null;
     let settled = false;
     try {
       const stream = await run();
@@ -296,7 +300,10 @@ export class VapiBudgetGuard {
       // second time (a double release drives `reserved` negative and weakens the
       // ceiling for other in-flight turns).
       settled = true;
-      this.guard.settle(model, usage.prompt, usage.completion, { reserved });
+      this.guard.settle(model, usage.prompt, usage.completion, {
+        reserved,
+        cacheReadInputTokens: usage.cacheRead,
+      });
     } finally {
       // Any exit before settle — error mid-stream, missing usage, or an early
       // consumer abort (for-await break -> generator.return()) — frees the hold.
@@ -373,11 +380,15 @@ export { BudgetExceeded };
  */
 function readUsage(
   usage: OpenAiUsageLike | null | undefined,
-): { prompt: number; completion: number } | null {
+): { prompt: number; completion: number; cacheRead: number } | null {
   if (usage === null || usage === undefined) return null;
   const prompt = usage.prompt_tokens;
   const completion = usage.completion_tokens;
   if (typeof prompt !== "number" || !Number.isFinite(prompt)) return null;
   if (typeof completion !== "number" || !Number.isFinite(completion)) return null;
-  return { prompt, completion };
+  const cachedRaw = usage.prompt_tokens_details?.cached_tokens;
+  const cached =
+    typeof cachedRaw === "number" && Number.isFinite(cachedRaw) ? Math.max(0, cachedRaw) : 0;
+  const cacheRead = Math.min(cached, prompt);
+  return { prompt: prompt - cacheRead, completion, cacheRead };
 }

--- a/js/src/adapters/vapi.ts
+++ b/js/src/adapters/vapi.ts
@@ -386,9 +386,11 @@ function readUsage(
   const completion = usage.completion_tokens;
   if (typeof prompt !== "number" || !Number.isFinite(prompt)) return null;
   if (typeof completion !== "number" || !Number.isFinite(completion)) return null;
+  const promptClamped = Math.max(0, prompt);
+  const completionClamped = Math.max(0, completion);
   const cachedRaw = usage.prompt_tokens_details?.cached_tokens;
   const cached =
     typeof cachedRaw === "number" && Number.isFinite(cachedRaw) ? Math.max(0, cachedRaw) : 0;
-  const cacheRead = Math.min(cached, prompt);
-  return { prompt: prompt - cacheRead, completion, cacheRead };
+  const cacheRead = Math.min(cached, promptClamped);
+  return { prompt: promptClamped - cacheRead, completion: completionClamped, cacheRead };
 }

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -27,6 +27,7 @@ import { BudgetExceeded, TokenBudgetExceeded, UnpriceableModelError } from "./er
 import { pushLedger } from "./sync.js";
 import {
   type ManualPrice,
+  type TokenCacheUsage,
   priceTokens,
   resolvePrice,
 } from "./pricing.js";
@@ -376,7 +377,11 @@ export class BudgetGuard {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { reserved?: ReservationHandle; price?: ManualPrice; label?: string } = {},
+    options: {
+      reserved?: ReservationHandle;
+      price?: ManualPrice;
+      label?: string;
+    } & TokenCacheUsage = {},
   ): number {
     const reserved = options.reserved ?? 0;
     // A bad reserved handle would corrupt this.reserved and break the ceiling for
@@ -405,9 +410,14 @@ export class BudgetGuard {
       return 0;
     }
 
+    const cache: TokenCacheUsage = {
+      cacheReadInputTokens: options.cacheReadInputTokens,
+      cacheCreationInputTokens: options.cacheCreationInputTokens,
+      cacheCreationInputTokens1h: options.cacheCreationInputTokens1h,
+    };
     let cost: number;
     try {
-      cost = priceTokens(priced, promptTokens, completionTokens);
+      cost = priceTokens(priced, promptTokens, completionTokens, cache);
     } catch (err) {
       // priceTokens can throw (e.g. non-finite costs). Release the in-flight
       // hold before re-throwing so `reserved` doesn't leak and shrink
@@ -418,9 +428,14 @@ export class BudgetGuard {
     if (reserved) {
       this.consumeReservation(reserved);
     }
-    // Tokens accrued match what priceTokens bills (prompt + completion; negative
-    // counts clamp to 0, as in pricing).
-    const accruedTokens = Math.max(0, promptTokens) + Math.max(0, completionTokens);
+    // Tokens accrued match what priceTokens bills (prompt + completion + cache
+    // buckets; negative counts clamp to 0, as in pricing).
+    const accruedTokens =
+      Math.max(0, promptTokens) +
+      Math.max(0, completionTokens) +
+      Math.max(0, options.cacheReadInputTokens ?? 0) +
+      Math.max(0, options.cacheCreationInputTokens ?? 0) +
+      Math.max(0, options.cacheCreationInputTokens1h ?? 0);
     this.spentUsd += cost;
     this.spentTokens += accruedTokens;
     this.accrueStep(cost, accruedTokens);
@@ -457,12 +472,15 @@ export class BudgetGuard {
     model: string,
     promptTokens: number,
     completionTokens: number,
-    options: { price?: ManualPrice; label?: string } = {},
+    options: { price?: ManualPrice; label?: string } & TokenCacheUsage = {},
   ): number {
     return this.settle(model, promptTokens, completionTokens, {
       reserved: 0,
       price: options.price,
       label: options.label,
+      cacheReadInputTokens: options.cacheReadInputTokens,
+      cacheCreationInputTokens: options.cacheCreationInputTokens,
+      cacheCreationInputTokens1h: options.cacheCreationInputTokens1h,
     });
   }
 

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -372,6 +372,13 @@ export class BudgetGuard {
    * {@link BudgetGuard.spendLog} (`label` tags it, e.g. with an agent/task name);
    * the warn-and-skip path accrues nothing and logs nothing, so the ledger stays
    * in lockstep with `spentUsd`.
+   *
+   * `promptTokens` is the **fresh / uncached** prompt count. Cache buckets on
+   * `options` (`cacheReadInputTokens`, creation) are additive and priced at the
+   * cache rate — they are not a subset of `promptTokens`. OpenAI-style
+   * `usage.prompt_tokens` *includes* cached tokens; subtract that share first
+   * (middleware and the Vapi adapter already do). Same contract as Python
+   * `BudgetGuard.settle`.
    */
   settle(
     model: string,
@@ -467,6 +474,9 @@ export class BudgetGuard {
    * Returns the USD cost of this call. If the model is unpriceable and no `price`
    * is given, behaviour depends on `failClosed`: warn + throw (default), or
    * warn + skip accrual.
+   *
+   * Same prompt/cache split as {@link BudgetGuard.settle}: `promptTokens` is
+   * fresh/uncached; `cacheReadInputTokens` is extra, not carved out of prompt.
    */
   record(
     model: string,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -36,6 +36,7 @@ export {
 export {
   type ManualPrice,
   type PricedModel,
+  type TokenCacheUsage,
   resolvePrice,
   priceTokens,
   costMapGeneratedAt,

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -62,13 +62,14 @@ export interface BudgetGuardMiddleware {
 function usageTokens(
   modelId: string,
   usage: unknown,
-): { promptTokens: number; completionTokens: number } {
+): { promptTokens: number; completionTokens: number; cacheReadInputTokens: number } {
   const u = usage as
     | {
         promptTokens?: unknown;
         completionTokens?: unknown;
         inputTokens?: unknown;
         outputTokens?: unknown;
+        cachedInputTokens?: unknown;
       }
     | null
     | undefined;
@@ -81,7 +82,15 @@ function usageTokens(
         `treated as free.`,
     );
   }
-  return { promptTokens, completionTokens };
+  const cachedRaw = u?.cachedInputTokens;
+  const cached =
+    typeof cachedRaw === "number" && Number.isFinite(cachedRaw) ? Math.max(0, cachedRaw) : 0;
+  const cacheReadInputTokens = Math.min(cached, promptTokens);
+  return {
+    promptTokens: promptTokens - cacheReadInputTokens,
+    completionTokens,
+    cacheReadInputTokens,
+  };
 }
 
 /**
@@ -116,12 +125,15 @@ export function budgetGuardMiddleware(guard: BudgetGuard): BudgetGuardMiddleware
       // again would double-subtract and clear a concurrent call's in-flight hold.
       let handled = false;
       try {
-        const { promptTokens, completionTokens } = usageTokens(
+        const { promptTokens, completionTokens, cacheReadInputTokens } = usageTokens(
           model.modelId,
           result?.usage,
         );
         handled = true;
-        guard.settle(model.modelId, promptTokens, completionTokens, { reserved });
+        guard.settle(model.modelId, promptTokens, completionTokens, {
+          reserved,
+          cacheReadInputTokens,
+        });
         return result;
       } catch (err) {
         if (!handled) guard.release(reserved); // failed reading usage, before settle()
@@ -153,12 +165,15 @@ export function budgetGuardMiddleware(guard: BudgetGuard): BudgetGuardMiddleware
           transform(chunk, controller) {
             if (chunk?.type === "finish" && !handled) {
               try {
-                const { promptTokens, completionTokens } = usageTokens(
+                const { promptTokens, completionTokens, cacheReadInputTokens } = usageTokens(
                   model.modelId,
                   chunk.usage,
                 );
                 handled = true;
-                guard.settle(model.modelId, promptTokens, completionTokens, { reserved });
+                guard.settle(model.modelId, promptTokens, completionTokens, {
+                  reserved,
+                  cacheReadInputTokens,
+                });
               } catch (err) {
                 // Release only if we never reached settle() (e.g. usage missing).
                 // If settle() itself threw, it already released its own hold.

--- a/js/src/middleware.ts
+++ b/js/src/middleware.ts
@@ -75,20 +75,27 @@ function usageTokens(
     | undefined;
   const promptTokens = u?.promptTokens ?? u?.inputTokens;
   const completionTokens = u?.completionTokens ?? u?.outputTokens;
-  if (typeof promptTokens !== "number" || typeof completionTokens !== "number") {
+  if (
+    typeof promptTokens !== "number" ||
+    typeof completionTokens !== "number" ||
+    !Number.isFinite(promptTokens) ||
+    !Number.isFinite(completionTokens)
+  ) {
     throw new Error(
       `Model '${modelId}' reported no token usage — the budget guard cannot ` +
         `meter spend it cannot see, so this call is rejected rather than ` +
         `treated as free.`,
     );
   }
+  const prompt = Math.max(0, promptTokens);
+  const completion = Math.max(0, completionTokens);
   const cachedRaw = u?.cachedInputTokens;
   const cached =
     typeof cachedRaw === "number" && Number.isFinite(cachedRaw) ? Math.max(0, cachedRaw) : 0;
-  const cacheReadInputTokens = Math.min(cached, promptTokens);
+  const cacheReadInputTokens = Math.min(cached, prompt);
   return {
-    promptTokens: promptTokens - cacheReadInputTokens,
-    completionTokens,
+    promptTokens: prompt - cacheReadInputTokens,
+    completionTokens: completion,
     cacheReadInputTokens,
   };
 }

--- a/js/src/pricing.ts
+++ b/js/src/pricing.ts
@@ -23,11 +23,17 @@ export interface PricedModel {
   inputCostPerToken: number;
   outputCostPerToken: number;
   source: "override" | "cost_map";
+  /** Published cache-read rate, or omitted when the map/override has none. */
+  cacheReadCostPerToken?: number;
+  /** Published cache-creation (5m) rate, or omitted when the map/override has none. */
+  cacheCreationCostPerToken?: number;
 }
 
 interface CostMapEntry {
   input_cost_per_token?: unknown;
   output_cost_per_token?: unknown;
+  cache_read_input_token_cost?: unknown;
+  cache_creation_input_token_cost?: unknown;
 }
 
 // Reserved dunder keys (__voice__, __meta__) are NOT models — exclude them so the
@@ -121,6 +127,16 @@ function bothFinite(a: unknown, b: unknown): boolean {
   );
 }
 
+function finiteOrNone(x: unknown): number | undefined {
+  return typeof x === "number" && Number.isFinite(x) ? x : undefined;
+}
+
+// Anthropic prompt-cache pricing multipliers when the map has no published rate.
+// Creation (5m) is 1.25x base input, creation (1h) is 2.0x, read is 0.1x.
+const CACHE_CREATION_MULTIPLIER = 1.25;
+const CACHE_CREATION_1H_MULTIPLIER = 2.0;
+const CACHE_READ_MULTIPLIER = 0.1;
+
 /**
  * Resolve a model to its per-token price, or `null` if it cannot be priced.
  *
@@ -167,10 +183,18 @@ export function resolvePrice(
         inputCostPerToken: input as number,
         outputCostPerToken: output as number,
         source: "cost_map",
+        cacheReadCostPerToken: finiteOrNone(entry.cache_read_input_token_cost),
+        cacheCreationCostPerToken: finiteOrNone(entry.cache_creation_input_token_cost),
       };
     }
   }
   return null;
+}
+
+export interface TokenCacheUsage {
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens1h?: number;
 }
 
 /** USD cost for token usage. Negative counts are clamped to zero. */
@@ -178,10 +202,25 @@ export function priceTokens(
   priced: PricedModel,
   promptTokens: number,
   completionTokens: number,
+  cache: TokenCacheUsage = {},
 ): number {
   const p = Math.max(0, promptTokens);
   const c = Math.max(0, completionTokens);
-  const cost = p * priced.inputCostPerToken + c * priced.outputCostPerToken;
+  const cc = Math.max(0, cache.cacheCreationInputTokens ?? 0);
+  const cc1h = Math.max(0, cache.cacheCreationInputTokens1h ?? 0);
+  const cr = Math.max(0, cache.cacheReadInputTokens ?? 0);
+
+  const cacheCreationRate =
+    priced.cacheCreationCostPerToken ?? priced.inputCostPerToken * CACHE_CREATION_MULTIPLIER;
+  const cacheReadRate =
+    priced.cacheReadCostPerToken ?? priced.inputCostPerToken * CACHE_READ_MULTIPLIER;
+
+  const cost =
+    p * priced.inputCostPerToken +
+    c * priced.outputCostPerToken +
+    cc * cacheCreationRate +
+    cc1h * priced.inputCostPerToken * CACHE_CREATION_1H_MULTIPLIER +
+    cr * cacheReadRate;
   if (!Number.isFinite(cost)) {
     // Defense-in-depth: resolvePrice already guarantees finite rates.
     throw new Error("Non-finite LLM cost — pricing entry is invalid");

--- a/js/src/pricing.ts
+++ b/js/src/pricing.ts
@@ -191,13 +191,14 @@ export function resolvePrice(
   return null;
 }
 
+/** Cache-token buckets for {@link priceTokens} / `record` / `settle`. Additive — not a subset of `promptTokens`. */
 export interface TokenCacheUsage {
   cacheCreationInputTokens?: number;
   cacheReadInputTokens?: number;
   cacheCreationInputTokens1h?: number;
 }
 
-/** USD cost for token usage. Negative counts are clamped to zero. */
+/** USD cost for token usage. Negative counts are clamped to zero. `promptTokens` is uncached; pass cache buckets separately. */
 export function priceTokens(
   priced: PricedModel,
   promptTokens: number,

--- a/js/test/middleware.test.ts
+++ b/js/test/middleware.test.ts
@@ -99,6 +99,30 @@ describe("budgetGuardMiddleware — wrapGenerate (ai@5 usage shape)", () => {
     expect(guard.spentUsd).toBeCloseTo(pricing.priceTokens(priced, 1000, 1000), 12);
   });
 
+  it("prices cachedInputTokens at the cache-read rate, not the full input rate", async () => {
+    const guard = new BudgetGuard(1.0);
+    const mw = budgetGuardMiddleware(guard);
+
+    const doGenerate = vi.fn(async () => ({
+      usage: { inputTokens: 10_000, outputTokens: 0, cachedInputTokens: 9_000 },
+    }));
+
+    await mw.wrapGenerate!({
+      doGenerate: doGenerate as never,
+      doStream: vi.fn() as never,
+      params: fakeParams,
+      model: fakeModel("gpt-4o"),
+    });
+
+    const priced = pricing.resolvePrice("gpt-4o")!;
+    expect(guard.spentUsd).toBeCloseTo(
+      pricing.priceTokens(priced, 1_000, 0, { cacheReadInputTokens: 9_000 }),
+      12,
+    );
+    const uncached = pricing.priceTokens(priced, 10_000, 0);
+    expect(guard.spentUsd / uncached).toBeCloseTo(0.55, 5);
+  });
+
   it("rejects a result with no usable token counts instead of metering $0", async () => {
     const guard = new BudgetGuard(1.0);
     const mw = budgetGuardMiddleware(guard);

--- a/js/test/middleware.test.ts
+++ b/js/test/middleware.test.ts
@@ -123,6 +123,39 @@ describe("budgetGuardMiddleware — wrapGenerate (ai@5 usage shape)", () => {
     expect(guard.spentUsd / uncached).toBeCloseTo(0.55, 5);
   });
 
+  it("rejects NaN token counts instead of splitting cache against them", async () => {
+    const guard = new BudgetGuard(1.0);
+    const mw = budgetGuardMiddleware(guard);
+    const doGenerate = vi.fn(async () => ({
+      usage: { inputTokens: Number.NaN, outputTokens: 0, cachedInputTokens: 9_000 },
+    }));
+    await expect(
+      mw.wrapGenerate!({
+        doGenerate: doGenerate as never,
+        doStream: vi.fn() as never,
+        params: fakeParams,
+        model: fakeModel("gpt-4o"),
+      }),
+    ).rejects.toThrow(/no token usage/);
+    expect(guard.spentUsd).toBe(0);
+    expect(guard.remainingUsd).toBe(1.0);
+  });
+
+  it("clamps negative prompt counts before the cache split", async () => {
+    const guard = new BudgetGuard(1.0);
+    const mw = budgetGuardMiddleware(guard);
+    await mw.wrapGenerate!({
+      doGenerate: vi.fn(async () => ({
+        usage: { inputTokens: -10_000, outputTokens: 0, cachedInputTokens: 9_000 },
+      })) as never,
+      doStream: vi.fn() as never,
+      params: fakeParams,
+      model: fakeModel("gpt-4o"),
+    });
+    expect(guard.spentUsd).toBe(0);
+    expect(guard.remainingUsd).toBe(1.0);
+  });
+
   it("rejects a result with no usable token counts instead of metering $0", async () => {
     const guard = new BudgetGuard(1.0);
     const mw = budgetGuardMiddleware(guard);

--- a/js/test/pricing.test.ts
+++ b/js/test/pricing.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { costMapGeneratedAt, resolvePrice } from "../src/pricing";
+import { costMapGeneratedAt, priceTokens, resolvePrice } from "../src/pricing";
 
 describe("resolvePrice", () => {
   it("resolves a known model and its provider-prefixed form", () => {
@@ -135,5 +135,58 @@ describe("costMapGeneratedAt / reserved keys", () => {
     expect(resolvePrice("__voice__")).toBeNull();
     // a real model still resolves
     expect(resolvePrice("gpt-4o")).not.toBeNull();
+  });
+});
+
+describe("cache-aware priceTokens", () => {
+  it("falls back to Anthropic-style multipliers when the model has no published cache rate", () => {
+    const priced = resolvePrice("claude-3-5-sonnet-20241022");
+    expect(priced).not.toBeNull();
+    expect(priced!.cacheReadCostPerToken).toBeUndefined();
+    const cost = priceTokens(priced!, 0, 0, {
+      cacheCreationInputTokens: 100,
+      cacheReadInputTokens: 1000,
+      cacheCreationInputTokens1h: 200,
+    });
+    // 5m write 1.25x, 1h write 2.0x, read 0.1x of input
+    const input = priced!.inputCostPerToken;
+    expect(cost).toBeCloseTo(100 * input * 1.25 + 200 * input * 2.0 + 1000 * input * 0.1, 12);
+  });
+
+  it("prices cache-read at the model's published rate, not a one-size multiplier", () => {
+    const anthropic = resolvePrice("claude-3-7-sonnet-20250219");
+    const openai = resolvePrice("gpt-4o");
+    expect(anthropic).not.toBeNull();
+    expect(openai).not.toBeNull();
+    expect(anthropic!.cacheReadCostPerToken).toBeCloseTo(3e-7, 12);
+    expect(openai!.cacheReadCostPerToken).toBeCloseTo(1.25e-6, 12);
+
+    expect(priceTokens(anthropic!, 0, 0, { cacheReadInputTokens: 1000 })).toBeCloseTo(
+      1000 * anthropic!.cacheReadCostPerToken!,
+      12,
+    );
+    expect(priceTokens(openai!, 0, 0, { cacheReadInputTokens: 1000 })).toBeCloseTo(
+      1000 * openai!.cacheReadCostPerToken!,
+      12,
+    );
+  });
+
+  it("does not attach cache rates to override-sourced prices", () => {
+    const ov = resolvePrice("gpt-4o", {
+      "gpt-4o": { inputCostPerToken: 1e-9, outputCostPerToken: 2e-9 },
+    });
+    expect(ov!.source).toBe("override");
+    expect(ov!.cacheReadCostPerToken).toBeUndefined();
+    expect(ov!.cacheCreationCostPerToken).toBeUndefined();
+  });
+
+  it("gpt-4o with a 90% cache hit is ~0.55x the uncached prompt, not 1.0x", () => {
+    // 10_000 prompt tokens, 90% cached, no completion. Python bills fresh at
+    // input and cached at cache-read (0.5x for gpt-4o). JS used to bill all
+    // 10_000 at the full input rate (~1.8x overcharge).
+    const priced = resolvePrice("gpt-4o")!;
+    const uncached = priceTokens(priced, 10_000, 0);
+    const cached = priceTokens(priced, 1_000, 0, { cacheReadInputTokens: 9_000 });
+    expect(cached / uncached).toBeCloseTo(0.55, 5);
   });
 });

--- a/js/test/spend-log.test.ts
+++ b/js/test/spend-log.test.ts
@@ -17,6 +17,14 @@ describe("BudgetGuard.spendLog", () => {
     expect(total).toBeCloseTo(guard.spentUsd, 12);
   });
 
+  it("record prices cache-read tokens cheaper than full input", () => {
+    const guard = new BudgetGuard(1.0);
+    const uncached = new BudgetGuard(1.0);
+    guard.record(MODEL, 1_000, 0, { cacheReadInputTokens: 9_000 });
+    uncached.record(MODEL, 10_000, 0);
+    expect(guard.spentUsd / uncached.spentUsd).toBeCloseTo(0.55, 5);
+  });
+
   it("llm event schema", () => {
     const guard = new BudgetGuard(1.0);
     const cost = guard.record(MODEL, 1_200, 350, { label: "researcher" });

--- a/js/test/spend-log.test.ts
+++ b/js/test/spend-log.test.ts
@@ -17,7 +17,9 @@ describe("BudgetGuard.spendLog", () => {
     expect(total).toBeCloseTo(guard.spentUsd, 12);
   });
 
-  it("record prices cache-read tokens cheaper than full input", () => {
+  it("record treats promptTokens as exclusive of cacheReadInputTokens", () => {
+    // Python settle() contract: prompt is fresh/uncached; cache buckets are extra.
+    // Adapters subtract cached tokens from provider prompt_tokens before record().
     const guard = new BudgetGuard(1.0);
     const uncached = new BudgetGuard(1.0);
     guard.record(MODEL, 1_000, 0, { cacheReadInputTokens: 9_000 });

--- a/js/test/vapi-adapter.test.ts
+++ b/js/test/vapi-adapter.test.ts
@@ -15,7 +15,9 @@ import {
   BudgetGuard,
   UnpriceableModelError,
   UnpriceableVoiceError,
+  priceTokens,
   priceVoiceLeg,
+  resolvePrice,
 } from "../src/index.js";
 import {
   VapiBudgetGuard,
@@ -105,6 +107,26 @@ describe("VapiBudgetGuard — settle on real usage", () => {
     expect(guard.remainingUsd).toBeCloseTo(1.0 - 0.002, 12); // reservation consumed, not leaked
     expect(guard.spendLog).toHaveLength(1);
     expect(guard.spendLog[0]!.modelOrTool).toBe("m");
+  });
+
+  it("prices OpenAI prompt_tokens_details.cached_tokens at the cache-read rate", async () => {
+    const guard = new BudgetGuard(1.0);
+    const budget = new VapiBudgetGuard(guard, { model: "gpt-4o" });
+    const cachedCompletion = {
+      id: "chatcmpl-x",
+      choices: [{ message: { role: "assistant", content: "hi" } }],
+      usage: {
+        prompt_tokens: 10_000,
+        completion_tokens: 0,
+        prompt_tokens_details: { cached_tokens: 9_000 },
+      },
+    };
+    await budget.guardCompletion(() => cachedCompletion);
+    const priced = resolvePrice("gpt-4o")!;
+    expect(guard.spentUsd).toBeCloseTo(
+      priceTokens(priced, 1_000, 0, { cacheReadInputTokens: 9_000 }),
+      12,
+    );
   });
 
   it("settles a streaming turn on the final chunk's usage and passes chunks through", async () => {

--- a/js/test/vapi-adapter.test.ts
+++ b/js/test/vapi-adapter.test.ts
@@ -129,6 +129,22 @@ describe("VapiBudgetGuard — settle on real usage", () => {
     );
   });
 
+  it("clamps negative prompt_tokens before the cache split", async () => {
+    const guard = new BudgetGuard(1.0);
+    const budget = new VapiBudgetGuard(guard, { model: "gpt-4o" });
+    await budget.guardCompletion(() => ({
+      id: "chatcmpl-x",
+      choices: [{ message: { role: "assistant", content: "hi" } }],
+      usage: {
+        prompt_tokens: -10_000,
+        completion_tokens: 0,
+        prompt_tokens_details: { cached_tokens: 9_000 },
+      },
+    }));
+    expect(guard.spentUsd).toBe(0);
+    expect(guard.remainingUsd).toBe(1.0);
+  });
+
   it("settles a streaming turn on the final chunk's usage and passes chunks through", async () => {
     const guard = new BudgetGuard(1.0, { priceOverrides: { m: PRICE } });
     const budget = new VapiBudgetGuard(guard, { model: "m" });


### PR DESCRIPTION
## Summary
- The JS cost map already carries cache-read / cache-creation rates. `priceTokens` ignored them and billed cached prompt tokens at the full input rate.
- Python already prices this correctly. On gpt-4o with a 90% cache hit, JS was ~1.8× Python. This wires cache usage through `record` / `settle`, Vercel middleware (`cachedInputTokens`), and the Vapi adapter (`prompt_tokens_details.cached_tokens`). Same call now bills ~0.55× uncached, matching Python.

## Test plan
- [x] `npm test` in `js/` — 239 passed
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeded
- [x] `py -m pytest -q` — 473 passed, 5 skipped (no Python code change)

No Python change. js 0.15.5.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache-aware pricing for cached prompt reads and cache creation.
  * Updated usage tracking and settlement to account for provider-reported cached tokens.
  * Added cached-token usage and pricing support to the JavaScript API.
* **Bug Fixes**
  * Corrected billing for prompts with high cache-hit rates, including gpt-4o.
* **Chores**
  * Released JavaScript package version 0.15.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->