### PR TITLE
feat: port StreamGuard to TypeScript for mid-stream budget enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ packages — `floe-guard` on [PyPI](https://pypi.org/project/floe-guard/) and
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 both packages adhere to [Semantic Versioning](https://semver.org/).
 
+## Unreleased — js 0.16.0
+
+### Added (js)
+
+- `StreamGuard`, `guardStream` and `approxTokens` for chunk-wise streaming USD
+  enforcement (#124), matching Python's accounting semantics. Partial spend is
+  settled before budget interruption; concurrent streams share accrued costs.
+  Sync and async iterators settle on early exit. Includes explicit final-usage
+  reconciliation, Python parity tests and a runnable no-key example.
+
 ## Unreleased — py 0.23.6 / js 0.15.5
 
 ### Fixed (js)

--- a/examples/streaming_guard.mjs
+++ b/examples/streaming_guard.mjs
@@ -1,0 +1,44 @@
+/** Run `cd js && npm ci && npm run build`, then `node ../examples/streaming_guard.mjs`.
+ * No API key, provider SDK or network access. Uses the actual built package.
+ */
+import assert from "node:assert/strict";
+import { BudgetExceeded, BudgetGuard, guardStream } from "../js/dist/index.js";
+
+const guard = new BudgetGuard(0.001, {
+  priceOverrides: {
+    "demo-model": { inputCostPerToken: 0, outputCostPerToken: 0.00001 },
+  },
+  onBlock: () => {},
+});
+// As in the Python example, reject an oversized first request before opening
+// a source. This uses the existing estimateCall API, not a new streaming API.
+const estimate = guard.estimateCall("demo-model", 1000, 100000);
+assert.equal(estimate, 1);
+assert.throws(() => guard.reserve(estimate), BudgetExceeded);
+assert.equal(guard.spentUsd, 0);
+assert.equal(guard.remainingUsd, 0.001);
+console.log("PASS: oversized first request blocked before generation; $0 spent.");
+
+let sourceClosed = false;
+async function* response() {
+  try {
+    for (;;) yield "a".repeat(40); // ten estimated tokens, $0.0001 per chunk
+  } finally {
+    sourceClosed = true;
+  }
+}
+
+let delivered = 0;
+try {
+  for await (const _chunk of guardStream(guard, "demo-model", response())) delivered++;
+  assert.fail("The runaway stream must stop");
+} catch (error) {
+  if (!(error instanceof BudgetExceeded)) throw error;
+  console.log(`Stopped after ${delivered} delivered chunks.`);
+  console.log(`Partial spend recorded: $${guard.spentUsd.toFixed(4)} (limit $0.0010).`);
+}
+assert.equal(delivered, 10);
+assert.equal(sourceClosed, true);
+assert.equal(guard.spendLog.length, 1);
+assert.equal(guard.spendLog[0].completionTokens, 110);
+console.log("PASS: crossing chunk recorded, source closed, one ledger entry.");

--- a/js/README.md
+++ b/js/README.md
@@ -34,6 +34,79 @@ The middleware sits in the call path: it `check()`s before `doGenerate` /
 `doStream` (throwing `BudgetExceeded` to halt the run) and `record()`s priced
 token usage after — for streaming it reads usage from the `finish` part.
 
+## Mid-stream budget enforcement
+
+`StreamGuard` and `guardStream` port Python's streaming USD guard. They price
+each text delta before it reaches the consumer. When a chunk crosses the
+shared ceiling, its partial spend is recorded in `guard.spendLog` **before**
+`BudgetExceeded` is thrown. Active streams on the same guard share the ceiling.
+
+```ts
+import { BudgetGuard, guardStream } from "floe-guard";
+
+const guard = new BudgetGuard(0.01);
+// textDeltas is your provider's Iterable<string> or AsyncIterable<string>.
+for await (const text of guardStream(guard, "gpt-4o", textDeltas)) {
+  consume(text);
+}
+```
+
+For structured chunks, supply `{ getText: chunk => chunk.delta.text ?? "" }`
+using your provider's actual shape. Without an extractor, non-string chunks
+throw instead of silently recording zero. Synchronous inputs return a
+synchronous iterator; asynchronous inputs return an asynchronous iterator.
+
+Use `StreamGuard` directly when the provider reports final usage:
+
+```ts
+import { StreamGuard } from "floe-guard";
+
+const reserved = guard.reserve(guard.estimateCall("gpt-4o", 100, 200));
+const stream = new StreamGuard(guard, "gpt-4o", { promptTokens: 100, reserved });
+try {
+  for await (const text of textDeltas) {
+    stream.feedText(text); // or feedTokens(n) with known per-chunk counts
+    consume(text);
+  }
+  stream.finish({ promptTokens: reportedPromptTokens, completionTokens: reportedCompletionTokens });
+} finally {
+  stream.close(); // idempotent; settles estimates if finish() was not reached
+}
+```
+
+- Options: `promptTokens`, `reserved`, `price`, `label`, and `countTokens(delta)`.
+  `guardStream` additionally accepts `getText(chunk)`.
+  Configuration is captured at construction; changing the caller's options or
+  manual price object later does not change an existing stream.
+- `approxTokens` defaults to roughly four Unicode characters per token, with
+  a minimum of one for a non-empty delta. A custom tokenizer can replace it.
+  `finish()` reconciles to reported usage; `completionTokens` exposes the running
+  estimate. Mid-stream checks cover the aggregate USD ceiling, matching Python;
+  token reservations are reconciled at settlement.
+- An unpriceable model fails at construction and releases its reservation.
+  With `failClosed: false`, unpriceable streams pass through and settlement
+  warns and skips accounting, matching the existing guard policy.
+- The wrapper settles on exhaustion, source/consumer errors, and early `break`,
+  and closes the source iterator when iteration ends early. Direct users must
+  call `close()` in `finally`. If a wrapper is **never iterated**, its reservation
+  remains the caller's responsibility: call `guard.release(reserved)`.
+- The crossing chunk has already been generated. With accurate counts, the
+  local cutoff can overshoot by that chunk; heuristic error, parallel streams,
+  provider buffering and delayed cancellation can cause additional actual
+  spend. Stopping iteration requests iterator cleanup, not guaranteed remote
+  cancellation. Connect cleanup to your provider's abort mechanism where needed.
+- Existing Vapi, LiveKit and middleware streaming behavior is unchanged; this
+  is the standalone primitive requested in issue #124.
+
+Run the no-key example from a repository checkout:
+
+```bash
+cd js
+npm ci
+npm run build
+node ../examples/streaming_guard.mjs
+```
+
 ## Pricing
 
 Tokens are priced **offline** from a bundled

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floe-guard",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floe-guard",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@livekit/agents": "^1.6.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "floe-guard",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Know what every AI call really costs — a live ledger of your agent's real spend, plus a hard-stop before runaway spend crosses your ceiling. Vercel AI SDK middleware + LiveKit / Vapi / Retell voice adapters. Local, no account, no telemetry.",
   "type": "module",
   "license": "MIT",

--- a/js/src/guard.ts
+++ b/js/src/guard.ts
@@ -231,6 +231,7 @@ export class BudgetGuard {
   private lastToolCost = 0;
   /** USD held for in-flight calls (reserved, not yet settled). Counts toward the ceiling. */
   private reserved = 0;
+  private readonly streamCosts = new Map<symbol, { accrued: number; held: number }>();
   /** Per-call ledger, oldest first; a ring buffer when maxLogEvents is set. */
   private readonly spendEvents: SpendEvent[] = [];
   private readonly maxLogEvents?: number;
@@ -910,6 +911,44 @@ export class BudgetGuard {
       }
     }
     return null;
+  }
+
+  /** @internal Validate before transferring a reservation to a stream. */
+  _validateStreamReservation(reserved: ReservationHandle): void {
+    this.reservedUsdOf(reserved);
+  }
+
+  /** @internal Register accrued-but-unsettled streaming spend. */
+  _registerStream(reserved: ReservationHandle): symbol {
+    const held = this.reservedUsdOf(reserved);
+    const key = Symbol();
+    this.streamCosts.set(key, { accrued: 0, held });
+    return key;
+  }
+
+  /** @internal Settlement moved this stream's accrual into spentUsd. */
+  _unregisterStream(key: symbol): void {
+    this.streamCosts.delete(key);
+  }
+
+  /** @internal Replace this stream's estimate with its cumulative actual estimate.
+   * Count other streams' overages once, in addition to their existing holds.
+   * Synchronous within one JS isolate, matching Python's locked registry.
+   */
+  _streamWouldCross(key: symbol, cumulative: number): boolean {
+    const own = this.streamCosts.get(key)!;
+    own.accrued = cumulative;
+    let otherOverage = 0;
+    for (const [otherKey, other] of this.streamCosts) {
+      if (otherKey !== key) otherOverage += Math.max(0, other.accrued - other.held);
+    }
+    const others = this.spentUsd + Math.max(0, this.reserved - own.held) + otherOverage;
+    return others + cumulative > this.limitUsd + EPS;
+  }
+
+  /** @internal Notify and throw after a stream has settled its partial spend. */
+  _blockStream(): never {
+    return this.raiseBlock(["usd", "aggregate", this.spentUsd, this.limitUsd]);
   }
 
   /** Notify + throw the right error for a [dimension, scope, spent, limit] block. */

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -48,6 +48,13 @@ export {
 } from "./retry.js";
 
 export * as pricing from "./pricing.js";
+export {
+  StreamGuard,
+  guardStream,
+  approxTokens,
+  type StreamGuardOptions,
+  type GuardStreamOptions,
+} from "./stream.js";
 
 export {
   type VoiceMode,

--- a/js/src/stream.ts
+++ b/js/src/stream.ts
@@ -1,0 +1,180 @@
+/**
+ * Chunk-wise USD enforcement, mirroring Python's StreamGuard.
+ * Generated chunks are billed even when they cross the limit: settle first,
+ * then throw. Token estimates and source cancellation are provider-dependent.
+ */
+import { BudgetGuard, type ReservationHandle } from "./guard.js";
+import { UnpriceableModelError } from "./errors.js";
+import { priceTokens, resolvePrice, type ManualPrice } from "./pricing.js";
+
+export interface StreamGuardOptions {
+  /** Known input tokens; final provider usage can override this at finish(). */
+  promptTokens?: number;
+  /** The original handle from reserve(), including any token hold. */
+  reserved?: ReservationHandle;
+  price?: ManualPrice;
+  label?: string;
+  /** Count each text delta; defaults to approxTokens. */
+  countTokens?: (delta: string) => number;
+}
+
+/** Python's heuristic: four Unicode code points per token, at least one per delta. */
+export function approxTokens(text: string): number {
+  if (typeof text !== "string") throw new TypeError("stream text must be a string");
+  return text ? Math.max(1, Math.floor(Array.from(text).length / 4)) : 0;
+}
+
+function tokenCount(value: number): number {
+  if (!Number.isFinite(value)) throw new RangeError("token count must be finite");
+  return Math.max(0, Math.trunc(value));
+}
+
+/**
+ * Meter one response; the crossing chunk is settled before BudgetExceeded.
+ * Call close() in finally for direct use, or let guardStream own cleanup.
+ * Concurrent streams must share the same BudgetGuard within one JS isolate.
+ */
+export class StreamGuard {
+  private tokens = 0;
+  private closed = false;
+  private readonly priced;
+  private key: symbol | undefined;
+  private promptTokens: number;
+  private readonly reserved: ReservationHandle;
+  private readonly price: ManualPrice | undefined;
+  private readonly label: string | undefined;
+  private readonly countTokens: (delta: string) => number;
+
+  constructor(
+    private readonly guard: BudgetGuard,
+    private readonly model: string,
+    options: StreamGuardOptions = {},
+  ) {
+    this.reserved = options.reserved ?? 0;
+    guard._validateStreamReservation(this.reserved);
+    try {
+      // Python captures constructor arguments and ManualPrice is immutable.
+      // Keep the same configuration for both enforcement and settlement even
+      // if the caller later replaces options or mutates its manual price.
+      this.price = options.price === undefined ? undefined : { ...options.price };
+      this.label = options.label;
+      this.countTokens = options.countTokens ?? approxTokens;
+      this.promptTokens = tokenCount(options.promptTokens ?? 0);
+      this.priced = resolvePrice(
+        model,
+        this.price === undefined
+          ? guard.priceOverrides
+          : { ...guard.priceOverrides, [model]: this.price },
+      );
+      if (this.priced === null && guard.failClosed) {
+        console.warn(`Cannot price model '${model}': pass a price override to enforce a streaming budget.`);
+        throw new UnpriceableModelError(model);
+      }
+    } catch (error) {
+      guard.release(this.reserved);
+      throw error;
+    }
+  }
+
+  /** Generated completion tokens counted so far (estimated until finish()). */
+  get completionTokens(): number {
+    return this.tokens;
+  }
+
+  /** Meter a text delta with the configured tokenizer. */
+  feedText(delta: string): void {
+    if (typeof delta !== "string") throw new TypeError("stream text must be a string");
+    const count = this.countTokens;
+    this.feedTokens(count(delta));
+  }
+
+  /** Meter additional completion tokens, settling before a budget interruption. */
+  feedTokens(tokens: number): void {
+    if (this.closed) throw new Error("stream already settled");
+    this.tokens = tokenCount(this.tokens + tokenCount(tokens));
+    if (this.priced === null) return;
+    const cost = priceTokens(this.priced, this.promptTokens, this.tokens);
+    // An unconsumed wrapper owns no registry entry; its reservation still
+    // belongs to the caller until iteration starts, as in Python.
+    this.key ??= this.guard._registerStream(this.reserved);
+    if (this.guard._streamWouldCross(this.key, cost)) {
+      this.finish();
+      this.guard._blockStream();
+    }
+  }
+
+  /** Reconcile estimates to provider usage, or settle accumulated estimates. */
+  finish(usage: { promptTokens?: number; completionTokens?: number } = {}): number {
+    if (this.closed) throw new Error("stream already settled");
+    const prompt = tokenCount(usage.promptTokens ?? this.promptTokens);
+    const completion = tokenCount(usage.completionTokens ?? this.tokens);
+    this.promptTokens = prompt;
+    this.tokens = completion;
+    this.closed = true;
+    try {
+      return this.guard.settle(this.model, prompt, completion, {
+        reserved: this.reserved,
+        price: this.price,
+        label: this.label,
+      });
+    } finally {
+      if (this.key !== undefined) this.guard._unregisterStream(this.key);
+    }
+  }
+
+  /** Idempotent cleanup for a finally block; partial generated usage is billed. */
+  close(): void {
+    if (!this.closed) this.finish();
+  }
+}
+
+export interface GuardStreamOptions<C> extends StreamGuardOptions {
+  /** Required for structured provider chunks; must return a string. */
+  getText?: (chunk: C) => string;
+}
+
+/**
+ * Meter before yielding; all exits after iteration starts settle partial usage.
+ * Model validation is eager. A never-started wrapper leaves its reservation
+ * with the caller, who must release it. Early exit closes the source iterator;
+ * whether that cancels remote generation depends on the source's implementation.
+ */
+export function guardStream<C>(
+  guard: BudgetGuard, model: string, chunks: AsyncIterable<C>, options?: GuardStreamOptions<C>,
+): AsyncIterableIterator<C>;
+export function guardStream<C>(
+  guard: BudgetGuard, model: string, chunks: Iterable<C>, options?: GuardStreamOptions<C>,
+): IterableIterator<C>;
+export function guardStream<C>(
+  guard: BudgetGuard, model: string, chunks: Iterable<C> | AsyncIterable<C>, options?: GuardStreamOptions<C>,
+): IterableIterator<C> | AsyncIterableIterator<C>;
+export function guardStream<C>(
+  guard: BudgetGuard, model: string, chunks: Iterable<C> | AsyncIterable<C>, options: GuardStreamOptions<C> = {},
+): IterableIterator<C> | AsyncIterableIterator<C> {
+  const stream = new StreamGuard(guard, model, options);
+  const extract = options.getText ?? ((chunk: C): string => {
+    if (typeof chunk !== "string") throw new TypeError("guardStream needs getText for non-string chunks");
+    return chunk;
+  });
+  function* run(source: Iterable<C>): IterableIterator<C> {
+    try {
+      for (const chunk of source) {
+        stream.feedText(extract(chunk));
+        yield chunk;
+      }
+    } finally {
+      stream.close();
+    }
+  }
+  async function* runAsync(source: AsyncIterable<C>): AsyncIterableIterator<C> {
+    try {
+      for await (const chunk of source) {
+        stream.feedText(extract(chunk));
+        yield chunk;
+      }
+    } finally {
+      stream.close();
+    }
+  }
+  return Symbol.asyncIterator in chunks ? runAsync(chunks) : run(chunks);
+}

--- a/js/test/stream-guard.test.ts
+++ b/js/test/stream-guard.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from "vitest";
+import { BudgetExceeded, BudgetGuard, StreamGuard, UnpriceableModelError, guardStream, approxTokens } from "../src/index.js";
+
+const MODEL = "stream-test";
+const price = { inputCostPerToken: 0.0000025, outputCostPerToken: 0.00001 };
+const makeGuard = (limit = 0.01) => new BudgetGuard(limit, {
+  priceOverrides: { [MODEL]: price }, onBlock: () => {},
+});
+
+describe("StreamGuard", () => {
+  it("captures price, tokenizer and label when constructed", () => {
+    const guard = makeGuard(1);
+    const options = {
+      price: { inputCostPerToken: 0, outputCostPerToken: 0.01 },
+      countTokens: () => 10,
+      label: "original",
+    };
+    const stream = new StreamGuard(guard, "custom-model", options);
+    options.price = { inputCostPerToken: 0, outputCostPerToken: 0 };
+    options.countTokens = () => 0;
+    options.label = "changed";
+    stream.feedText("hello");
+    expect(stream.finish()).toBeCloseTo(0.1, 12);
+    expect(guard.spendLog[0]).toMatchObject({ completionTokens: 10, label: "original" });
+  });
+
+  it("copies manual price fields so mutation cannot change settlement", () => {
+    const guard = makeGuard(1);
+    const manualPrice = { inputCostPerToken: 0, outputCostPerToken: 0.01 };
+    const stream = new StreamGuard(guard, "custom-model", { price: manualPrice });
+    manualPrice.outputCostPerToken = 0;
+    stream.feedTokens(10);
+    expect(stream.finish()).toBeCloseTo(0.1, 12);
+    expect(guard.spendLog[0].costUsd).toBeCloseTo(0.1, 12);
+  });
+
+  it("uses captured configuration to settle the crossing chunk before interruption", () => {
+    const guard = makeGuard(0.05);
+    const options = {
+      price: { inputCostPerToken: 0, outputCostPerToken: 0.01 },
+      countTokens: () => 10,
+    };
+    const stream = new StreamGuard(guard, "custom-model", options);
+    options.price = { inputCostPerToken: 0, outputCostPerToken: 0 };
+    options.countTokens = () => 0;
+    expect(() => stream.feedText("hello")).toThrow(BudgetExceeded);
+    expect(guard.spentUsd).toBeCloseTo(0.1, 12);
+    expect(guard.spendLog).toHaveLength(1);
+  });
+  it("never calls fetch unless hosted sync was explicitly enabled", () => {
+    const fetch = vi.fn(() => { throw new Error("unexpected network request"); });
+    vi.stubGlobal("fetch", fetch);
+    try {
+      const guard = makeGuard(1);
+      expect([...guardStream(guard, MODEL, ["hello"])]).toEqual(["hello"]);
+      expect(() => [...guardStream(makeGuard(0), MODEL, ["hello"])]).toThrow(BudgetExceeded);
+      expect(fetch).not.toHaveBeenCalled();
+    } finally { vi.unstubAllGlobals(); }
+  });
+
+  it("releases token holds on fail-closed construction", () => {
+    const guard = new BudgetGuard(1, { tokenLimit: 10 });
+    const reserved = guard.reserve(0.1, { estimatedTokens: 10 });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => new StreamGuard(guard, "unknown-model", { reserved })).toThrow(UnpriceableModelError);
+      const replacement = guard.reserve(0.1, { estimatedTokens: 10 });
+      guard.release(replacement);
+      expect(guard.remainingUsd).toBe(1);
+    } finally { warning.mockRestore(); }
+  });
+
+  it("counts parallel streams' overages once and preserves a surviving reservation", () => {
+    const guard = makeGuard();
+    const a = new StreamGuard(guard, MODEL, { reserved: guard.reserve(0.002) });
+    const b = new StreamGuard(guard, MODEL, { reserved: guard.reserve(0.004) });
+    a.feedTokens(500); // $0.005 accrued, including $0.003 beyond its hold
+    b.feedTokens(500); // joint $0.010 fits, without double-counting either hold
+    expect(() => a.feedTokens(10)).toThrow(BudgetExceeded);
+    expect(guard.remainingUsd).toBeCloseTo(0.0009, 12); // b still holds $0.004
+    b.close();
+    expect(guard.spentUsd).toBeCloseTo(0.0101, 12);
+    expect(guard.spendLog).toHaveLength(2);
+  });
+
+  it("notifies onBlock only after partial spending is recorded and the hold is released", () => {
+    const notices: number[] = [];
+    const guard = new BudgetGuard(0.0001, {
+      priceOverrides: { [MODEL]: price },
+      onBlock: spent => {
+        expect(guard.spendLog).toHaveLength(1);
+        expect(guard.remainingUsd).toBe(0);
+        notices.push(spent);
+      },
+    });
+    const stream = new StreamGuard(guard, MODEL, { reserved: guard.reserve(0.00005) });
+    expect(() => stream.feedTokens(20)).toThrow(BudgetExceeded);
+    expect(notices).toEqual([0.0002]);
+  });
+
+  it("releases token holds so future reservations can reuse the token capacity", () => {
+    const guard = new BudgetGuard(1, { tokenLimit: 10, priceOverrides: { [MODEL]: price } });
+    const stream = new StreamGuard(guard, MODEL, {
+      reserved: guard.reserve(0.01, { estimatedTokens: 8 }),
+    });
+    stream.feedTokens(2);
+    stream.close();
+    const next = guard.reserve(0.01, { estimatedTokens: 8 });
+    guard.release(next);
+    expect(guard.spentTokens).toBe(2);
+    expect(guard.remainingUsd).toBeCloseTo(0.99998, 12);
+  });
+
+  it("meters synchronous chunks before yielding the crossing chunk", () => {
+    const guard = makeGuard(0.0001);
+    const stream = guardStream(guard, MODEL, ["a".repeat(40), "b".repeat(40)]);
+    expect(stream.next().value).toBe("a".repeat(40));
+    expect(() => stream.next()).toThrow(BudgetExceeded);
+    expect(guard.spendLog[0].completionTokens).toBe(20);
+  });
+
+  it("settles earlier chunks if the tokenizer throws", () => {
+    const guard = makeGuard(1);
+    const stream = guardStream(guard, MODEL, ["first", "bad"], {
+      reserved: guard.reserve(0.1),
+      countTokens: text => { if (text === "bad") throw new Error("tokenizer failed"); return 10; },
+    });
+    expect(() => [...stream]).toThrow("tokenizer failed");
+    expect(guard.remainingUsd).toBeCloseTo(0.9999, 12);
+  });
+
+  it("still settles if source cleanup throws", async () => {
+    const guard = makeGuard(1);
+    async function* source() { try { yield "hello"; } finally { throw new Error("cleanup failed"); } }
+    await expect((async () => {
+      for await (const _chunk of guardStream(guard, MODEL, source(), { reserved: guard.reserve(0.1) })) break;
+    })()).rejects.toThrow("cleanup failed");
+    expect(guard.remainingUsd).toBeCloseTo(0.99999, 12);
+  });
+  it("rejects an extractor that returns a non-string instead of silently recording zero", () => {
+    const guard = makeGuard(1);
+    const chunks = [{ text: "hello" }];
+    // @ts-expect-error JavaScript callers are not protected by static types.
+    const stream = guardStream(guard, MODEL, chunks, {
+      reserved: guard.reserve(0.1),
+      getText: () => undefined,
+    });
+    expect(() => stream.next()).toThrow(TypeError);
+    expect(guard.remainingUsd).toBe(1);
+  });
+  it.each([["", 0], ["abc", 1], ["abcdefgh", 2], ["😀😀😀😀😀😀😀😀", 2]] as const)(
+    "matches Python's heuristic for %s", (text, expected) => expect(approxTokens(text)).toBe(expected),
+  );
+
+  it("uses a custom tokenizer and manual price", () => {
+    const guard = makeGuard(1);
+    const stream = new StreamGuard(guard, "custom-model", { price, countTokens: () => 7 });
+    stream.feedText("x");
+    expect(stream.finish()).toBeCloseTo(0.00007, 12);
+  });
+
+  it("settles its own reservation on a budget abort without clearing another hold", () => {
+    const guard = makeGuard();
+    const other = guard.reserve(0.004);
+    const stream = new StreamGuard(guard, MODEL, { reserved: guard.reserve(0.003) });
+    stream.feedTokens(600);
+    expect(() => stream.feedTokens(10)).toThrow(BudgetExceeded);
+    guard.release(other);
+    expect(guard.remainingUsd).toBeCloseTo(0.0039, 12);
+    stream.close();
+    expect(guard.spendLog).toHaveLength(1);
+  });
+
+  it("settles partial spend on source failure", () => {
+    const guard = makeGuard(1);
+    function* source() { yield "a".repeat(40); throw new Error("network died"); }
+    expect(() => [...guardStream(guard, MODEL, source(), { reserved: guard.reserve(0.1) })]).toThrow("network died");
+    expect(guard.spentUsd).toBeCloseTo(0.0001, 12);
+    expect(guard.remainingUsd).toBeCloseTo(0.9999, 12);
+  });
+
+  it("settles on normal exhaustion including prompt tokens", () => {
+    const guard = makeGuard(1);
+    const chunks = ["a".repeat(40), "b".repeat(40)];
+    expect([...guardStream(guard, MODEL, chunks, { promptTokens: 50 })]).toEqual(chunks);
+    expect(guard.spentUsd).toBeCloseTo(0.000325, 12);
+    expect(guard.spendLog[0]).toMatchObject({ promptTokens: 50, completionTokens: 20 });
+  });
+
+  it("fails closed eagerly without consuming the source", () => {
+    const guard = makeGuard(1);
+    let started = false;
+    function* source() { started = true; yield "x"; }
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(() => guardStream(guard, "unknown-model", source(), { reserved: guard.reserve(0.1) })).toThrow(UnpriceableModelError);
+      expect(started).toBe(false);
+      expect(guard.remainingUsd).toBe(1);
+    } finally { warning.mockRestore(); }
+  });
+
+  it("refuses structured chunks without an extractor and frees the hold", () => {
+    const guard = makeGuard(1);
+    const stream = guardStream(guard, MODEL, [{ delta: "hi" }], { reserved: guard.reserve(0.1) });
+    expect(() => stream.next()).toThrow(/getText/);
+    expect(guard.remainingUsd).toBe(1);
+  });
+
+  it("extracts structured chunks and charges only the generated text", () => {
+    const guard = makeGuard(1);
+    const chunks = [{ delta: "hello" }];
+    expect([...guardStream(guard, MODEL, chunks, { getText: c => c.delta })]).toEqual(chunks);
+    expect(guard.spendLog[0].completionTokens).toBe(1);
+  });
+
+  it.each([NaN, Infinity, -1])("rejects invalid reservation %s", reserved => {
+    expect(() => new StreamGuard(makeGuard(), MODEL, { reserved })).toThrow(RangeError);
+  });
+
+  it.each([NaN, Infinity])("rejects nonfinite token counts %s without corrupting previous accrual", count => {
+    const guard = makeGuard(1);
+    const stream = new StreamGuard(guard, MODEL);
+    stream.feedTokens(10);
+    expect(() => stream.feedTokens(count)).toThrow(RangeError);
+    stream.close();
+    expect(guard.spentUsd).toBeCloseTo(0.0001, 12);
+  });
+
+  it("direct use settles in finally after a consumer error", () => {
+    const guard = makeGuard(1);
+    const stream = new StreamGuard(guard, MODEL, { reserved: guard.reserve(0.1) });
+    expect(() => {
+      try { stream.feedTokens(10); throw new Error("consumer failed"); }
+      finally { stream.close(); }
+    }).toThrow("consumer failed");
+    expect(guard.remainingUsd).toBeCloseTo(0.9999, 12);
+  });
+
+  it("leaves a never-started iterator's reservation with the caller", () => {
+    const guard = makeGuard(1);
+    const reserved = guard.reserve(0.1);
+    const unused = guardStream(guard, MODEL, ["x"], { reserved });
+    unused.return?.();
+    expect(guard.remainingUsd).toBeCloseTo(0.9);
+    expect(guard.spendLog).toHaveLength(0);
+    guard.release(reserved);
+    expect(guard.remainingUsd).toBe(1);
+  });
+
+  it("closes async sources and settles after an early consumer break", async () => {
+    const guard = makeGuard(1);
+    let closed = false;
+    async function* source() { try { yield "hello"; yield "world"; } finally { closed = true; } }
+    for await (const _chunk of guardStream(guard, MODEL, source(), { reserved: guard.reserve(0.1) })) break;
+    expect(closed).toBe(true);
+    expect(guard.remainingUsd).toBeCloseTo(0.99999, 12);
+  });
+  it("meters asynchronous chunks and closes their source on budget interruption", async () => {
+    const guard = makeGuard(0.0001);
+    let sourceClosed = false;
+    async function* source() {
+      try { yield "a".repeat(40); yield "b".repeat(40); yield "unreachable"; }
+      finally { sourceClosed = true; }
+    }
+    const seen: string[] = [];
+    await expect((async () => {
+      for await (const chunk of guardStream(guard, MODEL, source())) seen.push(chunk);
+    })()).rejects.toThrow(BudgetExceeded);
+    expect(seen).toEqual(["a".repeat(40)]);
+    expect(sourceClosed).toBe(true);
+    expect(guard.spentUsd).toBeCloseTo(0.0002, 12);
+    expect(guard.spendLog).toHaveLength(1);
+  });
+  it("settles partial usage and closes the source on an early consumer break", () => {
+    const guard = makeGuard(1);
+    let sourceClosed = false;
+    function* source() {
+      try { yield "a".repeat(40); yield "b".repeat(40); }
+      finally { sourceClosed = true; }
+    }
+    for (const chunk of guardStream(guard, MODEL, source(), { reserved: guard.reserve(0.1) })) {
+      expect(chunk).toHaveLength(40);
+      break;
+    }
+    expect(sourceClosed).toBe(true);
+    expect(guard.spentUsd).toBeCloseTo(0.0001, 12);
+    expect(guard.remainingUsd).toBeCloseTo(0.9999, 12);
+    expect(guard.spendLog).toHaveLength(1);
+  });
+  it.each([true, false])("handles an unknown model with failClosed=%s without leaking a hold", (failClosed) => {
+    const guard = new BudgetGuard(1, { failClosed });
+    const reserved = guard.reserve(0.1);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      if (failClosed) {
+        expect(() => new StreamGuard(guard, "unknown-model", { reserved })).toThrow(UnpriceableModelError);
+      } else {
+        const stream = new StreamGuard(guard, "unknown-model", { reserved });
+        stream.feedTokens(10000);
+        expect(stream.finish()).toBe(0);
+      }
+      expect(guard.remainingUsd).toBe(1);
+      expect(guard.spendLog).toHaveLength(0);
+      expect(warning).toHaveBeenCalled();
+    } finally { warning.mockRestore(); }
+  });
+  it("reconciles provider usage and releases USD and token reservations", () => {
+    const guard = makeGuard(1);
+    const reserved = guard.reserve(0.01, { estimatedTokens: 200 });
+    const stream = new StreamGuard(guard, MODEL, { reserved, promptTokens: 100, label: "writer" });
+    stream.feedText("a".repeat(40));
+    expect(stream.completionTokens).toBe(10);
+    expect(stream.finish({ promptTokens: 120, completionTokens: 37 })).toBeCloseTo(0.00067, 12);
+    expect(guard.remainingUsd).toBeCloseTo(0.99933, 12);
+    expect(guard.spendLog[0]).toMatchObject({ promptTokens: 120, completionTokens: 37, label: "writer" });
+    expect(() => stream.feedTokens(1)).toThrow(/settled/);
+    expect(() => stream.finish()).toThrow(/settled/);
+  });
+  it("shares the ceiling between parallel unreserved streams", () => {
+    const guard = makeGuard();
+    const a = new StreamGuard(guard, MODEL);
+    const b = new StreamGuard(guard, MODEL);
+    for (let i = 0; i < 50; i++) { a.feedTokens(10); b.feedTokens(10); }
+    expect(() => a.feedTokens(10)).toThrow(BudgetExceeded);
+    expect(() => b.feedTokens(10)).toThrow(BudgetExceeded);
+    expect(guard.spentUsd).toBeCloseTo(0.0102, 12);
+    expect(guard.spendLog).toHaveLength(2);
+  });
+  it("interrupts a runaway response and records the crossing chunk before throwing", () => {
+    const guard = makeGuard();
+    const stream = new StreamGuard(guard, MODEL);
+    for (let i = 0; i < 100; i++) stream.feedTokens(10);
+    expect(() => stream.feedTokens(10)).toThrow(BudgetExceeded);
+    expect(guard.spentUsd).toBeCloseTo(0.0101, 12);
+    expect(guard.spendLog).toHaveLength(1);
+    expect(guard.spendLog[0].completionTokens).toBe(1010);
+    expect(() => guard.check()).toThrow(BudgetExceeded);
+  });
+});


### PR DESCRIPTION
Closes #124.

TypeScript already has request-sized estimates, but it lacks Python's standalone mid-stream budget guard. This ports that missing primitive: each chunk is priced before being yielded, and a crossing chunk's partial spend is settled into `spendLog` before `BudgetExceeded` is thrown.

Changes:

- Add `StreamGuard`, `guardStream`, and `approxTokens` in `js/src/stream.ts`, exported from the package root.
- Track active streams against a shared USD ceiling without double-counting reservations. Ordinary check/reserve admission and remainingUsd include unsettled stream overages. Preserve original reservation handles so settlement releases token holds too.
- Support synchronous and asynchronous iterators, eager unknown-model rejection, fail-open behavior, custom tokenizers, and final provider-usage reconciliation through `finish()`.
- Capture constructor configuration, including resolved override and bundled prices, so later caller mutations cannot make enforcement and settlement disagree.
- Add documentation and a runnable no-key example covering preflight rejection and mid-stream interruption. Bump the JS package to 0.16.1 after resolving the version collision with upstream, following #128.

Vapi, LiveKit, and middleware integrations are unchanged, as requested by the issue.

Validation:

- Full TypeScript suite: **294 tests passed across 18 files**, including **52 streaming cases**, on Windows with Node 24.
- All 15 Python streaming test cases have behavioral counterparts. The six request-estimate cases remain in the existing TS estimate suite; Python-specific LiteLLM/LangChain estimate tests are outside this port.
- Additional coverage includes configuration mutation, mixed stream/call admission, captured-rate settlement, fail-open pricing mutation, reserved parallel streams, token-hold reuse, malformed chunks, early breaks, cleanup failures, and no-network assertions.
- Typecheck, ESM/CommonJS builds, and declaration generation passed.
- Ran `node examples/streaming_guard.mjs` against the built package: oversized first request rejected with zero spending; runaway stream stopped after 10 delivered chunks, recorded the 11th crossing chunk, and closed the source.
- The configuration-mutation reproducer now records the same $0.10 as Python; built CommonJS runtime checks passed too.

Streaming behavior:

- Direct callers use `close()` in `finally` in place of Python's context manager. A wrapper that is never iterated leaves its reservation with the caller, matching Python's documented ownership rule.
- Chunk checks enforce aggregate USD spending; token holds reconcile at settlement. Source iterators close on early termination, but remote cancellation depends on the provider integration.
- The crossing chunk has already been generated and is recorded before interruption. Token counting defaults to approximately four characters per token; provider-reported usage can reconcile that estimate at `finish()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streaming budget controls for synchronous and asynchronous iterators.
  - Supports per-chunk token tracking, custom pricing, shared spending limits, partial-spend settlement, and final usage reconciliation.
  - Streams stop when spending limits are reached, with iterator cleanup and reservation release.
  - Added support for structured chunks and token estimation.
  - Exported new streaming guard APIs.

- **Documentation**
  - Added usage guidance and a no-key streaming example.

- **Chores**
  - Updated the JavaScript package version to 0.16.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->